### PR TITLE
Adding support to handle workspace inside the repository

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
@@ -21,6 +21,7 @@ public class ExecutorContext {
     private String terraformVersion;
     private String source;
     private String branch;
+    private String folder;
     private String vcsType;
     private String accessToken;
     private HashMap<String, String> environmentVariables;

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -93,7 +93,7 @@ public class ExecutorService {
         executorContext.setTerraformVersion(job.getWorkspace().getTerraformVersion());
         executorContext.setSource(job.getWorkspace().getSource());
         executorContext.setBranch(job.getWorkspace().getBranch());
-
+        executorContext.setFolder(job.getWorkspace().getFolder());
         return sendToExecutor(job, executorContext);
     }
 

--- a/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
@@ -44,6 +44,9 @@ public class Workspace {
     @Column(name = "branch")
     private String branch;
 
+    @Column(name = "folder")
+    private String folder;
+
     @Column(name = "terraform_version")
     private String terraformVersion;
 

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -23,4 +23,5 @@
     <include file="/db/changelog/local/changelog-2.4.0.xml"/>
     <include file="/db/changelog/local/changelog-2.6.0-pat.xml"/>
     <include file="/db/changelog/local/changelog-2.6.0-ssh.xml"/>
+    <include file="/db/changelog/local/changelog-2.6.0-workspace-folder.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.6.0-workspace-folder.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.6.0-workspace-folder.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="16" author="alfespa17@gmail.com">
+        <addColumn tableName="workspace" >
+            <column name="folder" type="varchar(64)" defaultValue="/"/>
+        </addColumn>
+        <update tableName="workspace">
+            <column name="folder" value="/"/>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -43,9 +43,11 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <configuration>
                     <excludes>
-                        <exclude>**/azure/*</exclude>
-                        <exclude>org/terrakube/api/**/*Properties.*</exclude>
-                        <exclude>org/terrakube/rs/*</exclude>
+                        <exclude>org/terrakube/api/**/*Tests.*</exclude>
+                        <exclude>org/terrakube/api/plugin/security/audit/local/*</exclude>
+                        <exclude>org/terrakube/api/plugin/security/authentication/local/*</exclude>
+                        <exclude>org/terrakube/api/plugin/security/groups/local/*</exclude>
+                        <exclude>org/terrakube/api/plugin/security/user/local/*</exclude>
                     </excludes>
                 </configuration>
                 <executions>

--- a/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
+++ b/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
@@ -21,6 +21,7 @@ public class TerraformJob {
     private String terraformVersion;
     private String source;
     private String branch;
+    private String folder;
     private String vcsType;
     private String accessToken;
     private String terraformOutput;

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -59,7 +59,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
         } catch (IOException e) {
             log.error(e.getMessage());
         }
-        return workspaceCloneFolder.getParentFile();
+        return workspaceCloneFolder != null ? workspaceCloneFolder.getParentFile() : new File("/tmp/"+UUID.randomUUID());
     }
 
     private File setupWorkspaceDirectory(String organizationId, String workspaceId) throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>2.6.0-beta2</revision>
+        <revision>2.6.0-beta.3</revision>
         <sonar.organization>azbuilder</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.project.key>AzBuilder_azb-server</sonar.project.key>

--- a/ui/src/domain/Workspaces/Create.jsx
+++ b/ui/src/domain/Workspaces/Create.jsx
@@ -309,6 +309,9 @@ export const CreateWorkspace = () => {
               <Form.Item name="branch" label="VCS branch" placeholder="(default branch)" extra=" The branch from which to import new versions. This defaults to the value your version control provides as the default branch for this repository." rules={[{ required: true }]}>
                 <Input />
               </Form.Item>
+              <Form.Item name="folder" label="Workspace folder" placeholder="/" extra=" Default workspace directory. Use / for the root folder" rules={[{ required: true }]}>
+                <Input />
+              </Form.Item>
               <Form.Item name="terraformVersion" label="Terraform Version" rules={[{ required: true }]} extra="The version of Terraform to use for this workspace. It will not upgrade automatically.">
                 <Select placeholder="select version" style={{ width: 250 }} >
                   {terraformVersions.map(function (name, index) {

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -178,6 +178,7 @@ export const WorkspaceDetails = (props) => {
         attributes: {
           name: values.name,
           description: values.description,
+          folder: values.folder,
           terraformVersion: values.terraformVersion,
         },
       },
@@ -339,6 +340,8 @@ export const WorkspaceDetails = (props) => {
                         initialValues={{
                           name: workspace.data.attributes.name,
                           description: workspace.data.attributes.description,
+                          folder: workspace.data.attributes.folder
+
                         }}
                         layout="vertical"
                         name="form-settings"
@@ -356,6 +359,12 @@ export const WorkspaceDetails = (props) => {
                           label="Description"
                         >
                           <Input.TextArea placeholder="Workspace description" />
+                        </Form.Item>
+                        <Form.Item
+                          name="folder"
+                          label="Workspace Repository Folder"
+                        >
+                          <Input />
                         </Form.Item>
                         <Form.Item
                           name="terraformVersion"


### PR DESCRIPTION
Adding support to handle multiple workspaces using the same git repository using "folders".

### API Changes
Including new "folder" field
```
POST  {{server}}/api/v1/organization/{{organizationId}}/workspace
{
  "data": {
    "type": "workspace",
    "attributes": {
      "name": "Sample SSH",
      "source": "git@github.com:XXXX/terrakube-workspace.git",
      "branch": "main",
      "terraformVersion": "1.0.11",
      "folder": "/folder1/folder2"
    }
}
```
### UI Changes
Adding field to setup the workspace folder inside the git repository.

![image](https://user-images.githubusercontent.com/4461895/184259715-3e656caa-3fb9-4712-896d-3e77b78b6308.png)

Include option to update the workspace folder.

![image](https://user-images.githubusercontent.com/4461895/184259349-ad40881c-8353-4719-9577-1768917929bf.png)

Closes #217 