### PR TITLE
Fix build setup to allow custom CA certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,10 @@ scripts/setup/minio/docker-compose.yaml
 .envRegistry
 .envUi
 GITPOD.md
+
+terrakubeDemo1.key
+terrakubeDemo2.key
+terrakubeDemo1.crt
+terrakubeDemo2.crt
+bindings/ca-certificates/terrakubeDemo1.pem
+bindings/ca-certificates/terrakubeDemo2.pem

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -50,7 +50,9 @@ tasks:
   - name: Setup Development Environment
     init: |
       chmod +x scripts/setupDevelopmentEnvironment.sh &&
-      chmod +x scripts/setupDevelopmentEnvironmentMinio.sh
+      chmod +x scripts/setupDevelopmentEnvironmentMinio.sh &&
+      chmod +x scripts/build/terrakubeBuild.sh &&
+      chmod +x scripts/build/generateSampleCaCerts.sh 
     command: scripts/setupDevelopmentEnvironment.sh
 
   - name: Dex Authentication Url

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -39,6 +39,28 @@
         <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}
         </sonar.coverage.jacoco.xmlReportPaths>
     </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                <image>
+                    <bindings>
+                        <binding>${basedir}/../bindings/ca-certificates:/platform/bindings/ca-certificates</binding>
+                    </bindings>
+                </image>
+            </configuration>
+            <executions>
+                    <execution>
+                        <goals>
+                            <goal>build-image</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/bindings/ca-certificates/type
+++ b/bindings/ca-certificates/type
@@ -1,0 +1,1 @@
+ca-certificates

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -34,7 +34,6 @@
 		<sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}
 		</sonar.coverage.jacoco.xmlReportPaths>
 	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -183,7 +182,19 @@
 							<artifactId>lombok</artifactId>
 						</exclude>
 					</excludes>
+					<image>
+						<bindings>
+							<binding>${basedir}/../bindings/ca-certificates:/platform/bindings/ca-certificates</binding>
+						</bindings>
+					</image>
 				</configuration>
+				<executions>
+                    <execution>
+                        <goals>
+                            <goal>build-image</goal>
+                        </goals>
+                    </execution>
+                </executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.11</version>
+        <version>2.6.12</version>
     </parent>
 
     <groupId>org.terrakube</groupId>
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>2.7.0</revision>
+        <revision>2.7.1</revision>
         <sonar.organization>azbuilder</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.project.key>AzBuilder_azb-server</sonar.project.key>

--- a/registry/pom.xml
+++ b/registry/pom.xml
@@ -30,6 +30,28 @@
 		<gcp-libraries-bom.version>25.4.0</gcp-libraries-bom.version>
 		<sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
 	</properties>
+	<build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                <image>
+                    <bindings>
+                        <binding>${basedir}/../bindings/ca-certificates:/platform/bindings/ca-certificates</binding>
+                    </bindings>
+                </image>
+            </configuration>
+            <executions>
+                    <execution>
+                        <goals>
+                            <goal>build-image</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/scripts/build/generateSampleCaCerts.sh
+++ b/scripts/build/generateSampleCaCerts.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+rm terrakubeDemo1.key
+rm terrakubeDemo2.key
+rm terrakubeDemo1.crt
+rm terrakubeDemo2.crt
+rm bindings/ca-certificates/terrakubeDemo1.PEM
+rm bindings/ca-certificates/terrakubeDemo1.PEM
+
+openssl req -x509 -sha256 -days 30 -nodes -newkey rsa:2048 -subj "/CN=demo.terrakube1.com/C=SV/L=San Salvador" -keyout terrakubeDemo1.key -out terrakubeDemo1.crt
+openssl req -x509 -sha256 -days 30 -nodes -newkey rsa:2048 -subj "/CN=demo.terrakube2.com/C=SV/L=San Salvador" -keyout terrakubeDemo2.key -out terrakubeDemo2.crt
+
+openssl x509 -in terrakubeDemo1.crt -out bindings/ca-certificates/terrakubeDemo1.pem -outform PEM
+openssl x509 -in terrakubeDemo2.crt -out bindings/ca-certificates/terrakubeDemo2.pem -outform PEM

--- a/scripts/build/terrakubeBuild.sh
+++ b/scripts/build/terrakubeBuild.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 # Install Java Dependencies
 mvn clean install
 
@@ -18,11 +16,8 @@ docker run --user="root" --entrypoint launcher $(docker images executor -q) "apt
 docker commit --change='ENTRYPOINT ["/cnb/process/web"]' --change='USER cnb' $(docker ps -lq) executortemp
 
 # Setup docker tags
-docker tag $(docker images api-server -q) azbuilder/api-server:$VERSION
 docker tag $(docker images api-server -q) azbuilder/api-server:latest
-docker tag $(docker images open-registry -q) azbuilder/open-registry:$VERSION
 docker tag $(docker images open-registry -q) azbuilder/open-registry:latest
-docker tag $(docker images executortemp -q) azbuilder/executor:$VERSION
 docker tag $(docker images executortemp -q) azbuilder/executor:latest
 
 # Build Terrakube UI Image
@@ -35,5 +30,4 @@ yarn install
 docker build -t terrakube-ui:latest  . 
 
 # Setup tags for UI
-docker tag $(docker images terrakube-ui -q) azbuilder/terrakube-ui:$VERSION
 docker tag $(docker images terrakube-ui -q) azbuilder/terrakube-ui:latest

--- a/scripts/build/terrakubeBuild.sh
+++ b/scripts/build/terrakubeBuild.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+# Install Java Dependencies
+mvn clean install
+
+# Update Terrakube Version
+mvn -pl "api,registry,executor" versions:set-property -Dproperty=revision -DnewVersion=$VERSION -DgenerateBackupPoms=false
+
+# Build Terrakube Images
+mvn -pl "api,registry,executor" spring-boot:build-image -B  --file pom.xml
+
+# Install other dependencies to use with Terrakube Extensions in terrakube executor creating a temporal image
+docker run --user="root" --entrypoint launcher $(docker images executor -q) "apt-get update && apt-get install git jq curl -y"
+
+# Rollback to original entry point
+docker commit --change='ENTRYPOINT ["/cnb/process/web"]' --change='USER cnb' $(docker ps -lq) executortemp
+
+# Setup docker tags
+docker tag $(docker images api-server -q) azbuilder/api-server:$VERSION
+docker tag $(docker images api-server -q) azbuilder/api-server:latest
+docker tag $(docker images open-registry -q) azbuilder/open-registry:$VERSION
+docker tag $(docker images open-registry -q) azbuilder/open-registry:latest
+docker tag $(docker images executortemp -q) azbuilder/executor:$VERSION
+docker tag $(docker images executortemp -q) azbuilder/executor:latest
+
+# Build Terrakube UI Image
+cd ui 
+
+# Install UI dependencies
+yarn install
+
+# Build docker image
+docker build -t terrakube-ui:latest  . 
+
+# Setup tags for UI
+docker tag $(docker images terrakube-ui -q) azbuilder/terrakube-ui:$VERSION
+docker tag $(docker images terrakube-ui -q) azbuilder/terrakube-ui:latest


### PR DESCRIPTION
## Include custom CA certificates

Fix POM configuration to allow adding custom CA certificates using the following folder  "bindings/ca-certificates". 

![image](https://user-images.githubusercontent.com/4461895/193379949-163ac034-884f-4949-8e48-033c9c2d81fb.png)

> Certificates should be in PEM format.

When running the build using the command "mvn spring-boot:build-image" the certificates are loaded inside the system trustore automatically

![image](https://user-images.githubusercontent.com/4461895/193380003-df972768-8fa9-48e5-ac96-5850831c1fba.png)

## Example Script

A script was added to generate some sample certificates in PEM format "./scripts/build/generateSampleCaCerts.sh" to test it

Once the certificates are added inside the ca-certificates folder we can use the "./scripts/build/terrakubeBuild.sh" to create the new images.

```bash
git clone https://github.com/AzBuilder/terrakube
cd terrakube
mv EXAMPLE.pem bindings/ca-certificates

# This script should be run from the root folder
./scripts/build/terrakubeBuild.sh
``` 
Reference: 
https://stackoverflow.com/questions/68720570/how-to-embed-ca-certificates-with-spring-bootbuild-image

## Dependency Update

Updating spring-boot version to 2.6.12

