### PR TITLE
Allow custom admin group name

### DIFF
--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -48,7 +48,7 @@ org.terrakube.api.plugin.datasource.databasePassword=${DatasourcePassword}
 ################
 #OWNER INSTANCE#
 ################
-org.terrakube.owner=TERRAKUBE_ADMIN
+org.terrakube.owner=${TERRAKUBE_ADMIN_GROUP:TERRAKUBE_ADMIN}
 
 ##################
 #Validation Types#

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -48,7 +48,7 @@ org.terrakube.api.plugin.datasource.databasePassword=${DatasourcePassword}
 ################
 #OWNER INSTANCE#
 ################
-org.terrakube.owner=TERRAKUBE_ADMIN
+org.terrakube.owner=${TERRAKUBE_ADMIN_GROUP:TERRAKUBE_ADMIN}
 
 ##################
 #Validation Types#

--- a/scripts/setupDevelopmentEnvironment.sh
+++ b/scripts/setupDevelopmentEnvironment.sh
@@ -20,6 +20,7 @@ function generateApiVars(){
   AuthenticationValidationType="DEX"
   PatSecret=ejZRSFgheUBOZXAyUURUITUzdmdINDNeUGpSWHlDM1g=
   InternalSecret=S2JeOGNNZXJQTlpWNmhTITkha2NEKkt1VVBVQmFeQjM=
+  TERRAKUBE_ADMIN_GROUP="CUSTOM_ADMIN_NAME"
 
   StorageType="LOCAL"
 
@@ -39,6 +40,7 @@ function generateApiVars(){
   echo "StorageType=$StorageType" >> .envApi
   echo "TerrakubeUiURL=$TerrakubeUiURL" >> .envApi
   echo "spring_profiles_active=demo" >> .envApi
+  echo "#TERRAKUBE_ADMIN_GROUP=$TERRAKUBE_ADMIN_GROUP" >> .envApi
 }
 
 function generateRegistryVars(){


### PR DESCRIPTION
Sometimes we need to define a custom name for the Terrakube administrator group. 

- For example when using Github Authentication the groups claim in the Dex token is define like "GithubOrganizationName:GithubTeamName"
- When using the Google Cloud Identity authentication the group claim is define like "GROUP_NAME@yourdomain.com"

A new environment variable ***TERRAKUBE_ADMIN_GROUP*** is added to handle this cases, if the environment variable is not define the default name "TERRAKUBE_ADMIN" will be used.

If we need to define a custom name in GITPOD you only need to change the following line in ***.envApi file***

![image](https://user-images.githubusercontent.com/4461895/184516587-362fdd09-5c2a-4627-9333-f64b0b174bca.png)
