### PR TITLE
Update length for team name

### DIFF
--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -25,4 +25,5 @@
     <include file="/db/changelog/local/changelog-2.6.0-ssh.xml"/>
     <include file="/db/changelog/local/changelog-2.6.0-workspace-folder.xml"/>
     <include file="/db/changelog/local/changelog-2.6.0-workspace-lock.xml"/>
+    <include file="/db/changelog/local/changelog-2.6.0-team-update.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.6.0-team-update.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.6.0-team-update.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="18" author="alfespa17@gmail.com">
+        <modifyDataType
+           columnName="name"
+           newDataType="varchar(64)"
+           tableName="team"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
When using Google Identity the groups name include the @domain and the name sometimes can be quite long