### PR TITLE
Add SSH Keys support for modules and workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,16 @@ This project contains three modules describe below:
 | ui       | React JS terrakube front end                                     |
 
 ### Version Control Services
-The platform support public and private repositories in the following providers:
+The platform support public and private repositories for modules and workspaces in the following providers:
 
 * GitHub.com
 * Bitbucket.com
 * Gitlab.com
 * Azure DevOps
+
+For private repositories you need to use one of the following methods for authentication:
+
+* oAuth Applications (GitHub, Bitbucket, Gitlab and Azure Devops)
 * SSH Keys 
   - RSA
   - ED25519

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ The platform support public and private repositories in the following providers:
 * Bitbucket.com
 * Gitlab.com
 * Azure DevOps
+* SSH Keys 
+  - RSA
+  - ED25519
 
 ### Requirements
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you want to develop or test Terrakube click in the following button to open a
 
 [![gitpod](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod&style=flat-square)](https://gitpod.io/#https://github.com/AzBuilder/terrakube)
 
-For more information about the test environment please refer to the following [document](development.md)and to learn about the API check the following [document](https://docs.terrakube.org/api/methods)
+For more information about the test environment please refer to the following [file](development.md) and to learn about the API check the following [api information](https://docs.terrakube.org/api/methods)
 
 ### Security - Authentication
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
         <mssql-jdbc.version>9.2.1.jre11</mssql-jdbc.version>
         <msal4j.version>1.11.2</msal4j.version>
         <lombok.version>1.18.20</lombok.version>
-        <jgit.version>5.12.0.202106070339-r</jgit.version>
+        <jgit.version>6.2.0.202206071550-r</jgit.version>
         <rest-assured.version>4.4.0</rest-assured.version>
         <junit-jupiter-api.version>5.7.2</junit-jupiter-api.version>
         <groovy.version>3.0.8</groovy.version>
@@ -129,6 +129,11 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
+            <version>${jgit.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit.ssh.apache</artifactId>
             <version>${jgit.version}</version>
         </dependency>
         <dependency>

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -98,10 +98,10 @@ public class ExecutorService {
     }
 
     private boolean sendToExecutor(Job job, ExecutorContext executorContext) {
-        log.info("Sending Job: /n {}", executorContext);
         RestTemplate restTemplate = new RestTemplate();
         ResponseEntity<ExecutorContext> response = restTemplate.postForEntity(this.executorUrl, executorContext, ExecutorContext.class);
-
+        executorContext.setAccessToken("****");
+        log.info("Sending Job: /n {}", executorContext);
         log.info("Response Status: {}", response.getStatusCode().value());
 
         if (response.getStatusCode().equals(HttpStatus.ACCEPTED)) {

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -6,6 +6,7 @@ import org.terrakube.api.repository.JobRepository;
 import org.terrakube.api.rs.globalvar.Globalvar;
 import org.terrakube.api.rs.job.Job;
 import org.terrakube.api.rs.job.JobStatus;
+import org.terrakube.api.rs.ssh.Ssh;
 import org.terrakube.api.rs.vcs.Vcs;
 import org.terrakube.api.rs.workspace.parameters.Category;
 import org.terrakube.api.rs.workspace.parameters.Variable;
@@ -46,6 +47,11 @@ public class ExecutorService {
             executorContext.setVcsType(vcs.getVcsType().toString());
             executorContext.setAccessToken(vcs.getAccessToken());
             log.info("Private Repository {}", executorContext.getVcsType());
+        } else if (job.getWorkspace().getSsh() != null) {
+            Ssh ssh = job.getWorkspace().getSsh();
+            executorContext.setVcsType(String.format("SSH~%s", ssh.getSshType().getFileName()));
+            executorContext.setAccessToken(ssh.getPrivateKey());
+            log.info("Private Repository using SSH private key");
         } else {
             executorContext.setVcsType("PUBLIC");
             log.info("Public Repository");
@@ -67,8 +73,8 @@ public class ExecutorService {
                 log.info("Variable Key: {} Value {}", variable.getKey(), variable.isSensitive() ? "sensitive" : variable.getValue());
             }
 
-        if(globalvarList != null)
-            for(Globalvar globalvar : globalvarList){
+        if (globalvarList != null)
+            for (Globalvar globalvar : globalvarList) {
                 if (globalvar.getCategory().equals(Category.TERRAFORM)) {
                     log.info("Adding terraform");
                     variables.putIfAbsent(globalvar.getKey(), globalvar.getValue());

--- a/api/src/main/java/org/terrakube/api/plugin/ssh/TerrakubeSshdSessionFactory.java
+++ b/api/src/main/java/org/terrakube/api/plugin/ssh/TerrakubeSshdSessionFactory.java
@@ -1,0 +1,77 @@
+package org.terrakube.api.plugin.ssh;
+
+
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.eclipse.jgit.transport.CredentialsProvider;
+import org.eclipse.jgit.transport.sshd.JGitKeyCache;
+import org.eclipse.jgit.transport.sshd.ServerKeyDatabase;
+import org.eclipse.jgit.transport.sshd.SshdSessionFactory;
+import org.eclipse.jgit.transport.sshd.SshdSessionFactoryBuilder;
+import org.eclipse.jgit.util.FS;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.Charset;
+import java.security.PublicKey;
+import java.util.Collections;
+import java.util.List;
+
+@Builder
+@Slf4j
+public class TerrakubeSshdSessionFactory {
+
+    private static String SSH_FOLDER = "%s/.terraform-spring-boot/ssh/%s/%s";
+
+    private String sshId;
+    private String sshFileName;
+    private String privateKey;
+
+    public SshdSessionFactory getSshdSessionFactory() {
+        File sshDir = generateSshFolder();
+        SshdSessionFactory sshdSessionFactory = new SshdSessionFactoryBuilder()
+                .setPreferredAuthentications("publickey")
+                .setHomeDirectory(FS.DETECTED.userHome())
+                .setServerKeyDatabase((h, s) -> new ServerKeyDatabase() {
+
+                    @Override
+                    public List<PublicKey> lookup(String connectAddress,
+                                                  InetSocketAddress remoteAddress,
+                                                  Configuration config) {
+                        return Collections.emptyList();
+                    }
+
+                    @Override
+                    public boolean accept(String connectAddress,
+                                          InetSocketAddress remoteAddress,
+                                          PublicKey serverKey, Configuration config,
+                                          CredentialsProvider provider) {
+                        return true;
+                    }
+
+                })
+                .setSshDirectory(sshDir)
+                .build(new JGitKeyCache());
+
+        return sshdSessionFactory;
+    }
+
+    private File generateSshFolder() {
+        String sshFilePath = String.format(SSH_FOLDER, FileUtils.getUserDirectoryPath(), this.sshId, this.sshFileName);
+        File sshFile = new File(sshFilePath);
+        try {
+            if(!sshFile.exists()) {
+                log.info("Creating new SSH folder for {}", this.sshId);
+                FileUtils.forceMkdirParent(sshFile);
+                FileUtils.writeStringToFile(sshFile, this.privateKey, Charset.defaultCharset());
+            } else {
+                log.info("SSH folder for {} already exists", this.sshId);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return sshFile.getParentFile();
+    }
+}

--- a/api/src/main/java/org/terrakube/api/rs/Organization.java
+++ b/api/src/main/java/org/terrakube/api/rs/Organization.java
@@ -7,6 +7,7 @@ import org.terrakube.api.rs.globalvar.Globalvar;
 import org.terrakube.api.rs.job.Job;
 import org.terrakube.api.rs.module.Module;
 import org.terrakube.api.rs.provider.Provider;
+import org.terrakube.api.rs.ssh.Ssh;
 import org.terrakube.api.rs.team.Team;
 import org.terrakube.api.rs.template.Template;
 import org.terrakube.api.rs.vcs.Vcs;
@@ -63,6 +64,10 @@ public class Organization {
     @UpdatePermission(expression = "user belongs organization")
     @OneToMany(mappedBy = "organization")
     private List<Vcs> vcs;
+
+    @UpdatePermission(expression = "user belongs organization")
+    @OneToMany(mappedBy = "organization")
+    private List<Ssh> ssh;
 
     @UpdatePermission(expression = "user belongs organization")
     @OneToMany(mappedBy = "organization")

--- a/api/src/main/java/org/terrakube/api/rs/checks/ssh/ReadPrivateKey.java
+++ b/api/src/main/java/org/terrakube/api/rs/checks/ssh/ReadPrivateKey.java
@@ -1,0 +1,27 @@
+package org.terrakube.api.rs.checks.ssh;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.terrakube.api.plugin.security.user.AuthenticatedUser;
+import org.terrakube.api.rs.checks.vcs.ReadAccessToken;
+import org.terrakube.api.rs.ssh.Ssh;
+
+import java.util.Optional;
+
+@SecurityCheck(ReadAccessToken.RULE)
+public class ReadPrivateKey extends OperationCheck<Ssh> {
+    public static final String RULE = "read private key";
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Override
+    public boolean ok(Ssh ssh, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        if(authenticatedUser.isServiceAccount(requestScope.getUser()) && authenticatedUser.isSuperUser(requestScope.getUser())){
+            return true;
+        }
+        return false;
+    }
+}

--- a/api/src/main/java/org/terrakube/api/rs/checks/ssh/ReadPrivateKey.java
+++ b/api/src/main/java/org/terrakube/api/rs/checks/ssh/ReadPrivateKey.java
@@ -6,12 +6,11 @@ import com.yahoo.elide.core.security.RequestScope;
 import com.yahoo.elide.core.security.checks.OperationCheck;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.terrakube.api.plugin.security.user.AuthenticatedUser;
-import org.terrakube.api.rs.checks.vcs.ReadAccessToken;
 import org.terrakube.api.rs.ssh.Ssh;
 
 import java.util.Optional;
 
-@SecurityCheck(ReadAccessToken.RULE)
+@SecurityCheck(ReadPrivateKey.RULE)
 public class ReadPrivateKey extends OperationCheck<Ssh> {
     public static final String RULE = "read private key";
     @Autowired

--- a/api/src/main/java/org/terrakube/api/rs/checks/ssh/TeamManageSsh.java
+++ b/api/src/main/java/org/terrakube/api/rs/checks/ssh/TeamManageSsh.java
@@ -11,7 +11,6 @@ import org.terrakube.api.plugin.security.user.AuthenticatedUser;
 import org.terrakube.api.rs.ssh.Ssh;
 import org.terrakube.api.rs.team.Team;
 
-import java.util.List;
 import java.util.Optional;
 
 @Slf4j

--- a/api/src/main/java/org/terrakube/api/rs/checks/ssh/TeamManageSsh.java
+++ b/api/src/main/java/org/terrakube/api/rs/checks/ssh/TeamManageSsh.java
@@ -1,0 +1,43 @@
+package org.terrakube.api.rs.checks.ssh;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.terrakube.api.plugin.security.groups.GroupService;
+import org.terrakube.api.plugin.security.user.AuthenticatedUser;
+import org.terrakube.api.rs.ssh.Ssh;
+import org.terrakube.api.rs.team.Team;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamManageSsh.RULE)
+public class TeamManageSsh extends OperationCheck<Ssh> {
+    public static final String RULE = "team manage ssh";
+
+    @Autowired
+    GroupService groupService;
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Override
+    public boolean ok(Ssh ssh, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.info("team manage ssh {}", ssh.getId());
+        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
+        for (Team team : ssh.getOrganization().getTeam()) {
+            if (isServiceAccount){
+                if (groupService.isServiceMember(requestScope.getUser(), team.getName()) && team.isManageVcs() ){
+                    return true;
+                }
+            } else {
+                if (groupService.isMember(requestScope.getUser(), team.getName()) && team.isManageVcs())
+                    return true;
+            }
+        }
+        return false;
+    }
+}

--- a/api/src/main/java/org/terrakube/api/rs/checks/ssh/TeamViewSsh.java
+++ b/api/src/main/java/org/terrakube/api/rs/checks/ssh/TeamViewSsh.java
@@ -8,12 +8,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.terrakube.api.plugin.security.user.AuthenticatedUser;
 import org.terrakube.api.rs.checks.membership.MembershipService;
-import org.terrakube.api.rs.checks.vcs.TeamViewVcs;
 import org.terrakube.api.rs.ssh.Ssh;
 import java.util.Optional;
 
 @Slf4j
-@SecurityCheck(TeamViewVcs.RULE)
+@SecurityCheck(TeamViewSsh.RULE)
 public class TeamViewSsh extends OperationCheck<Ssh> {
     public static final String RULE = "team view ssh";
 

--- a/api/src/main/java/org/terrakube/api/rs/checks/ssh/TeamViewSsh.java
+++ b/api/src/main/java/org/terrakube/api/rs/checks/ssh/TeamViewSsh.java
@@ -1,0 +1,31 @@
+package org.terrakube.api.rs.checks.ssh;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.terrakube.api.plugin.security.user.AuthenticatedUser;
+import org.terrakube.api.rs.checks.membership.MembershipService;
+import org.terrakube.api.rs.checks.vcs.TeamViewVcs;
+import org.terrakube.api.rs.ssh.Ssh;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamViewVcs.RULE)
+public class TeamViewSsh extends OperationCheck<Ssh> {
+    public static final String RULE = "team view ssh";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    MembershipService membershipService;
+
+    @Override
+    public boolean ok(Ssh ssh, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.info("team view ssh {}", ssh.getId());
+        return authenticatedUser.isSuperUser(requestScope.getUser()) ? true : membershipService.checkMembership(requestScope.getUser(), ssh.getOrganization().getTeam());
+    }
+}

--- a/api/src/main/java/org/terrakube/api/rs/module/Module.java
+++ b/api/src/main/java/org/terrakube/api/rs/module/Module.java
@@ -115,7 +115,6 @@ public class Module extends GenericAuditFields {
                 tags = Git.lsRemoteRepository()
                         .setTags(true)
                         .setRemote(source)
-                        .setCredentialsProvider(credentialsProvider)
                         .setTransportConfigCallback(transportConfigCallback)
                         .callAsMap();
             }

--- a/api/src/main/java/org/terrakube/api/rs/module/Module.java
+++ b/api/src/main/java/org/terrakube/api/rs/module/Module.java
@@ -119,7 +119,14 @@ public class Module extends GenericAuditFields {
                         .setTransportConfigCallback(transportConfigCallback)
                         .callAsMap();
             }
-            
+
+            if (ssh == null && vcs == null){
+                tags = Git.lsRemoteRepository()
+                        .setTags(true)
+                        .setRemote(source)
+                        .callAsMap();
+            }
+
             tags.forEach((key, value) -> {
                 versionList.add(key.replace("refs/tags/", ""));
             });

--- a/api/src/main/java/org/terrakube/api/rs/module/Module.java
+++ b/api/src/main/java/org/terrakube/api/rs/module/Module.java
@@ -66,6 +66,7 @@ public class Module extends GenericAuditFields {
         try {
             CredentialsProvider credentialsProvider = null;
             TransportConfigCallback transportConfigCallback = null;
+            Map<String, Ref> tags = null;
             if (vcs != null) {
                 log.info("vcs using {}", vcs.getVcsType());
                 switch (vcs.getVcsType()) {
@@ -85,6 +86,12 @@ public class Module extends GenericAuditFields {
                         credentialsProvider = null;
                         break;
                 }
+
+                tags = Git.lsRemoteRepository()
+                        .setTags(true)
+                        .setRemote(source)
+                        .setCredentialsProvider(credentialsProvider)
+                        .callAsMap();
             }
 
             if (ssh != null){
@@ -104,14 +111,15 @@ public class Module extends GenericAuditFields {
                         }
                     }
                 };
-            }
 
-            Map<String, Ref> tags = Git.lsRemoteRepository()
-                    .setTags(true)
-                    .setRemote(source)
-                    .setCredentialsProvider(credentialsProvider)
-                    .setTransportConfigCallback(transportConfigCallback)
-                    .callAsMap();
+                tags = Git.lsRemoteRepository()
+                        .setTags(true)
+                        .setRemote(source)
+                        .setCredentialsProvider(credentialsProvider)
+                        .setTransportConfigCallback(transportConfigCallback)
+                        .callAsMap();
+            }
+            
             tags.forEach((key, value) -> {
                 versionList.add(key.replace("refs/tags/", ""));
             });

--- a/api/src/main/java/org/terrakube/api/rs/module/Module.java
+++ b/api/src/main/java/org/terrakube/api/rs/module/Module.java
@@ -5,21 +5,20 @@ import com.yahoo.elide.core.RequestScope;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jgit.api.TransportConfigCallback;
+import org.eclipse.jgit.transport.*;
 import org.terrakube.api.plugin.security.audit.GenericAuditFields;
+import org.terrakube.api.plugin.ssh.TerrakubeSshdSessionFactory;
 import org.terrakube.api.rs.Organization;
+import org.terrakube.api.rs.ssh.Ssh;
 import org.terrakube.api.rs.vcs.Vcs;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Ref;
-import org.eclipse.jgit.transport.CredentialsProvider;
-import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.hibernate.annotations.Type;
 
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 @ReadPermission(expression = "team view module")
 @CreatePermission(expression = "team manage module")
@@ -66,6 +65,7 @@ public class Module extends GenericAuditFields {
         List<String> versionList = new ArrayList<>();
         try {
             CredentialsProvider credentialsProvider = null;
+            TransportConfigCallback transportConfigCallback = null;
             if (vcs != null) {
                 log.info("vcs using {}", vcs.getVcsType());
                 switch (vcs.getVcsType()) {
@@ -86,10 +86,31 @@ public class Module extends GenericAuditFields {
                         break;
                 }
             }
+
+            if (ssh != null){
+                log.info("vcs using ssh {}", ssh.getId());
+
+                transportConfigCallback = transport -> {
+                    if(transport instanceof SshTransport) {
+                        if( transport instanceof SshTransport) {
+                            SshTransport sshTransportSSh = (SshTransport) transport;
+                            TerrakubeSshdSessionFactory terrakubeSshdSessionFactory = TerrakubeSshdSessionFactory
+                                    .builder()
+                                    .sshId(ssh.getId().toString())
+                                    .sshFileName(ssh.getSshType().getFileName())
+                                    .privateKey(ssh.getPrivateKey())
+                                    .build();
+                            ((SshTransport) transport).setSshSessionFactory(terrakubeSshdSessionFactory.getSshdSessionFactory());
+                        }
+                    }
+                };
+            }
+
             Map<String, Ref> tags = Git.lsRemoteRepository()
                     .setTags(true)
                     .setRemote(source)
                     .setCredentialsProvider(credentialsProvider)
+                    .setTransportConfigCallback(transportConfigCallback)
                     .callAsMap();
             tags.forEach((key, value) -> {
                 versionList.add(key.replace("refs/tags/", ""));
@@ -102,4 +123,7 @@ public class Module extends GenericAuditFields {
 
     @OneToOne
     private Vcs vcs;
+
+    @OneToOne
+    private Ssh ssh;
 }

--- a/api/src/main/java/org/terrakube/api/rs/ssh/Ssh.java
+++ b/api/src/main/java/org/terrakube/api/rs/ssh/Ssh.java
@@ -1,0 +1,44 @@
+package org.terrakube.api.rs.ssh;
+
+import com.yahoo.elide.annotation.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.Type;
+import org.terrakube.api.plugin.security.audit.GenericAuditFields;
+import org.terrakube.api.rs.Organization;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@ReadPermission(expression = "team view vcs")
+@CreatePermission(expression = "team manage vcs")
+@UpdatePermission(expression = "team manage vcs")
+@DeletePermission(expression = "team manage vcs")
+@Include(rootLevel = false)
+@Getter
+@Setter
+@Entity
+public class Ssh extends GenericAuditFields {
+
+    @Id
+    @Type(type = "uuid-char")
+    @GeneratedValue
+    private UUID id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "description")
+    private String description;
+
+    @ReadPermission(expression = "read access token")
+    @Column(name = "private_key")
+    private String privateKey;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ssh_type")
+    private SshType sshType;
+
+    @ManyToOne
+    private Organization organization;
+}

--- a/api/src/main/java/org/terrakube/api/rs/ssh/Ssh.java
+++ b/api/src/main/java/org/terrakube/api/rs/ssh/Ssh.java
@@ -10,10 +10,10 @@ import org.terrakube.api.rs.Organization;
 import javax.persistence.*;
 import java.util.UUID;
 
-@ReadPermission(expression = "team view vcs")
-@CreatePermission(expression = "team manage vcs")
-@UpdatePermission(expression = "team manage vcs")
-@DeletePermission(expression = "team manage vcs")
+@ReadPermission(expression = "team view ssh")
+@CreatePermission(expression = "team manage ssh")
+@UpdatePermission(expression = "team manage ssh")
+@DeletePermission(expression = "team manage ssh")
 @Include(rootLevel = false)
 @Getter
 @Setter
@@ -31,7 +31,7 @@ public class Ssh extends GenericAuditFields {
     @Column(name = "description")
     private String description;
 
-    @ReadPermission(expression = "read access token")
+    @ReadPermission(expression = "read private key")
     @Column(name = "private_key")
     private String privateKey;
 

--- a/api/src/main/java/org/terrakube/api/rs/ssh/SshType.java
+++ b/api/src/main/java/org/terrakube/api/rs/ssh/SshType.java
@@ -1,0 +1,14 @@
+package org.terrakube.api.rs.ssh;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public enum SshType {
+    rsa("id_rsa"),
+    ed25519("id_ed25519");
+
+    @Getter
+    private String fileName;
+
+}

--- a/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
@@ -4,6 +4,7 @@ import com.yahoo.elide.annotation.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.terrakube.api.rs.Organization;
+import org.terrakube.api.rs.ssh.Ssh;
 import org.terrakube.api.rs.vcs.Vcs;
 import org.terrakube.api.rs.workspace.parameters.Variable;
 import org.terrakube.api.rs.job.Job;
@@ -64,4 +65,7 @@ public class Workspace {
 
     @OneToOne
     private Vcs vcs;
+
+    @OneToOne
+    private Ssh ssh;
 }

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -22,4 +22,5 @@
     <include file="/db/changelog/local/changelog-2.3.1.xml"/>
     <include file="/db/changelog/local/changelog-2.4.0.xml"/>
     <include file="/db/changelog/local/changelog-2.6.0-pat.xml"/>
+    <include file="/db/changelog/local/changelog-2.6.0-ssh.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.6.0-ssh.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.6.0-ssh.xml
@@ -21,7 +21,7 @@
                 <constraints nullable="false" foreignKeyName="fk_ssh_org" references="organization(id)"/>
             </column>
         </createTable>
-        <addColumn tableName="workspace" >
+        <addColumn tableName="module" >
             <column name="ssh_id" type="varchar(36)">
                 <constraints nullable="true" foreignKeyName="fk_ssh_vcs" references="vcs(id)"/>
             </column>

--- a/api/src/main/resources/db/changelog/local/changelog-2.6.0-ssh.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.6.0-ssh.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="15" author="alfespa17@gmail.com">
+        <createTable tableName="ssh">
+            <column name="id" type="varchar(36)">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="varchar(64)"/>
+            <column name="description" type="varchar2(64)"/>
+            <column name="private_key" type="clob"/>
+            <column name="ssh_type" type="varchar2(32)"/>
+            <column name="created_date" type="datetime"/>
+            <column name="updated_date" type="datetime"/>
+            <column name="created_by" type="varchar2(128)"/>
+            <column name="updated_by" type="varchar2(128)"/>
+            <column name="organization_id" type="varchar(36)">
+                <constraints nullable="false" foreignKeyName="fk_ssh_org" references="organization(id)"/>
+            </column>
+        </createTable>
+        <addColumn tableName="workspace" >
+            <column name="ssh_id" type="varchar(36)">
+                <constraints nullable="true" foreignKeyName="fk_ssh_vcs" references="vcs(id)"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.6.0-ssh.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.6.0-ssh.xml
@@ -26,5 +26,10 @@
                 <constraints nullable="true" foreignKeyName="fk_module_ssh" references="ssh(id)"/>
             </column>
         </addColumn>
+        <addColumn tableName="workspace" >
+            <column name="ssh_id" type="varchar(36)">
+                <constraints nullable="true" foreignKeyName="fk_workspace_ssh" references="ssh(id)"/>
+            </column>
+        </addColumn>
     </changeSet>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.6.0-ssh.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.6.0-ssh.xml
@@ -23,7 +23,7 @@
         </createTable>
         <addColumn tableName="module" >
             <column name="ssh_id" type="varchar(36)">
-                <constraints nullable="true" foreignKeyName="fk_ssh_vcs" references="vcs(id)"/>
+                <constraints nullable="true" foreignKeyName="fk_module_ssh" references="ssh(id)"/>
             </column>
         </addColumn>
     </changeSet>

--- a/api/src/test/java/org/terrakube/api/ModuleTests.java
+++ b/api/src/test/java/org/terrakube/api/ModuleTests.java
@@ -54,6 +54,7 @@ class ModuleTests extends ServerApplicationTests{
                                                                 id("a42f538b-8c75-4311-8e73-ea2c0f2fb577")
                                                         )
                                                 ),
+                                                relation("ssh", true),
                                                 relation("vcs",true,
                                                         resource(
                                                                 type("vcs"),

--- a/api/src/test/java/org/terrakube/api/OrganizationTests.java
+++ b/api/src/test/java/org/terrakube/api/OrganizationTests.java
@@ -43,6 +43,7 @@ class OrganizationTests extends ServerApplicationTests {
                                                 relation("job"),
                                                 relation("module"),
                                                 relation("provider"),
+                                                relation("ssh"),
                                                 relation("team"),
                                                 relation("template"),
                                                 relation("vcs"),

--- a/api/src/test/java/org/terrakube/api/WorkspaceTests.java
+++ b/api/src/test/java/org/terrakube/api/WorkspaceTests.java
@@ -49,6 +49,7 @@ class WorkspaceTests extends ServerApplicationTests{
                                                         )
                                                 ),
                                                 relation("schedule"),
+                                                relation("ssh", true),
                                                 relation("variable"),
                                                 relation("vcs",true,
                                                         resource(

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -22,7 +22,7 @@
 		<commons-codec>1.15</commons-codec>
 		<okhttp.version>4.9.1</okhttp.version>
 		<azure-storage-blob.version>12.16.0</azure-storage-blob.version>
-		<jgit.version>5.12.0.202106070339-r</jgit.version>
+		<jgit.version>6.2.0.202206071550-r</jgit.version>
 		<lombok.version>1.18.24</lombok.version>
 		<groovy.version>3.0.7</groovy.version>
 		<ivy.version>2.5.0</ivy.version>
@@ -98,6 +98,11 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
+			<version>${jgit.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jgit</groupId>
+			<artifactId>org.eclipse.jgit.ssh.apache</artifactId>
 			<version>${jgit.version}</version>
 		</dependency>
 		<dependency>

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -3,6 +3,12 @@ package org.terrakube.executor.service.workspace;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
 import org.apache.commons.io.FilenameUtils;
+import org.eclipse.jgit.transport.SshTransport;
+import org.eclipse.jgit.transport.sshd.JGitKeyCache;
+import org.eclipse.jgit.transport.sshd.ServerKeyDatabase;
+import org.eclipse.jgit.transport.sshd.SshdSessionFactory;
+import org.eclipse.jgit.transport.sshd.SshdSessionFactoryBuilder;
+import org.eclipse.jgit.util.FS;
 import org.terrakube.executor.service.mode.TerraformJob;
 import org.terrakube.executor.service.workspace.registry.SetupPrivateRegistry;
 import org.eclipse.jgit.api.Git;
@@ -14,12 +20,20 @@ import org.springframework.stereotype.Service;
 import org.apache.commons.io.FileUtils;
 
 import java.io.*;
+import java.net.InetSocketAddress;
+import java.nio.charset.Charset;
+import java.security.PublicKey;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Service
 public class SetupWorkspaceImpl implements SetupWorkspace {
 
     private static final String EXECUTOR_DIRECTORY = "/.terraform-spring-boot/executor/";
+    private static final String SSH_DIRECTORY = "%s/.terraform-spring-boot/ssh/executor/%s/%s/%s";
+    private static final String SSH_EXECUTOR_JOB = "%s/.terraform-spring-boot/ssh/executor/%s";
 
     OkHttpClient httpClient;
     SetupPrivateRegistry setupPrivateRegistry;
@@ -36,7 +50,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
         File workspaceFolder = null;
         try {
             workspaceFolder = setupWorkspaceDirectory(terraformJob.getOrganizationId(), terraformJob.getWorkspaceId());
-            downloadWorkspace(workspaceFolder, terraformJob.getSource(), terraformJob.getBranch(), terraformJob.getVcsType(), terraformJob.getAccessToken());
+            downloadWorkspace(workspaceFolder, terraformJob.getSource(), terraformJob.getBranch(), terraformJob.getVcsType(), terraformJob.getAccessToken(), terraformJob.getJobId());
             if (enableRegistrySecurity)
                 setupPrivateRegistry.addCredentials(workspaceFolder);
         } catch (IOException e) {
@@ -60,17 +74,73 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
         return executorFolder;
     }
 
-    private void downloadWorkspace(File workspaceFolder, String source, String branch, String vcsType, String accessToken) throws IOException {
+    private void downloadWorkspace(File workspaceFolder, String source, String branch, String vcsType, String accessToken, String jobId) throws IOException {
         try {
-            Git.cloneRepository()
-                    .setURI(source)
-                    .setDirectory(workspaceFolder)
-                    .setCredentialsProvider(setupCredentials(vcsType, accessToken))
-                    .setBranch(branch)
-                    .call();
+            if (vcsType.startsWith("SSH")) {
+                Git.cloneRepository()
+                        .setURI(source)
+                        .setDirectory(workspaceFolder)
+                        .setBranch(branch)
+                        .setTransportConfigCallback(transport -> {
+                            ((SshTransport) transport).setSshSessionFactory(getSshdSessionFactory(vcsType, accessToken, jobId));
+                        })
+                        .call();
+                FileUtils.deleteDirectory(new File(String.format(SSH_EXECUTOR_JOB, FileUtils.getUserDirectoryPath(), jobId)));
+            } else {
+                Git.cloneRepository()
+                        .setURI(source)
+                        .setDirectory(workspaceFolder)
+                        .setCredentialsProvider(setupCredentials(vcsType, accessToken))
+                        .setBranch(branch)
+                        .call();
+            }
         } catch (GitAPIException ex) {
             log.error(ex.getMessage());
         }
+    }
+
+    public SshdSessionFactory getSshdSessionFactory(String vcsType, String accessToken, String jobId) {
+        File sshDir = generateWorkspaceSshFolder(vcsType, accessToken, jobId);
+        SshdSessionFactory sshdSessionFactory = new SshdSessionFactoryBuilder()
+                .setServerKeyDatabase((h, s) -> new ServerKeyDatabase() {
+
+                    @Override
+                    public List<PublicKey> lookup(String connectAddress,
+                                                  InetSocketAddress remoteAddress,
+                                                  Configuration config) {
+                        return Collections.emptyList();
+                    }
+
+                    @Override
+                    public boolean accept(String connectAddress,
+                                          InetSocketAddress remoteAddress,
+                                          PublicKey serverKey, Configuration config,
+                                          CredentialsProvider provider) {
+                        return true;
+                    }
+
+                })
+                .setPreferredAuthentications("publickey")
+                .setHomeDirectory(FS.DETECTED.userHome())
+                .setSshDirectory(sshDir)
+                .build(new JGitKeyCache());
+
+        return sshdSessionFactory;
+    }
+
+    private File generateWorkspaceSshFolder(String vcsType, String privateKey, String jobId) {
+        String sshId = UUID.randomUUID().toString();
+        String sshFileName = vcsType.split("~")[1];
+        String sshFilePath = String.format(SSH_DIRECTORY, FileUtils.getUserDirectoryPath(), jobId, sshId, sshFileName);
+        File sshFile = new File(sshFilePath);
+        try {
+            log.info("Creating new SSH folder for job {} sshId {}", jobId, sshId);
+            FileUtils.forceMkdirParent(sshFile);
+            FileUtils.writeStringToFile(sshFile, privateKey, Charset.defaultCharset());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return sshFile.getParentFile();
     }
 
     private CredentialsProvider setupCredentials(String vcsType, String accessToken) {

--- a/registry/pom.xml
+++ b/registry/pom.xml
@@ -17,7 +17,7 @@
 		<azure.version>3.13.1</azure.version>
 		<java.version>11</java.version>
 		<lombok.version>1.18.20</lombok.version>
-		<terrakube-client-starter.version>0.9.0</terrakube-client-starter.version>
+		<terrakube-client-starter.version>0.10.1</terrakube-client-starter.version>
 		<jgit.version>5.12.0.202106070339-r</jgit.version>
 		<commons-io.version>2.8.0</commons-io.version>
 		<azure-storage-blob.version>12.14.3</azure-storage-blob.version>
@@ -57,6 +57,11 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
+			<version>${jgit.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jgit</groupId>
+			<artifactId>org.eclipse.jgit.ssh.apache</artifactId>
 			<version>${jgit.version}</version>
 		</dependency>
 		<dependency>

--- a/registry/src/main/java/org/terrakube/registry/service/git/GitServiceImpl.java
+++ b/registry/src/main/java/org/terrakube/registry/service/git/GitServiceImpl.java
@@ -4,46 +4,57 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.TransportConfigCallback;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.transport.CredentialsProvider;
+import org.eclipse.jgit.transport.SshTransport;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.eclipse.jgit.transport.sshd.JGitKeyCache;
+import org.eclipse.jgit.transport.sshd.ServerKeyDatabase;
+import org.eclipse.jgit.transport.sshd.SshdSessionFactory;
+import org.eclipse.jgit.transport.sshd.SshdSessionFactoryBuilder;
+import org.eclipse.jgit.util.FS;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.net.InetSocketAddress;
+import java.nio.charset.Charset;
+import java.security.PublicKey;
+import java.util.*;
 
 @Slf4j
 @Service
 public class GitServiceImpl implements GitService {
 
     private static final String GIT_DIRECTORY = "/.terraform-spring-boot/git/";
+    private static final String SSH_REGISTRY_DIRECTORY = "%s/.terraform-spring-boot/ssh/registry/%s/id_%s";
 
     @Override
     public File getCloneRepositoryByTag(String repository, String tag, String vcsType, String accessToken) {
         File gitCloneRepository = null;
         try {
             String userHomeDirectory = FileUtils.getUserDirectoryPath();
+            String tempFolder = UUID.randomUUID().toString();
             String gitRepositoryPath = userHomeDirectory.concat(
                     FilenameUtils.separatorsToSystem(
-                            GIT_DIRECTORY + "/" + UUID.randomUUID()
+                            GIT_DIRECTORY + "/" + tempFolder
                     ));
             gitCloneRepository = new File(gitRepositoryPath);
             FileUtils.forceMkdir(gitCloneRepository);
             FileUtils.cleanDirectory(gitCloneRepository);
 
-            String correctTag = validateCorrectTag(tag, repository, setupCredentials(vcsType, accessToken));
+            String correctTag = validateCorrectTag(tag, repository, vcsType, accessToken, tempFolder);
 
             Git.cloneRepository()
                     .setURI(repository)
                     .setDirectory(gitCloneRepository)
                     .setBranch("refs/tags/" + correctTag)
                     .setCredentialsProvider(setupCredentials(vcsType, accessToken))
+                    .setTransportConfigCallback(setupTransportConfigCallback(vcsType, accessToken, tempFolder))
                     .call();
+
         } catch (GitAPIException | IOException ex) {
             log.error(ex.getMessage());
         }
@@ -72,7 +83,7 @@ public class GitServiceImpl implements GitService {
         return credentialsProvider;
     }
 
-    private String validateCorrectTag(String originalTag, String repository, CredentialsProvider credentialsProvider) {
+    private String validateCorrectTag(String originalTag, String repository, String vcsType, String accessToken, String folderName) {
         List<String> versionList = new ArrayList<>();
         String finalTag = originalTag;
         Map<String, Ref> tags = null;
@@ -80,7 +91,8 @@ public class GitServiceImpl implements GitService {
             tags = Git.lsRemoteRepository()
                     .setTags(true)
                     .setRemote(repository)
-                    .setCredentialsProvider(credentialsProvider)
+                    .setCredentialsProvider(setupCredentials(vcsType, accessToken))
+                    .setTransportConfigCallback(setupTransportConfigCallback(vcsType, accessToken, folderName))
                     .callAsMap();
         } catch (GitAPIException e) {
             throw new RuntimeException(e);
@@ -94,4 +106,52 @@ public class GitServiceImpl implements GitService {
 
         return finalTag;
     }
+
+    private TransportConfigCallback setupTransportConfigCallback(String vcsType, String privateKey, String folderName){
+        if(vcsType.startsWith("SSH")){
+            SshdSessionFactory registrySshFactory = new SshdSessionFactoryBuilder()
+                    .setServerKeyDatabase((h, s) -> new ServerKeyDatabase() {
+                        @Override
+                        public List<PublicKey> lookup(String connectAddress,
+                                                      InetSocketAddress remoteAddress,
+                                                      Configuration config) {
+                            return Collections.emptyList();
+                        }
+
+                        @Override
+                        public boolean accept(String connectAddress,
+                                              InetSocketAddress remoteAddress,
+                                              PublicKey serverKey, Configuration config,
+                                              CredentialsProvider provider) {
+                            return true;
+                        }
+
+                    })
+                    .setPreferredAuthentications("publickey")
+                    .setSshDirectory(generateRegistrySshFolder(vcsType, privateKey, folderName))
+                    .setHomeDirectory(FS.DETECTED.userHome())
+                    .build(new JGitKeyCache());
+            return transport -> {
+                ((SshTransport) transport).setSshSessionFactory(registrySshFactory);
+            };
+        } else {
+            return null;
+        }
+    }
+
+    private File generateRegistrySshFolder(String vcsType, String privateKey, String folderName) {
+        String sshFileName = vcsType.split("~")[1];
+        String sshFilePath = String.format(SSH_REGISTRY_DIRECTORY, FileUtils.getUserDirectoryPath(), folderName, sshFileName);
+        File sshFile = new File(sshFilePath);
+        log.info("Creating new SSH folder for registry {}", sshFilePath);
+        try {
+            FileUtils.forceMkdirParent(sshFile);
+            FileUtils.writeStringToFile(sshFile, privateKey, Charset.defaultCharset());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return sshFile.getParentFile();
+    }
+
+
 }

--- a/scripts/template/thunder-tests/thunderEnvironment.json
+++ b/scripts/template/thunder-tests/thunderEnvironment.json
@@ -45,6 +45,10 @@
       {
         "name": "sshModuleRepo",
         "value": ""
+      },
+      {
+        "name": "sshWorkspaceRepo",
+        "value": ""
       }
     ]
   }

--- a/scripts/template/thunder-tests/thunderEnvironment.json
+++ b/scripts/template/thunder-tests/thunderEnvironment.json
@@ -49,6 +49,22 @@
       {
         "name": "sshWorkspaceRepo",
         "value": ""
+      },
+      {
+        "name": "registryModuleOrg",
+        "value": "gcp"
+      },
+      {
+        "name": "registryModuleName",
+        "value": "kubernetes-engine"
+      },
+      {
+        "name": "registryModuleProvider",
+        "value": "google"
+      },
+      {
+        "name": "registryModuleVersion",
+        "value": "v22.1.0"
       }
     ]
   }

--- a/scripts/template/thunder-tests/thunderEnvironment.json
+++ b/scripts/template/thunder-tests/thunderEnvironment.json
@@ -34,7 +34,18 @@
     "created": "2022-07-23T17:50:06.873Z",
     "modified": "2022-07-23T17:50:11.500Z",
     "data": [
-      
+      {
+        "name": "sshKeyType",
+        "value": ""
+      },
+      {
+        "name": "sshPrivateKey",
+        "value": ""
+      },
+      {
+        "name": "sshModuleRepo",
+        "value": ""
+      }
     ]
   }
 ]

--- a/thunder-tests/thunderCollection.json
+++ b/thunder-tests/thunderCollection.json
@@ -193,6 +193,13 @@
         "containerId": "",
         "created": "2022-07-27T22:41:44.007Z",
         "sortNum": 300000
+      },
+      {
+        "_id": "003bb224-853c-4e33-a0e8-1620307cbdae",
+        "name": "Step 11 - SSH Support",
+        "containerId": "",
+        "created": "2022-08-07T15:49:55.301Z",
+        "sortNum": 132461
       }
     ],
     "settings": {

--- a/thunder-tests/thunderclient.json
+++ b/thunder-tests/thunderclient.json
@@ -8,7 +8,7 @@
     "method": "POST",
     "sortNum": 10000,
     "created": "2022-07-22T21:25:36.069Z",
-    "modified": "2022-07-23T18:11:53.228Z",
+    "modified": "2022-08-07T15:55:46.567Z",
     "headers": [
       {
         "name": "Content-Type",
@@ -18,7 +18,7 @@
     "params": [],
     "body": {
       "type": "json",
-      "raw": "{\n  \"data\": {\n    \"type\": \"organization\",\n    \"attributes\": {\n      \"name\": \"hashicorp2\",\n      \"description\": \"hashicorp organization\"\n    }\n  }\n}",
+      "raw": "{\n  \"data\": {\n    \"type\": \"organization\",\n    \"attributes\": {\n      \"name\": \"hashicorp\",\n      \"description\": \"hashicorp organization\"\n    }\n  }\n}",
       "form": []
     },
     "auth": {
@@ -1332,68 +1332,93 @@
     "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
     "containerId": "670da35d-59c7-429d-8dd0-3eeea2b429cd",
     "name": "create module without vcs",
-    "url": "{{server}}/api/v1/organization/{{organizationId}}/module",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/module",
     "method": "POST",
     "sortNum": 450000,
     "created": "2022-07-22T21:25:36.114Z",
-    "modified": "2022-07-22T21:25:36.114Z",
+    "modified": "2022-08-07T16:41:58.664Z",
     "headers": [
       {
         "name": "Content-Type",
         "value": "application/vnd.api+json"
       }
     ],
+    "params": [],
     "body": {
       "type": "json",
-      "raw": "{\r\n  \"data\": {\r\n    \"type\": \"module\",\r\n    \"attributes\": {\r\n      \"name\": \"sample\",\r\n      \"description\": \"Sample module\",\r\n      \"provider\": \"azurerm\",\r\n      \"source\": \"https://github.com/AzBuilder/terrakube-docker-compose.git\"\r\n    }\r\n  }\r\n}"
-    }
+      "raw": "{\n  \"data\": {\n    \"type\": \"module\",\n    \"attributes\": {\n      \"name\": \"sample\",\n      \"description\": \"Sample module\",\n      \"provider\": \"azurerm\",\n      \"source\": \"https://github.com/AzBuilder/terraform-azurerm-terrakube-cloud-storage.git\"\n    }\n  }\n}",
+      "form": []
+    },
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
   },
   {
     "_id": "25eaf62e-6bb6-44e6-a3c2-229e5b8fd532",
     "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
     "containerId": "670da35d-59c7-429d-8dd0-3eeea2b429cd",
     "name": "search modules",
-    "url": "{{server}}/api/v1/organization/{{organizationId}}/module",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/module",
     "method": "GET",
     "sortNum": 460000,
     "created": "2022-07-22T21:25:36.115Z",
-    "modified": "2022-07-22T21:25:36.115Z",
-    "headers": []
+    "modified": "2022-08-07T16:43:47.168Z",
+    "headers": [],
+    "params": [],
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
   },
   {
     "_id": "3383ab80-2d33-4c5d-8faa-a68a81ad3383",
     "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
     "containerId": "670da35d-59c7-429d-8dd0-3eeea2b429cd",
     "name": "search module by id",
-    "url": "{{server}}/api/v1/organization/{{organizationId}}/module/{{moduleId}}",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/module/{{moduleId}}",
     "method": "GET",
     "sortNum": 470000,
     "created": "2022-07-22T21:25:36.116Z",
-    "modified": "2022-07-22T21:25:36.116Z",
-    "headers": []
+    "modified": "2022-08-07T16:44:08.434Z",
+    "headers": [],
+    "params": [],
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
   },
   {
     "_id": "161d4ee1-bb8b-492f-a560-2bf5676913a0",
     "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
     "containerId": "670da35d-59c7-429d-8dd0-3eeea2b429cd",
     "name": "delete module by id",
-    "url": "{{server}}/api/v1/organization/{{organizationId}}/module/{{moduleId}}",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/module/{{moduleId}}",
     "method": "DELETE",
     "sortNum": 480000,
     "created": "2022-07-22T21:25:36.117Z",
-    "modified": "2022-07-22T21:25:36.117Z",
-    "headers": []
+    "modified": "2022-08-07T16:29:19.946Z",
+    "headers": [],
+    "params": [],
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
   },
   {
     "_id": "23bbfa3f-cae6-4e0f-a676-63a702abffae",
     "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
     "containerId": "670da35d-59c7-429d-8dd0-3eeea2b429cd",
     "name": "search module by name,provider and organization",
-    "url": "{{server}}/api/v1/organization/{{organizationId}}/module?filter[module]=name==azure;provider==azurerm",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/module?filter[module]=name==azure;provider==azurerm",
     "method": "GET",
     "sortNum": 490000,
     "created": "2022-07-22T21:25:36.118Z",
-    "modified": "2022-07-22T21:25:36.118Z",
+    "modified": "2022-08-07T16:29:47.538Z",
     "headers": [
       {
         "name": "Content-Type",
@@ -1403,9 +1428,15 @@
     "params": [
       {
         "name": "filter[module]",
-        "value": "name==azure;provider==azurerm"
+        "value": "name==azure;provider==azurerm",
+        "isPath": false
       }
-    ]
+    ],
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
   },
   {
     "_id": "ea503013-e1bd-4aff-95ec-2179da6e7cd6",
@@ -1894,6 +1925,69 @@
     "params": [],
     "auth": {
       "type": "none"
+    },
+    "tests": []
+  },
+  {
+    "_id": "ba24cc2f-3b48-40aa-be4b-745fc831f3e5",
+    "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
+    "containerId": "003bb224-853c-4e33-a0e8-1620307cbdae",
+    "name": "create ssh key",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/ssh",
+    "method": "POST",
+    "sortNum": 730000,
+    "created": "2022-08-07T15:50:12.597Z",
+    "modified": "2022-08-07T16:53:22.417Z",
+    "headers": [
+      {
+        "name": "Content-Type",
+        "value": "application/vnd.api+json"
+      }
+    ],
+    "params": [],
+    "body": {
+      "type": "json",
+      "raw": "{\n  \"data\": {\n    \"type\": \"ssh\",\n    \"attributes\": {\n      \"name\": \"Sample SSH Key\",\n      \"description\": \"SSH Key Description\",\n      \"privateKey\": \"{{sshPrivateKey}}\",\n      \"sshType\": \"{{sshKeyType}}\"\n    }\n  }\n}",
+      "form": []
+    },
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": [
+      {
+        "type": "set-env-var",
+        "custom": "json.data.id",
+        "action": "setto",
+        "value": "{{sshId}}"
+      }
+    ]
+  },
+  {
+    "_id": "25c584a9-c9b9-43e5-862b-7563846365bf",
+    "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
+    "containerId": "003bb224-853c-4e33-a0e8-1620307cbdae",
+    "name": "create module with ssh",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/module",
+    "method": "POST",
+    "sortNum": 740000,
+    "created": "2022-08-07T16:13:18.969Z",
+    "modified": "2022-08-07T16:19:47.931Z",
+    "headers": [
+      {
+        "name": "Content-Type",
+        "value": "application/vnd.api+json"
+      }
+    ],
+    "params": [],
+    "body": {
+      "type": "json",
+      "raw": "{\n  \"data\": {\n    \"type\": \"module\",\n    \"attributes\": {\n      \"name\": \"SSH Module\",\n      \"description\": \"Sample SSH module\",\n      \"provider\": \"azurerm\",\n      \"source\": \"{{sshModuleRepo}}\"\n    },\n    \"relationships\": {\n      \"ssh\": {\n        \"data\": {\n          \"type\": \"ssh\",\n          \"id\": \"{{sshId}}\"\n        }\n      }\n  }\n  }\n}",
+      "form": []
+    },
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
     },
     "tests": []
   }

--- a/thunder-tests/thunderclient.json
+++ b/thunder-tests/thunderclient.json
@@ -2025,5 +2025,35 @@
         "value": "{{workspaceId}}"
       }
     ]
+  },
+  {
+    "_id": "92aa8b0e-5379-4549-846b-43a0417cbdda",
+    "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
+    "containerId": "003bb224-853c-4e33-a0e8-1620307cbdae",
+    "name": "search ssh key",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/ssh",
+    "method": "GET",
+    "sortNum": 735000,
+    "created": "2022-08-08T00:55:12.117Z",
+    "modified": "2022-08-08T00:55:24.698Z",
+    "headers": [
+      {
+        "name": "Content-Type",
+        "value": "application/vnd.api+json"
+      }
+    ],
+    "params": [],
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": [
+      {
+        "type": "set-env-var",
+        "custom": "json.data.id",
+        "action": "setto",
+        "value": "{{sshId}}"
+      }
+    ]
   }
 ]

--- a/thunder-tests/thunderclient.json
+++ b/thunder-tests/thunderclient.json
@@ -1845,11 +1845,11 @@
     "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
     "containerId": "965fa789-1b7c-48e1-a252-8c7487f9333d",
     "name": "Search Versions",
-    "url": "{{terrakubeRegistry}}/terraform/modules/v1/gcp/kubernetes-engine/google/versions",
+    "url": "{{terrakubeRegistry}}/terraform/modules/v1/{{registryModuleOrg}}/{{registryModuleName}}/{{registryModuleProvider}}/versions",
     "method": "GET",
     "sortNum": 680000,
     "created": "2022-07-27T21:25:40.248Z",
-    "modified": "2022-07-27T21:31:01.960Z",
+    "modified": "2022-08-08T22:11:50.150Z",
     "headers": [],
     "params": [],
     "auth": {
@@ -1863,11 +1863,11 @@
     "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
     "containerId": "965fa789-1b7c-48e1-a252-8c7487f9333d",
     "name": "Download Version",
-    "url": "{{terrakubeRegistry}}/terraform/modules/v1/gcp/kubernetes-engine/google/v22.0.0/download",
+    "url": "{{terrakubeRegistry}}/terraform/modules/v1/{{registryModuleOrg}}/{{registryModuleName}}/{{registryModuleProvider}}/{{registryModuleVersion}}/download",
     "method": "GET",
     "sortNum": 690000,
     "created": "2022-07-27T21:25:47.998Z",
-    "modified": "2022-07-27T21:29:31.957Z",
+    "modified": "2022-08-08T22:12:19.939Z",
     "headers": [],
     "params": [],
     "auth": {
@@ -1972,7 +1972,7 @@
     "method": "POST",
     "sortNum": 740000,
     "created": "2022-08-07T16:13:18.969Z",
-    "modified": "2022-08-07T16:19:47.931Z",
+    "modified": "2022-08-08T21:59:34.782Z",
     "headers": [
       {
         "name": "Content-Type",
@@ -1982,7 +1982,7 @@
     "params": [],
     "body": {
       "type": "json",
-      "raw": "{\n  \"data\": {\n    \"type\": \"module\",\n    \"attributes\": {\n      \"name\": \"SSH Module\",\n      \"description\": \"Sample SSH module\",\n      \"provider\": \"azurerm\",\n      \"source\": \"{{sshModuleRepo}}\"\n    },\n    \"relationships\": {\n      \"ssh\": {\n        \"data\": {\n          \"type\": \"ssh\",\n          \"id\": \"{{sshId}}\"\n        }\n      }\n  }\n  }\n}",
+      "raw": "{\n  \"data\": {\n    \"type\": \"module\",\n    \"attributes\": {\n      \"name\": \"sshsample\",\n      \"description\": \"Sample SSH module\",\n      \"provider\": \"azurerm\",\n      \"source\": \"{{sshModuleRepo}}\"\n    },\n    \"relationships\": {\n      \"ssh\": {\n        \"data\": {\n          \"type\": \"ssh\",\n          \"id\": \"{{sshId}}\"\n        }\n      }\n  }\n  }\n}",
       "form": []
     },
     "auth": {

--- a/thunder-tests/thunderclient.json
+++ b/thunder-tests/thunderclient.json
@@ -177,7 +177,7 @@
     "method": "POST",
     "sortNum": 80000,
     "created": "2022-07-22T21:25:36.076Z",
-    "modified": "2022-07-22T23:28:54.643Z",
+    "modified": "2022-08-08T00:04:52.559Z",
     "headers": [
       {
         "name": "Content-Type",
@@ -187,7 +187,7 @@
     "params": [],
     "body": {
       "type": "json",
-      "raw": "{\n  \"data\": {\n    \"type\": \"template\",\n    \"attributes\": {\n      \"name\": \"plan_apply\",\n      \"description\": \"Terraform Plan Apply\",\n      \"version\": \"1.0.0\",\n      \"tcl\": \"ZmxvdzoKICAtIHR5cGU6ICJ0ZXJyYWZvcm1QbGFuIgogICAgc3RlcDogMTAwCiAgLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgICBzdGVwOiAyMDA=\"\n    }\n  }\n}",
+      "raw": "{\n  \"data\": {\n    \"type\": \"template\",\n    \"attributes\": {\n      \"name\": \"plan_apply\",\n      \"description\": \"Terraform Plan Apply\",\n      \"version\": \"1.0.0\",\n      \"tcl\": \"ZmxvdzoKICAtIHR5cGU6ICJ0ZXJyYWZvcm1QbGFuIgogICAgbmFtZTogIlBsYW4iCiAgICBzdGVwOiAxMDAK\"\n    }\n  }\n}",
       "form": []
     },
     "auth": {
@@ -1099,7 +1099,7 @@
     "method": "POST",
     "sortNum": 380000,
     "created": "2022-07-22T21:25:36.107Z",
-    "modified": "2022-07-22T23:49:26.221Z",
+    "modified": "2022-08-08T00:15:47.193Z",
     "headers": [
       {
         "name": "Content-Type",
@@ -1109,7 +1109,7 @@
     "params": [],
     "body": {
       "type": "json",
-      "raw": "{\n  \"data\": {\n    \"type\": \"job\",\n    \"attributes\": {\n      \"tcl\": \"{{template_plan_apply_id}}\"\n    },\n    \"relationships\":{\n        \"workspace\":{\n            \"data\":{\n                \"type\": \"workspace\",\n                \"id\": \"{{workspaceId}}\"\n            }\n        }\n    }\n  }\n}",
+      "raw": "{\n  \"data\": {\n    \"type\": \"job\",\n    \"attributes\": {\n      \"templateReference\": \"{{template_plan_apply_id}}\"\n    },\n    \"relationships\":{\n        \"workspace\":{\n            \"data\":{\n                \"type\": \"workspace\",\n                \"id\": \"{{workspaceId}}\"\n            }\n        }\n    }\n  }\n}",
       "form": []
     },
     "auth": {
@@ -1990,5 +1990,40 @@
       "bearer": "{{access_token}}"
     },
     "tests": []
+  },
+  {
+    "_id": "3e8aa1a2-d273-4dd3-b711-fc61b610763c",
+    "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
+    "containerId": "003bb224-853c-4e33-a0e8-1620307cbdae",
+    "name": "create wokspace with ssh",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/workspace",
+    "method": "POST",
+    "sortNum": 750000,
+    "created": "2022-08-07T23:30:33.035Z",
+    "modified": "2022-08-07T23:41:18.501Z",
+    "headers": [
+      {
+        "name": "Content-Type",
+        "value": "application/vnd.api+json"
+      }
+    ],
+    "params": [],
+    "body": {
+      "type": "json",
+      "raw": "{\n    \"data\": {\n        \"type\": \"workspace\",\n        \"attributes\": {\n            \"branch\": \"main\",\n            \"name\": \"Sample-Workspace SSH\",\n            \"source\":  \"{{sshWorkspaceRepo}}\",\n            \"terraformVersion\": \"1.0.11\"\n        },\n        \"relationships\": {\n            \"ssh\": {\n                \"data\": {\n                    \"type\": \"ssh\",\n                    \"id\": \"{{sshId}}\"\n                }\n            }\n        }\n    }\n}",
+      "form": []
+    },
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": [
+      {
+        "type": "set-env-var",
+        "custom": "json.data.id",
+        "action": "setto",
+        "value": "{{workspaceId}}"
+      }
+    ]
   }
 ]

--- a/ui/src/domain/Modules/Details.jsx
+++ b/ui/src/domain/Modules/Details.jsx
@@ -325,10 +325,10 @@ export const ModuleDetails = ({ setOrganizationName, organizationName }) => {
                         <td>
                           {renderVCSLogo(vcsProvider)}{" "}
                           <a
-                            href={module.data.attributes.source}
+                            href={module.data.attributes.source.replace(":","/").replace("git@","https://")}
                             target="_blank"
                           >
-                            {new URL(module.data.attributes.source)?.pathname
+                            {new URL(module.data.attributes.source.replace(":","/").replace("git@","https://"))?.pathname
                               ?.replace(".git", "")
                               ?.substring(1)}
                           </a>

--- a/ui/src/domain/Modules/Details.jsx
+++ b/ui/src/domain/Modules/Details.jsx
@@ -325,10 +325,10 @@ export const ModuleDetails = ({ setOrganizationName, organizationName }) => {
                         <td>
                           {renderVCSLogo(vcsProvider)}{" "}
                           <a
-                            href={module.data.attributes.source.replace(":","/").replace("git@","https://")}
+                            href={fixSshURL(module.data.attributes.source)}
                             target="_blank"
                           >
-                            {new URL(module.data.attributes.source.replace(":","/").replace("git@","https://"))?.pathname
+                            {new URL(fixSshURL(module.data.attributes.source))?.pathname
                               ?.replace(".git", "")
                               ?.substring(1)}
                           </a>
@@ -562,3 +562,12 @@ export const ModuleDetails = ({ setOrganizationName, organizationName }) => {
     </Content>
   );
 };
+
+
+function fixSshURL(source){
+  if(source.startsWith("git@")){
+      return source.replace(":","/").replace("git@","https://")
+  } else {
+      return source
+  }
+}

--- a/ui/src/domain/Organizations/Details.jsx
+++ b/ui/src/domain/Organizations/Details.jsx
@@ -181,9 +181,9 @@ export const OrganizationDetails = ({
                           &nbsp;&nbsp;{item.terraformVersion}
                         </span>
                         <span>
-                          {renderVCSLogo(new URL(item.source.replace(":","/").replace("git@","https://")).hostname)}&nbsp;{" "}
-                          <a href={item.source.replace(":","/").replace("git@","https://")} target="_blank">
-                            {new URL(item.source.replace(":","/").replace("git@","https://"))?.pathname
+                          {renderVCSLogo(new URL(fixSshURL(item.source)).hostname)}&nbsp;{" "}
+                          <a href={fixSshURL(item.source)} target="_blank">
+                            {new URL(fixSshURL(item.source))?.pathname
                               ?.replace(".git", "")
                               ?.substring(1)}
                           </a>
@@ -200,6 +200,14 @@ export const OrganizationDetails = ({
     </Content>
   );
 };
+
+function fixSshURL(source){
+  if(source.startsWith("git@")){
+      return source.replace(":","/").replace("git@","https://")
+  } else {
+      return source
+  }
+}
 
 function setupOrganizationIncludes(includes, setWorkspaces) {
   let workspaces = [];

--- a/ui/src/domain/Organizations/Details.jsx
+++ b/ui/src/domain/Organizations/Details.jsx
@@ -181,9 +181,9 @@ export const OrganizationDetails = ({
                           &nbsp;&nbsp;{item.terraformVersion}
                         </span>
                         <span>
-                          {renderVCSLogo(new URL(item.source).hostname)}&nbsp;{" "}
-                          <a href={item.source} target="_blank">
-                            {new URL(item.source)?.pathname
+                          {renderVCSLogo(new URL(item.source.replace(":","/").replace("git@","https://")).hostname)}&nbsp;{" "}
+                          <a href={item.source.replace(":","/").replace("git@","https://")} target="_blank">
+                            {new URL(item.source.replace(":","/").replace("git@","https://"))?.pathname
                               ?.replace(".git", "")
                               ?.substring(1)}
                           </a>


### PR DESCRIPTION
## SSH support

Including support to use SSH Keys (RSA and ED25519) inside the organizations, now Terrakube can authenticate with private repositories without using oAuth applications.

Only users inside teams with "Manage VCS settings" will be able to create SSH keys
![image](https://user-images.githubusercontent.com/4461895/183532283-15a670af-c6e4-4edb-aab8-73ec31249321.png)

### SSH Endpoint 
Elide now expose the SSH endpoint:
```
POST {{terrakubeApi}}/api/v1/organization/{{organizationId}}/ssh
{
  "data": {
    "type": "ssh",
    "attributes": {
      "name": "SSH KEY NAME",
      "description": "SSH KEY DESCRIPTION",
      "privateKey": "{{sshPrivateKey}}", 
      "sshType": "{{sshKeyType}}"
    }
  }
}
```
> sshType field can be ***rsa*** or ***ed25519***
> When sending the private key please include ***"\n"*** at the end of each line

### Module/Workspace support

To use the SSH support in modules the ***source***  should be used like ***"git@github.com:AzBuilder/terrakube-docker-compose.git"*** and the request should include the relationship to the SSH key

Example Module:
```
POST {{terrakubeApi}}/api/v1/organization/{{organizationId}}/module
{
  "data": {
    "type": "module",
    "attributes": {
      "name": "sshsample",
      "description": "Sample SSH module",
      "provider": "azurerm",
      "source": "{{sshModuleRepo}}"
    },
    "relationships": {
      "ssh": {
        "data": {
          "type": "ssh",
          "id": "{{sshId}}"
        }
      }
  }
  }
}
```

Example Workspace:
```
POST {{terrakubeApi}}/api/v1/organization/{{organizationId}}/workspace
{
    "data": {
        "type": "workspace",
        "attributes": {
            "branch": "main",
            "name": "Sample-Workspace SSH",
            "source":  "{{sshWorkspaceRepo}}",
            "terraformVersion": "1.0.11"
        },
        "relationships": {
            "ssh": {
                "data": {
                    "type": "ssh",
                    "id": "{{sshId}}"
                }
            }
        }
    }
}
```

### Thunder Test SSH Support

You can use thunder client inside Gitpod to test the SSH support. The first step is to add the parameters in the environment variables as the following example:

![image](https://user-images.githubusercontent.com/4461895/183531210-7c28f948-531b-4158-b3cf-25c2b8cd373b.png)

This folder can be use to test the API using the environment variables defined above
![image](https://user-images.githubusercontent.com/4461895/183531338-623e4e4a-6f81-45bc-896d-59ee3c1f6e3c.png)

### Additional note
- Changes inside the UI component will be included in other PR. 