### PR TITLE
Lock/Unlocked Workspace

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJobService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJobService.java
@@ -2,13 +2,16 @@ package org.terrakube.api.plugin.scheduler;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.terrakube.api.repository.JobRepository;
 import org.terrakube.api.repository.StepRepository;
+import org.terrakube.api.repository.WorkspaceRepository;
 import org.terrakube.api.rs.job.Job;
 import org.terrakube.api.rs.job.JobStatus;
 import org.terrakube.api.rs.job.step.Step;
 import org.quartz.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.terrakube.api.rs.workspace.Workspace;
 
 import java.text.ParseException;
 
@@ -24,6 +27,8 @@ public class ScheduleJobService {
     Scheduler scheduler;
 
     StepRepository stepRepository;
+
+    WorkspaceRepository workspaceRepository;
 
     public void createJobTrigger(String cronExpression, String triggerId) throws ParseException, SchedulerException {
 
@@ -70,6 +75,10 @@ public class ScheduleJobService {
                 .build();
 
         log.info("Create Job Context {}", jobDetail.getKey());
+
+        Workspace workspace = job.getWorkspace();
+        workspace.setLocked(true);
+        workspaceRepository.save(workspace);
         scheduler.scheduleJob(jobDetail, trigger);
     }
 

--- a/api/src/main/java/org/terrakube/api/rs/checks/job/TeamManageJob.java
+++ b/api/src/main/java/org/terrakube/api/rs/checks/job/TeamManageJob.java
@@ -1,0 +1,49 @@
+package org.terrakube.api.rs.checks.job;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.terrakube.api.plugin.security.groups.GroupService;
+import org.terrakube.api.plugin.security.user.AuthenticatedUser;
+import org.terrakube.api.rs.job.Job;
+import org.terrakube.api.rs.team.Team;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamManageJob.RULE)
+public class TeamManageJob extends OperationCheck<Job> {
+    public static final String RULE = "team manage job";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    GroupService groupService;
+
+    @Override
+    public boolean ok(Job job, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.info("team manage job {}", job.getId());
+        List<Team> teamList = job.getOrganization().getTeam();
+        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
+        boolean isWorkspaceLock = job.getWorkspace().isLocked();
+        if(isWorkspaceLock){
+            log.warn("Workspace {} {} is locked, job creation is denied", job.getWorkspace().getId(), job.getWorkspace().getName());
+        }
+        for (Team team : teamList) {
+            if (isServiceAccount){
+                if (groupService.isServiceMember(requestScope.getUser(), team.getName()) && team.isManageWorkspace() && !isWorkspaceLock ){
+                    return true;
+                }
+            } else {
+                if (groupService.isMember(requestScope.getUser(), team.getName()) && team.isManageWorkspace() && !isWorkspaceLock)
+                    return true;
+            }
+        }
+        return false;
+    }
+}

--- a/api/src/main/java/org/terrakube/api/rs/checks/job/TeamViewJob.java
+++ b/api/src/main/java/org/terrakube/api/rs/checks/job/TeamViewJob.java
@@ -1,0 +1,35 @@
+package org.terrakube.api.rs.checks.job;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.terrakube.api.plugin.security.user.AuthenticatedUser;
+import org.terrakube.api.rs.checks.membership.MembershipService;
+import org.terrakube.api.rs.job.Job;
+import org.terrakube.api.rs.team.Team;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamViewJob.RULE)
+public class TeamViewJob extends OperationCheck<Job> {
+    public static final String RULE = "team view job";
+
+    @Autowired
+    MembershipService membershipService;
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Override
+    public boolean ok(Job job, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.info("team view job {}", job.getId());
+        List<Team> teamList = job.getOrganization().getTeam();
+        return authenticatedUser.isSuperUser(requestScope.getUser()) ? true : membershipService.checkMembership(requestScope.getUser(), teamList);
+
+    }
+}

--- a/api/src/main/java/org/terrakube/api/rs/hooks/job/JobManageHook.java
+++ b/api/src/main/java/org/terrakube/api/rs/hooks/job/JobManageHook.java
@@ -7,9 +7,11 @@ import com.yahoo.elide.core.security.RequestScope;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.terrakube.api.plugin.scheduler.ScheduleJobService;
+import org.terrakube.api.repository.WorkspaceRepository;
 import org.terrakube.api.rs.job.Job;
 import org.terrakube.api.rs.job.JobStatus;
 import org.quartz.SchedulerException;
+import org.terrakube.api.rs.workspace.Workspace;
 
 import java.text.ParseException;
 import java.util.Optional;
@@ -20,6 +22,8 @@ public class JobManageHook implements LifeCycleHook<Job> {
 
     private ScheduleJobService scheduleJobService;
 
+    private WorkspaceRepository workspaceRepository;
+
     @Override
     public void execute(LifeCycleHookBinding.Operation operation, LifeCycleHookBinding.TransactionPhase transactionPhase, Job job, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.info("JobCreateHook {}", job.getId());
@@ -29,8 +33,12 @@ public class JobManageHook implements LifeCycleHook<Job> {
                     scheduleJobService.createJobContext(job);
                     break;
                 case UPDATE:
-                    if(job.getStatus().equals(JobStatus.cancelled))
+                    if(job.getStatus().equals(JobStatus.cancelled)) {
+                        Workspace workspace = workspaceRepository.getById(job.getWorkspace().getId());
+                        workspace.setLocked(false);
+                        workspaceRepository.save(workspace);
                         scheduleJobService.deleteJobContext(job.getId());
+                    }
                     break;
                 default:
                     log.info("Not supported {}", operation);

--- a/api/src/main/java/org/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/org/terrakube/api/rs/job/Job.java
@@ -1,9 +1,6 @@
 package org.terrakube.api.rs.job;
 
-import com.yahoo.elide.annotation.CreatePermission;
-import com.yahoo.elide.annotation.Include;
-import com.yahoo.elide.annotation.LifeCycleHookBinding;
-import com.yahoo.elide.annotation.UpdatePermission;
+import com.yahoo.elide.annotation.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.terrakube.api.plugin.security.audit.GenericAuditFields;
@@ -17,6 +14,9 @@ import java.util.List;
 
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.CREATE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = JobManageHook.class)
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.UPDATE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = JobManageHook.class)
+@ReadPermission(expression = "team view job")
+@CreatePermission(expression = "team manage job")
+@UpdatePermission(expression = "team manage job OR user is a super service")
 @Include(rootLevel = false)
 @Getter
 @Setter

--- a/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
@@ -47,6 +47,9 @@ public class Workspace {
     @Column(name = "folder")
     private String folder;
 
+    @Column(name = "locked")
+    private boolean locked;
+
     @Column(name = "terraform_version")
     private String terraformVersion;
 

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -24,4 +24,5 @@
     <include file="/db/changelog/local/changelog-2.6.0-pat.xml"/>
     <include file="/db/changelog/local/changelog-2.6.0-ssh.xml"/>
     <include file="/db/changelog/local/changelog-2.6.0-workspace-folder.xml"/>
+    <include file="/db/changelog/local/changelog-2.6.0-workspace-lock.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.6.0-workspace-lock.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.6.0-workspace-lock.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="16" author="alfespa17@gmail.com">
+        <addColumn tableName="workspace" >
+            <column name="locked" type="boolean" defaultValueBoolean="false"/>
+        </addColumn>
+        <update tableName="workspace">
+            <column name="locked" valueBoolean="false"/>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/test/java/org/terrakube/api/JobTests.java
+++ b/api/src/test/java/org/terrakube/api/JobTests.java
@@ -4,11 +4,18 @@ import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
+import org.terrakube.api.rs.job.Job;
+import org.terrakube.api.rs.workspace.Workspace;
+
+import java.util.List;
+import java.util.UUID;
+
 import static io.restassured.RestAssured.given;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
-class JobTests extends ServerApplicationTests{
+class JobTests extends ServerApplicationTests {
 
     @Test
     void createJobAsOrgMember() {
@@ -21,6 +28,63 @@ class JobTests extends ServerApplicationTests{
                 response().withStatusCode(HttpStatus.ACCEPTED.value()).withBody("")
         );
 
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"job\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"templateReference\": \"2db36f7c-f549-4341-a789-315d47eb061d\"\n" +
+                        "    },\n" +
+                        "    \"relationships\":{\n" +
+                        "        \"workspace\":{\n" +
+                        "            \"data\":{\n" +
+                        "                \"type\": \"workspace\",\n" +
+                        "                \"id\": \"5ed411ca-7ab8-4d2f-b591-02d0d5788afc\"\n" +
+                        "            }\n" +
+                        "        }\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/job/")
+                .then()
+                .assertThat()
+                .body("data.attributes.templateReference", IsEqual.equalTo("2db36f7c-f549-4341-a789-315d47eb061d"))
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    void createJobLockedWorkspace() {
+        mockServer.reset();
+        mockServer.when(
+                request()
+                        .withMethod(HttpMethod.POST.name())
+                        .withPath("/api/v1/terraform-rs")
+        ).respond(
+                response().withStatusCode(HttpStatus.ACCEPTED.value()).withBody("")
+        );
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"workspace\",\n" +
+                        "    \"id\": \"5ed411ca-7ab8-4d2f-b591-02d0d5788afc\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"locked\": \"true\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .patch("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/workspace/5ed411ca-7ab8-4d2f-b591-02d0d5788afc")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
 
         given()
                 .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
@@ -44,10 +108,28 @@ class JobTests extends ServerApplicationTests{
                 .post("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/job")
                 .then()
                 .assertThat()
-                .body("data.attributes.templateReference", IsEqual.equalTo("2db36f7c-f549-4341-a789-315d47eb061d"))
                 .log()
                 .all()
-                .statusCode(HttpStatus.CREATED.value());
+                .statusCode(HttpStatus.FORBIDDEN.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"workspace\",\n" +
+                        "    \"id\": \"5ed411ca-7ab8-4d2f-b591-02d0d5788afc\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"locked\": \"false\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .patch("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/workspace/5ed411ca-7ab8-4d2f-b591-02d0d5788afc")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
     }
 
 }

--- a/api/src/test/java/org/terrakube/api/ServerApplicationTests.java
+++ b/api/src/test/java/org/terrakube/api/ServerApplicationTests.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.mockserver.integration.ClientAndServer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;

--- a/thunder-tests/thunderclient.json
+++ b/thunder-tests/thunderclient.json
@@ -393,7 +393,7 @@
     "method": "POST",
     "sortNum": 150000,
     "created": "2022-07-22T21:25:36.084Z",
-    "modified": "2022-07-22T23:35:43.811Z",
+    "modified": "2022-08-15T20:36:26.776Z",
     "headers": [
       {
         "name": "Content-Type",
@@ -403,7 +403,7 @@
     "params": [],
     "body": {
       "type": "json",
-      "raw": "{\n  \"data\": {\n    \"type\": \"schedule\",\n    \"attributes\": {\n      \"cron\": \"0 0/30 * * * ?\",\n      \"templateReference\": \"{{template_plan_apply_id}}\"\n    }\n  }\n}",
+      "raw": "{\n  \"data\": {\n    \"type\": \"schedule\",\n    \"attributes\": {\n      \"cron\": \"0 * * ? * *\",\n      \"templateReference\": \"{{template_plan_apply_id}}\"\n    }\n  }\n}",
       "form": []
     },
     "auth": {
@@ -502,7 +502,7 @@
     "method": "POST",
     "sortNum": 190000,
     "created": "2022-07-22T21:25:36.088Z",
-    "modified": "2022-07-22T23:31:33.226Z",
+    "modified": "2022-08-15T22:58:35.385Z",
     "headers": [
       {
         "name": "Content-Type",
@@ -512,7 +512,7 @@
     "params": [],
     "body": {
       "type": "json",
-      "raw": "{\n  \"data\": {\n    \"type\": \"workspace\",\n    \"attributes\": {\n      \"name\": \"Docker Compose Sample\",\n      \"source\": \"https://github.com/AzBuilder/terrakube-docker-compose.git\",\n      \"branch\": \"main\",\n      \"terraformVersion\": \"1.0.11\"\n    }\n  }\n}",
+      "raw": "{\n  \"data\": {\n    \"type\": \"workspace\",\n    \"attributes\": {\n      \"name\": \"Docker Compose Sample\",\n      \"source\": \"https://github.com/AzBuilder/terrakube-docker-compose.git\",\n      \"branch\": \"main\",\n      \"folder\": \"/\",\n      \"locked\": \"true\",\n      \"terraformVersion\": \"1.0.11\"\n    }\n  }\n}",
       "form": []
     },
     "auth": {
@@ -2118,6 +2118,41 @@
         "custom": "json.data.id",
         "action": "setto",
         "value": "{{sshId}}"
+      }
+    ]
+  },
+  {
+    "_id": "3fe44be5-1a25-4b7b-8f82-60b1f3cdd2e4",
+    "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
+    "containerId": "1e847596-c3bf-42d4-90d4-26e522a90d0d",
+    "name": "update workspace",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/workspace/{{workspaceId}}",
+    "method": "PATCH",
+    "sortNum": 195000,
+    "created": "2022-08-15T20:38:10.125Z",
+    "modified": "2022-08-15T20:46:09.677Z",
+    "headers": [
+      {
+        "name": "Content-Type",
+        "value": "application/vnd.api+json"
+      }
+    ],
+    "params": [],
+    "body": {
+      "type": "json",
+      "raw": "{\n  \"data\": {\n    \"type\": \"workspace\",\n    \"id\": \"{{workspaceId}}\",\n    \"attributes\": {\n      \"locked\": \"true\"\n    }\n  }\n}",
+      "form": []
+    },
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": [
+      {
+        "type": "set-env-var",
+        "custom": "json.data.id",
+        "action": "setto",
+        "value": "{{workspaceId}}"
       }
     ]
   }

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -18,6 +18,7 @@ import {
   Select,
   message,
   Spin,
+  Switch
 } from "antd";
 import { compareVersions } from "./Workspaces";
 import { CreateJob } from "../Jobs/Create";
@@ -32,6 +33,7 @@ import {
   SyncOutlined,
   ExclamationCircleOutlined,
   StopOutlined,
+  InfoCircleOutlined
 } from "@ant-design/icons";
 import "./Workspaces.css";
 const { TabPane } = Tabs;
@@ -179,6 +181,7 @@ export const WorkspaceDetails = (props) => {
           name: values.name,
           description: values.description,
           folder: values.folder,
+          locked: values.locked,
           terraformVersion: values.terraformVersion,
         },
       },
@@ -340,7 +343,8 @@ export const WorkspaceDetails = (props) => {
                         initialValues={{
                           name: workspace.data.attributes.name,
                           description: workspace.data.attributes.description,
-                          folder: workspace.data.attributes.folder
+                          folder: workspace.data.attributes.folder,
+                          locked: workspace.data.attributes.locked
 
                         }}
                         layout="vertical"
@@ -365,6 +369,9 @@ export const WorkspaceDetails = (props) => {
                           label="Workspace Repository Folder"
                         >
                           <Input />
+                        </Form.Item>
+                        <Form.Item name="locked" valuePropName="checked" label="Lock Workspace" tooltip={{ title: 'Lock Workspace', icon: <InfoCircleOutlined /> }} >
+                          <Switch />
                         </Form.Item>
                         <Form.Item
                           name="terraformVersion"


### PR DESCRIPTION
Add new option to lock/unlocked workspace inside organizations

```
POST {{terrakubeApi}}/api/v1/organization/{{organizationId}}/workspace

{
  "data": {
    "type": "workspace",
    "attributes": {
      "name": "Docker Compose Sample",
      "source": "https://github.com/AzBuilder/terrakube-docker-compose.git",
      "branch": "main",
      "folder": "/",
      "locked": "true",
      "terraformVersion": "1.0.11"
    }
  }
}
```

Add option to lock/unlock in workspace settings. 

![image](https://user-images.githubusercontent.com/4461895/184761351-07c9f579-073d-464f-82e0-84cf98accec5.png)

If a workspace is using "locked=true" all new jobs will return 403 when doing the request

```
POST {{terrakubeApi}}/api/v1/organization/{{organizationId}}/job
```

Fixes #209  #184 