### PR TITLE
Improve error handling for Terraform Operations (Plan/Apply/Destroy)

### DIFF
--- a/executor/src/main/java/org/terrakube/executor/service/executor/ExecutorJobImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/executor/ExecutorJobImpl.java
@@ -61,15 +61,17 @@ public class ExecutorJobImpl implements ExecutorJob {
                 executionSuccess = scriptEngineService.execute(terraformJob, terraformJob.getCommandList(), workspaceFolder, output);
                 terraformResult.setOutputLog(scriptOutput.toString());
                 terraformResult.setOutputErrorLog(scriptErrorOutput.toString());
+                terraformResult.setSuccessfulExecution(executionSuccess);
                 break;
             default:
-                executionSuccess = false;
                 terraformResult = new ExecutorJobResult();
                 terraformResult.setOutputLog("Command Completed");
                 terraformResult.setOutputErrorLog("Command type not defined");
+                terraformResult.setSuccessfulExecution(false);
                 break;
         }
 
+        executionSuccess = terraformResult.isSuccessfulExecution();
         updateJobStatus.setCompletedStatus(executionSuccess, terraformJob, terraformResult.getOutputLog(), terraformResult.getOutputErrorLog(), terraformResult.getPlanFile());
 
         try {

--- a/executor/src/main/java/org/terrakube/executor/service/status/UpdateJobStatusImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/status/UpdateJobStatusImpl.java
@@ -42,7 +42,7 @@ public class UpdateJobStatusImpl implements UpdateJobStatus {
     @Override
     public void setCompletedStatus(boolean successful, TerraformJob terraformJob, String jobOutput, String jobErrorOutput, String jobPlan) {
         if (!executorFlagsProperties.isDisableAcknowledge()) {
-            updateStepStatus(terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), jobOutput, jobErrorOutput);
+            updateStepStatus(successful, terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), jobOutput, jobErrorOutput);
             if(!isJobCancelled(terraformJob))
                 updateJobStatus(successful, terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), jobOutput, jobErrorOutput, jobPlan);
         }
@@ -78,10 +78,10 @@ public class UpdateJobStatusImpl implements UpdateJobStatus {
         terrakubeClient.updateJob(jobRequest, job.getRelationships().getOrganization().getData().getId(), job.getId());
     }
 
-    private void updateStepStatus(String organizationId, String jobId, String stepId, String jobOutput, String jobErrorOutput) {
+    private void updateStepStatus(boolean status, String organizationId, String jobId, String stepId, String jobOutput, String jobErrorOutput) {
         StepAttributes stepAttributes = new StepAttributes();
         stepAttributes.setOutput(this.terraformOutput.save(organizationId, jobId, stepId, jobOutput, jobErrorOutput));
-        stepAttributes.setStatus("completed");
+        stepAttributes.setStatus(status ? "completed": "failed");
 
         Step step = new Step();
         step.setId(stepId);

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -73,11 +73,10 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
             scriptAfterSuccessPlan = executePostOperationScripts(terraformJob, workingDirectory, outputPlan, executionPlan);
 
-            result.setPlanFile(executionPlan ? terraformState.saveTerraformPlan(terraformJob.getOrganizationId(),
-                    terraformJob.getWorkspaceId(), terraformJob.getJobId(), terraformJob.getStepId(), workingDirectory)
-                    : "");
-
             result = generateJobResult(scriptAfterSuccessPlan, jobOutput.toString(), jobErrorOutput.toString());
+            result.setPlanFile(executionPlan ? terraformState.saveTerraformPlan(terraformJob.getOrganizationId(),
+            terraformJob.getWorkspaceId(), terraformJob.getJobId(), terraformJob.getStepId(), workingDirectory)
+            : "");
         } catch (IOException | ExecutionException | InterruptedException exception) {
             result = setError(exception);
         }

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -44,7 +44,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             Consumer<String> output = getStringConsumer(jobOutput);
             Consumer<String> errorOutput = getStringConsumer(jobErrorOutput);
             HashMap<String, String> terraformParameters = getWorkspaceParameters(terraformJob.getVariables());
-            HashMap<String, String> environmentVariables = getWorkspaceParameters(terraformJob.getEnvironmentVariables());
+            HashMap<String, String> environmentVariables = getWorkspaceParameters(
+                    terraformJob.getEnvironmentVariables());
             boolean execution = false;
             boolean scriptBeforeSuccess;
             boolean scriptAfterSuccess = false;
@@ -81,19 +82,29 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                         output,
                         errorOutput).get();
 
+            log.warn("Terraform plan Executed Successfully: {}", execution);
+            if (execution) {
+                if (terraformJob.getCommandList() != null) {
+                    scriptAfterSuccess = scriptEngineService.execute(
+                            terraformJob,
+                            terraformJob
+                                    .getCommandList()
+                                    .stream()
+                                    .filter(command -> command.isAfter())
+                                    .collect(Collectors.toCollection(LinkedList::new)),
+                            workingDirectory,
+                            output);
+                } else {
+                    scriptAfterSuccess = true;
+                }
+            } else {
+                scriptAfterSuccess = false;
+            }
 
-            if (execution && terraformJob.getCommandList() != null)
-                scriptAfterSuccess = scriptEngineService.execute(
-                        terraformJob,
-                        terraformJob
-                                .getCommandList()
-                                .stream()
-                                .filter(command -> command.isAfter())
-                                .collect(Collectors.toCollection(LinkedList::new)),
-                        workingDirectory,
-                        output);
-
-            result.setPlanFile(execution ? terraformState.saveTerraformPlan(terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), terraformJob.getJobId(), terraformJob.getStepId(), workingDirectory) : "");
+            log.warn("Job Execute Successfully {}", scriptAfterSuccess);
+            result.setPlanFile(execution ? terraformState.saveTerraformPlan(terraformJob.getOrganizationId(),
+                    terraformJob.getWorkspaceId(), terraformJob.getJobId(), terraformJob.getStepId(), workingDirectory)
+                    : "");
             result.setSuccessfulExecution(scriptAfterSuccess);
             result.setOutputLog(jobOutput.toString());
             result.setOutputErrorLog(jobErrorOutput.toString());
@@ -114,7 +125,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             Consumer<String> output = getStringConsumer(terraformOutput);
             Consumer<String> errorOutput = getStringConsumer(terraformErrorOutput);
             HashMap<String, String> terraformParameters = getWorkspaceParameters(terraformJob.getVariables());
-            HashMap<String, String> environmentVariables = getWorkspaceParameters(terraformJob.getEnvironmentVariables());
+            HashMap<String, String> environmentVariables = getWorkspaceParameters(
+                    terraformJob.getEnvironmentVariables());
             boolean execution = false;
             boolean scriptBeforeSuccess;
             boolean scriptAfterSuccess = false;
@@ -146,7 +158,9 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                         terraformJob.getTerraformVersion(),
                         workingDirectory,
                         backendFile,
-                        (terraformState.downloadTerraformPlan(terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), terraformJob.getJobId(), terraformJob.getStepId(), workingDirectory) ? new HashMap<>() : terraformParameters),
+                        (terraformState.downloadTerraformPlan(terraformJob.getOrganizationId(),
+                                terraformJob.getWorkspaceId(), terraformJob.getJobId(), terraformJob.getStepId(),
+                                workingDirectory) ? new HashMap<>() : terraformParameters),
                         environmentVariables,
                         output,
                         errorOutput).get();
@@ -155,18 +169,26 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
             }
 
+            log.warn("Terraform apply Executed Successfully: {}", execution);
+            if (execution) {
+                if (terraformJob.getCommandList() != null) {
+                    scriptAfterSuccess = scriptEngineService.execute(
+                            terraformJob,
+                            terraformJob
+                                    .getCommandList()
+                                    .stream()
+                                    .filter(command -> command.isAfter())
+                                    .collect(Collectors.toCollection(LinkedList::new)),
+                            workingDirectory,
+                            output);
+                } else {
+                    scriptAfterSuccess = true;
+                }
+            } else {
+                scriptAfterSuccess = false;
+            }
 
-            if (execution && terraformJob.getCommandList() != null)
-                scriptAfterSuccess = scriptEngineService.execute(
-                        terraformJob,
-                        terraformJob
-                                .getCommandList()
-                                .stream()
-                                .filter(command -> command.isAfter())
-                                .collect(Collectors.toCollection(LinkedList::new)),
-                        workingDirectory,
-                        output);
-
+            log.warn("Job Execute Successfully {}", scriptAfterSuccess);
             result.setSuccessfulExecution(scriptAfterSuccess);
             result.setOutputLog(terraformOutput.toString());
             result.setOutputErrorLog(terraformErrorOutput.toString());
@@ -186,7 +208,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             Consumer<String> output = getStringConsumer(jobOutput);
             Consumer<String> errorOutput = getStringConsumer(jobErrorOutput);
             HashMap<String, String> terraformParameters = getWorkspaceParameters(terraformJob.getVariables());
-            HashMap<String, String> environmentVariables = getWorkspaceParameters(terraformJob.getEnvironmentVariables());
+            HashMap<String, String> environmentVariables = getWorkspaceParameters(
+                    terraformJob.getEnvironmentVariables());
             boolean execution = false;
             boolean scriptBeforeSuccess;
             boolean scriptAfterSuccess = false;
@@ -226,17 +249,26 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                 handleTerraformStateChange(terraformJob, workingDirectory);
             }
 
-            if (execution && terraformJob.getCommandList() != null)
-                scriptAfterSuccess = scriptEngineService.execute(
-                        terraformJob,
-                        terraformJob
-                                .getCommandList()
-                                .stream()
-                                .filter(command -> command.isAfter())
-                                .collect(Collectors.toCollection(LinkedList::new)),
-                        workingDirectory,
-                        output);
+            log.warn("Terraform destroy Executed Successfully: {}", execution);
+            if (execution) {
+                if (terraformJob.getCommandList() != null) {
+                    scriptAfterSuccess = scriptEngineService.execute(
+                            terraformJob,
+                            terraformJob
+                                    .getCommandList()
+                                    .stream()
+                                    .filter(command -> command.isAfter())
+                                    .collect(Collectors.toCollection(LinkedList::new)),
+                            workingDirectory,
+                            output);
+                } else {
+                    scriptAfterSuccess = true;
+                }
+            } else {
+                scriptAfterSuccess = false;
+            }
 
+            log.warn("Job Execute Successfully {}", scriptAfterSuccess);
             result.setSuccessfulExecution(scriptAfterSuccess);
             result.setOutputLog(jobOutput.toString());
             result.setOutputErrorLog(jobErrorOutput.toString());
@@ -246,11 +278,13 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         return result;
     }
 
-    private void handleTerraformStateChange(TerraformJob terraformJob, File workingDirectory) throws IOException, ExecutionException, InterruptedException {
+    private void handleTerraformStateChange(TerraformJob terraformJob, File workingDirectory)
+            throws IOException, ExecutionException, InterruptedException {
         log.info("Running Terraform show");
         TextStringBuilder jsonState = new TextStringBuilder();
         Consumer<String> applyJSON = getStringConsumer(jsonState);
-        if (terraformClient.show(terraformJob.getTerraformVersion(), workingDirectory, null, applyJSON, applyJSON).get()) {
+        if (terraformClient.show(terraformJob.getTerraformVersion(), workingDirectory, null, applyJSON, applyJSON)
+                .get()) {
             log.info("Uploading terraform state json");
             terraformState.saveStateJson(terraformJob, jsonState.toString());
 
@@ -258,7 +292,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             Consumer<String> terraformJsonOutput = getStringConsumer(jsonOutput);
 
             log.info("Checking terraform output json");
-            if (terraformClient.output(terraformJob.getTerraformVersion(), workingDirectory, terraformJsonOutput, terraformJsonOutput).get())
+            if (terraformClient.output(terraformJob.getTerraformVersion(), workingDirectory, terraformJsonOutput,
+                    terraformJsonOutput).get())
                 terraformJob.setTerraformOutput(jsonOutput.toString());
         }
     }
@@ -294,14 +329,16 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         return error;
     }
 
-
-    private String executeTerraformInit(TerraformJob terraformJob, File workingDirectory, Consumer<String> output, Consumer<String> errorOutput) throws IOException, ExecutionException, InterruptedException {
+    private String executeTerraformInit(TerraformJob terraformJob, File workingDirectory, Consumer<String> output,
+            Consumer<String> errorOutput) throws IOException, ExecutionException, InterruptedException {
 
         initBanner(terraformJob, output);
 
-        String backendFile = terraformState.getBackendStateFile(terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), workingDirectory);
+        String backendFile = terraformState.getBackendStateFile(terraformJob.getOrganizationId(),
+                terraformJob.getWorkspaceId(), workingDirectory);
 
-        terraformClient.init(terraformJob.getTerraformVersion(), workingDirectory, backendFile, output, errorOutput).get();
+        terraformClient.init(terraformJob.getTerraformVersion(), workingDirectory, backendFile, output, errorOutput)
+                .get();
         return backendFile;
     }
 
@@ -320,7 +357,9 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
     private void initBanner(TerraformJob terraformJob, Consumer<String> output) {
         AnsiFormat colorMessage = new AnsiFormat(GREEN_TEXT(), BLACK_BACK(), BOLD());
         output.accept(colorize(STEP_SEPARATOR, colorMessage));
-        output.accept(colorize("Initializing Terrakube Job " + terraformJob.getJobId() + " Step " + terraformJob.getStepId(), colorMessage));
+        output.accept(
+                colorize("Initializing Terrakube Job " + terraformJob.getJobId() + " Step " + terraformJob.getStepId(),
+                        colorMessage));
         output.accept(colorize("Running Terraform " + terraformJob.getTerraformVersion(), colorMessage));
         output.accept(colorize("\n\n" + STEP_SEPARATOR, colorMessage));
         output.accept(colorize("Running Terraform Init: ", colorMessage));

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -46,8 +46,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             HashMap<String, String> terraformParameters = getWorkspaceParameters(terraformJob.getVariables());
             HashMap<String, String> environmentVariables = getWorkspaceParameters(terraformJob.getEnvironmentVariables());
             boolean execution = false;
-            boolean scriptBeforeSuccess = true;
-            boolean scriptAfterSuccess = true;
+            boolean scriptBeforeSuccess;
+            boolean scriptAfterSuccess = false;
 
             String backendFile = executeTerraformInit(
                     terraformJob,
@@ -65,6 +65,10 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                                 .collect(Collectors.toCollection(LinkedList::new)),
                         workingDirectory,
                         output);
+            else {
+                log.warn("No commands to run before plan Job {}", terraformJob.getJobId());
+                scriptBeforeSuccess = true;
+            }
 
             showTerraformMessage("PLAN", output);
             if (scriptBeforeSuccess)
@@ -77,6 +81,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                         output,
                         errorOutput).get();
 
+
             if (execution && terraformJob.getCommandList() != null)
                 scriptAfterSuccess = scriptEngineService.execute(
                         terraformJob,
@@ -88,7 +93,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                         workingDirectory,
                         output);
 
-            result.setPlanFile(execution ? terraformState.saveTerraformPlan(terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), terraformJob.getJobId(), terraformJob.getStepId(), workingDirectory):"");
+            result.setPlanFile(execution ? terraformState.saveTerraformPlan(terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), terraformJob.getJobId(), terraformJob.getStepId(), workingDirectory) : "");
             result.setSuccessfulExecution(scriptAfterSuccess);
             result.setOutputLog(jobOutput.toString());
             result.setOutputErrorLog(jobErrorOutput.toString());
@@ -111,8 +116,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             HashMap<String, String> terraformParameters = getWorkspaceParameters(terraformJob.getVariables());
             HashMap<String, String> environmentVariables = getWorkspaceParameters(terraformJob.getEnvironmentVariables());
             boolean execution = false;
-            boolean scriptBeforeSuccess = true;
-            boolean scriptAfterSuccess = true;
+            boolean scriptBeforeSuccess;
+            boolean scriptAfterSuccess = false;
 
             String backendFile = executeTerraformInit(
                     terraformJob,
@@ -130,6 +135,10 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                                 .collect(Collectors.toCollection(LinkedList::new)),
                         workingDirectory,
                         output);
+            else {
+                log.warn("No commands to run before apply Job {}", terraformJob.getJobId());
+                scriptBeforeSuccess = true;
+            }
 
             showTerraformMessage("APPLY", output);
             if (scriptBeforeSuccess) {
@@ -179,8 +188,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             HashMap<String, String> terraformParameters = getWorkspaceParameters(terraformJob.getVariables());
             HashMap<String, String> environmentVariables = getWorkspaceParameters(terraformJob.getEnvironmentVariables());
             boolean execution = false;
-            boolean scriptBeforeSuccess = true;
-            boolean scriptAfterSuccess = true;
+            boolean scriptBeforeSuccess;
+            boolean scriptAfterSuccess = false;
 
             String backendFile = executeTerraformInit(
                     terraformJob,
@@ -198,6 +207,10 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                                 .collect(Collectors.toCollection(LinkedList::new)),
                         workingDirectory,
                         output);
+            else {
+                log.warn("No commands to run before destroy Job {}", terraformJob.getJobId());
+                scriptBeforeSuccess = true;
+            }
 
             showTerraformMessage("DESTROY", output);
             if (scriptBeforeSuccess) {

--- a/ui/src/domain/Jobs/Details.jsx
+++ b/ui/src/domain/Jobs/Details.jsx
@@ -83,6 +83,13 @@ export const DetailsJob = ({ jobId }) => {
         return (
           <SyncOutlined spin style={{ color: "#108ee9", fontSize: "20px" }} />
         );
+      case "failed":
+          return (
+            <CloseCircleTwoTone
+              twoToneColor="#FB0136"
+              style={{ fontSize: "20px" }}
+            />
+          );
       case "cancelled":
         return (
           <CloseCircleTwoTone
@@ -201,6 +208,8 @@ export const DetailsJob = ({ jobId }) => {
                   <ExclamationCircleOutlined />
                 ) : job.data.attributes.status === "cancelled" ? (
                   <StopOutlined />
+                ) : job.data.attributes.status === "failed" ? (
+                    <StopOutlined />
                 ) : (
                   <ClockCircleOutlined />
                 )
@@ -213,6 +222,8 @@ export const DetailsJob = ({ jobId }) => {
                   : job.data.attributes.status == "waitingApproval"
                   ? "#fa8f37"
                   : job.data.attributes.status == "rejected"
+                  ? "#FB0136"
+                  : job.data.attributes.status == "failed"
                   ? "#FB0136"
                   : ""
               }

--- a/ui/src/domain/Organizations/Details.jsx
+++ b/ui/src/domain/Organizations/Details.jsx
@@ -159,6 +159,8 @@ export const OrganizationDetails = ({
                               <CloseCircleOutlined />
                             ) : item.lastStatus === "cancelled" ? (
                               <StopOutlined />
+                            ) : item.lastStatus === "failed" ? (
+                              <StopOutlined />
                             ) : (
                               <ClockCircleOutlined />
                             )
@@ -236,6 +238,8 @@ function setupOrganizationIncludes(includes, setWorkspaces) {
               : lastStatus == "waitingApproval"
               ? "#fa8f37"
               : lastStatus === "rejected"
+              ? "#FB0136"
+              : lastStatus === "failed"
               ? "#FB0136"
               : "",
           ...element.attributes,

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -253,6 +253,8 @@ export const WorkspaceDetails = (props) => {
                                       <ExclamationCircleOutlined />
                                     ) : item.status === "cancelled" ? (
                                       <StopOutlined />
+                                    ) : item.status === "failed" ? (
+                                      <StopOutlined />
                                     ) : (
                                       <ClockCircleOutlined />
                                     )
@@ -426,6 +428,9 @@ function setupWorkspaceIncludes(
           case "rejected":
             finalColor = "#FB0136";
             break;
+          case "failed":
+              finalColor = "#FB0136";
+              break;
           case "running":
             finalColor = "#108ee9";
             break;


### PR DESCRIPTION
Correctly show when a terraform operation failed in the UI and stop flow execution when an error is detected when running the Terrakube Configuration Language flow

![image](https://user-images.githubusercontent.com/4461895/188191137-881bf268-3112-4fc2-b5ca-c4048962577e.png)
