### PR TITLE
Allow custom callback in VCS

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleVcs.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleVcs.java
@@ -40,7 +40,8 @@ public class ScheduleVcs implements org.quartz.Job {
                     vcs.getTokenExpiration(),
                     vcs.getClientId(),
                     vcs.getClientSecret(),
-                    vcs.getRefreshToken());
+                    vcs.getRefreshToken(),
+                    vcs.getCallback());
 
             if (!newTokenInformation.isEmpty()) {
                 Vcs tempVcs = vcsRepository.getById(vcs.getId());

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/GetAccessToken.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/GetAccessToken.java
@@ -4,5 +4,5 @@ import org.terrakube.api.plugin.vcs.provider.exception.TokenException;
 
 public interface GetAccessToken<T> {
 
-    T getAccessToken(String clientId, String clientSecret, String tempCode) throws TokenException;
+    T getAccessToken(String clientId, String clientSecret, String tempCode, String callback) throws TokenException;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsTokenService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsTokenService.java
@@ -16,13 +16,13 @@ public class AzDevOpsTokenService {
     @Value("${org.terrakube.hostname}")
     private String hostname;
 
-    public AzDevOpsToken getAccessToken(String vcsId, String clientSecret, String tempCode) throws TokenException {
+    public AzDevOpsToken getAccessToken(String vcsId, String clientSecret, String tempCode, String callback) throws TokenException {
         MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
         formData.add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
         formData.add("client_assertion", clientSecret);
         formData.add("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer");
         formData.add("assertion", tempCode);
-        formData.add("redirect_uri", String.format("https://%s/callback/v1/vcs/%s", hostname, vcsId));
+        formData.add("redirect_uri", String.format("https://%s/callback/v1/vcs/%s", hostname, callback == null ? vcsId: callback));
 
         AzDevOpsToken azDevOpsToken = getWebClient().post()
                 .uri("/oauth2/token")
@@ -34,13 +34,13 @@ public class AzDevOpsTokenService {
         return validateNewToken(azDevOpsToken);
     }
 
-    public AzDevOpsToken refreshAccessToken(String vcsId, String clientSecret, String refreshToken) throws TokenException {
+    public AzDevOpsToken refreshAccessToken(String vcsId, String clientSecret, String refreshToken, String callback) throws TokenException {
         MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
         formData.add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
         formData.add("client_assertion", clientSecret);
         formData.add("grant_type", "refresh_token");
         formData.add("assertion", refreshToken);
-        formData.add("redirect_uri", String.format("https://%s/callback/v1/vcs/%s", hostname, vcsId));
+        formData.add("redirect_uri", String.format("https://%s/callback/v1/vcs/%s", hostname, callback == null ? vcsId: callback));
 
         AzDevOpsToken azDevOpsToken  = getWebClient().post()
                 .uri("/oauth2/token")

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/bitbucket/BitbucketTokenService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/bitbucket/BitbucketTokenService.java
@@ -16,7 +16,7 @@ import java.time.Duration;
 public class BitbucketTokenService implements GetAccessToken<BitBucketToken> {
 
     @Override
-    public BitBucketToken getAccessToken(String clientId, String clientSecret, String tempCode) throws TokenException {
+    public BitBucketToken getAccessToken(String clientId, String clientSecret, String tempCode, String callback) throws TokenException {
         WebClient client = WebClient.builder()
                 .baseUrl("https://bitbucket.org")
                 .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubTokenService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubTokenService.java
@@ -9,7 +9,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
 public class GitHubTokenService implements GetAccessToken<GitHubToken> {
-    public GitHubToken getAccessToken(String clientId, String clientSecret, String tempCode) throws TokenException {
+    public GitHubToken getAccessToken(String clientId, String clientSecret, String tempCode, String callback) throws TokenException {
         WebClient client = WebClient.builder()
                 .baseUrl("https://github.com")
                 .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/gitlab/GitLabTokenService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/gitlab/GitLabTokenService.java
@@ -13,26 +13,26 @@ public class GitLabTokenService {
     @Value("${org.terrakube.hostname}")
     private String hostname;
 
-    public GitLabToken getAccessToken(String vcsId, String clientId, String clientSecret, String tempCode) throws TokenException {
+    public GitLabToken getAccessToken(String vcsId, String clientId, String clientSecret, String tempCode, String callback) throws TokenException {
         GitLabToken gitLabToken = getWebClient().post().uri(uriBuilder -> uriBuilder.path("/oauth/token")
                         .queryParam("client_id", clientId)
                         .queryParam("client_secret", clientSecret)
                         .queryParam("code",tempCode)
                         .queryParam("grant_type", "authorization_code")
-                        .queryParam("redirect_uri", String.format("https://%s/callback/v1/vcs/%s", hostname, vcsId))
+                        .queryParam("redirect_uri", String.format("https://%s/callback/v1/vcs/%s", hostname, callback == null ? vcsId: callback))
                         .build())
                 .retrieve().bodyToMono(GitLabToken.class).block();
 
         return validateNewToken(gitLabToken);
     }
 
-    public GitLabToken refreshAccessToken(String vcsId, String clientId, String clientSecret, String refreshToken) throws TokenException {
+    public GitLabToken refreshAccessToken(String vcsId, String clientId, String clientSecret, String refreshToken, String callback) throws TokenException {
         GitLabToken gitLabToken = getWebClient().post().uri(uriBuilder -> uriBuilder.path("/oauth/token")
                         .queryParam("client_id", clientId)
                         .queryParam("client_secret", clientSecret)
                         .queryParam("refresh_token", refreshToken)
                         .queryParam("grant_type", "refresh_token")
-                        .queryParam("redirect_uri", String.format("https://%s/callback/v1/vcs/%s", hostname, vcsId))
+                        .queryParam("redirect_uri", String.format("https://%s/callback/v1/vcs/%s", hostname, callback == null ? vcsId: callback))
                         .build())
                 .retrieve().bodyToMono(GitLabToken.class).block();
 

--- a/api/src/main/java/org/terrakube/api/repository/VcsRepository.java
+++ b/api/src/main/java/org/terrakube/api/repository/VcsRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
 public interface VcsRepository extends JpaRepository<Vcs, UUID> {
+
+    Vcs findByCallback(String callback);
 }

--- a/api/src/main/java/org/terrakube/api/rs/vcs/Vcs.java
+++ b/api/src/main/java/org/terrakube/api/rs/vcs/Vcs.java
@@ -40,6 +40,9 @@ public class Vcs extends GenericAuditFields {
     @Column(name = "client_id")
     private String clientId;
 
+    @Column(name = "callback")
+    private String callback;
+
     @ReadPermission(expression = "read vcs secret")
     @Column(name = "client_secret")
     private String clientSecret;

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -26,4 +26,5 @@
     <include file="/db/changelog/local/changelog-2.6.0-workspace-folder.xml"/>
     <include file="/db/changelog/local/changelog-2.6.0-workspace-lock.xml"/>
     <include file="/db/changelog/local/changelog-2.6.0-team-update.xml"/>
+    <include file="/db/changelog/local/changelog-2.8.0-vcs-callback.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.8.0-vcs-callback.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.8.0-vcs-callback.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="17" author="alfespa17@gmail.com">
+        <addColumn tableName="vcs" >
+            <column name="callback" type="varchar(36)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>2.7.1</revision>
+        <revision>2.8.0</revision>
         <sonar.organization>azbuilder</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.project.key>AzBuilder_azb-server</sonar.project.key>

--- a/scripts/template/thunder-tests/thunderEnvironment.json
+++ b/scripts/template/thunder-tests/thunderEnvironment.json
@@ -65,6 +65,54 @@
       {
         "name": "registryModuleVersion",
         "value": "v22.1.0"
+      },
+      {
+        "name": "githubClientId",
+        "value": ""
+      },
+      {
+        "name": "githubClientSecret",
+        "value": ""
+      },
+      {
+        "name": "githubCallback",
+        "value": "61c17182-f9dc-48c8-91d0-668f957a8941"
+      },
+      {
+        "name": "bitbucketClientId",
+        "value": ""
+      },
+      {
+        "name": "bitbucketClientSecret",
+        "value": ""
+      },
+      {
+        "name": "bitbucketCallback",
+        "value": "6350bbdd-4c4c-457a-a662-7c4a60bdb28a"
+      },
+      {
+        "name": "gitlabClientId",
+        "value": ""
+      },
+      {
+        "name": "gitlabClientSecret",
+        "value": ""
+      },
+      {
+        "name": "gitlabCallback",
+        "value": "254d9612-9bfa-4f0d-b712-00bc792a9789"
+      },
+      {
+        "name": "azdevopsClientId",
+        "value": ""
+      },
+      {
+        "name": "azdevopsClientSecret",
+        "value": ""
+      },
+      {
+        "name": "azdevopsCallback",
+        "value": "359f7079-74b2-4afc-9475-201e477d4648"
       }
     ]
   }

--- a/thunder-tests/thunderclient.json
+++ b/thunder-tests/thunderclient.json
@@ -8,7 +8,7 @@
     "method": "POST",
     "sortNum": 10000,
     "created": "2022-07-22T21:25:36.069Z",
-    "modified": "2022-08-07T15:55:46.567Z",
+    "modified": "2022-10-05T22:58:37.177Z",
     "headers": [
       {
         "name": "Content-Type",
@@ -18,7 +18,7 @@
     "params": [],
     "body": {
       "type": "json",
-      "raw": "{\n  \"data\": {\n    \"type\": \"organization\",\n    \"attributes\": {\n      \"name\": \"hashicorp\",\n      \"description\": \"hashicorp organization\"\n    }\n  }\n}",
+      "raw": "{\n  \"data\": {\n    \"type\": \"organization\",\n    \"attributes\": {\n      \"name\": \"hashicorp2\",\n      \"description\": \"hashicorp organization\"\n    }\n  }\n}",
       "form": []
     },
     "auth": {
@@ -1468,97 +1468,131 @@
     "_id": "156569f7-f8dc-4b3c-ac9e-ce30327290a4",
     "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
     "containerId": "f8b2bd0a-44ee-431d-8cfc-391c6d951a2b",
-    "name": "create vcs GitHub",
-    "url": "{{server}}/api/v1/organization/{{organizationId}}/vcs",
+    "name": "GitHub Custom Callback",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/vcs",
     "method": "POST",
     "sortNum": 510000,
     "created": "2022-07-22T21:25:36.120Z",
-    "modified": "2022-07-22T21:25:36.120Z",
+    "modified": "2022-10-05T21:56:42.189Z",
     "headers": [
       {
         "name": "Content-Type",
         "value": "application/vnd.api+json"
       }
     ],
+    "params": [],
     "body": {
       "type": "json",
-      "raw": "{\n  \"data\": {\n    \"type\": \"vcs\",\n    \"attributes\": {\n      \"name\": \"vcsGitHub\",\n      \"description\": \"vcsGitHubDescription\",\n      \"vcsType\": \"GITHUB\",\n      \"clientId\": \"{{githubClientId}}\",\n      \"clientSecret\": \"{{githubClientSecret}}\",\n      \"accessToken\": \"{{githubAccessToken}}\"\n    }\n  }\n}"
-    }
+      "raw": "{\n  \"data\": {\n    \"type\": \"vcs\",\n    \"attributes\": {\n      \"name\": \"vcsGitHubCustom\",\n      \"description\": \"vcsGitHubDescription\",\n      \"vcsType\": \"GITHUB\",\n      \"clientId\": \"{{githubClientId}}\",\n      \"clientSecret\": \"{{githubClientSecret}}\",\n      \"callback\": \"{{githubCallback}}\"\n    }\n  }\n}",
+      "form": []
+    },
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
   },
   {
     "_id": "33b6e9b9-502e-4ebf-886d-78ebb96489e4",
     "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
     "containerId": "f8b2bd0a-44ee-431d-8cfc-391c6d951a2b",
-    "name": "create vcs Bitbucket",
-    "url": "{{server}}/api/v1/organization/{{organizationId}}/vcs",
+    "name": "Bitbucket Custom Callback",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/vcs",
     "method": "POST",
     "sortNum": 520000,
     "created": "2022-07-22T21:25:36.121Z",
-    "modified": "2022-07-22T21:25:36.121Z",
+    "modified": "2022-10-05T23:02:50.987Z",
     "headers": [
       {
         "name": "Content-Type",
         "value": "application/vnd.api+json"
       }
     ],
+    "params": [],
     "body": {
       "type": "json",
-      "raw": "{\n  \"data\": {\n    \"type\": \"vcs\",\n    \"attributes\": {\n      \"name\": \"vcsBitbucket\",\n      \"description\": \"vcsDescription\",\n      \"vcsType\": \"BITBUCKET\",\n      \"clientId\": \"{{bitbucketClientId}}\",\n      \"clientSecret\": \"{{bitbucketSecret}}\"\n    }\n  }\n}"
-    }
+      "raw": "{\n  \"data\": {\n    \"type\": \"vcs\",\n    \"attributes\": {\n      \"name\": \"vcsBitbucketCustom\",\n      \"description\": \"vcsDescription\",\n      \"vcsType\": \"BITBUCKET\",\n      \"clientId\": \"{{bitbucketClientId}}\",\n      \"clientSecret\": \"{{bitbucketClientSecret}}\",\n      \"callback\": \"{{bitbuketCallback}}\"\n    }\n  }\n}",
+      "form": []
+    },
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
   },
   {
     "_id": "1cd4141d-ca34-42e9-ab3e-2a99d9653d95",
     "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
     "containerId": "f8b2bd0a-44ee-431d-8cfc-391c6d951a2b",
-    "name": "create vcs GitLab",
-    "url": "{{server}}/api/v1/organization/{{organizationId}}/vcs",
+    "name": "GitLab Default Callback",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/vcs",
     "method": "POST",
     "sortNum": 530000,
     "created": "2022-07-22T21:25:36.122Z",
-    "modified": "2022-07-22T21:25:36.122Z",
+    "modified": "2022-10-05T23:32:32.337Z",
     "headers": [
       {
         "name": "Content-Type",
         "value": "application/vnd.api+json"
       }
     ],
+    "params": [],
     "body": {
       "type": "json",
-      "raw": "{\n  \"data\": {\n    \"type\": \"vcs\",\n    \"attributes\": {\n      \"name\": \"vcsGitLab\",\n      \"description\": \"vcsDescription\",\n      \"vcsType\": \"GITLAB\",\n      \"clientId\": \"{{gitlabClientId}}\",\n      \"clientSecret\": \"{{gitlabSecretId}}\"\n    }\n  }\n}"
-    }
+      "raw": "{\n  \"data\": {\n    \"type\": \"vcs\",\n    \"attributes\": {\n      \"name\": \"vcsGitLab\",\n      \"description\": \"vcsDescription\",\n      \"vcsType\": \"GITLAB\",\n      \"clientId\": \"{{gitlabClientId}}\",\n      \"clientSecret\": \"{{gitlabClientSecret}}\"\n    }\n  }\n}",
+      "form": []
+    },
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
   },
   {
     "_id": "3fa5cd78-6b12-4364-9514-df4c9589e22c",
     "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
     "containerId": "f8b2bd0a-44ee-431d-8cfc-391c6d951a2b",
-    "name": "create vcs Azure DevOps",
-    "url": "{{server}}/api/v1/organization/{{organizationId}}/vcs",
+    "name": "Azure DevOps Default Callback",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/vcs",
     "method": "POST",
     "sortNum": 540000,
     "created": "2022-07-22T21:25:36.123Z",
-    "modified": "2022-07-22T21:25:36.123Z",
+    "modified": "2022-10-05T23:35:38.049Z",
     "headers": [
       {
         "name": "Content-Type",
         "value": "application/vnd.api+json"
       }
     ],
+    "params": [],
     "body": {
       "type": "json",
-      "raw": "{\n  \"data\": {\n    \"type\": \"vcs\",\n    \"attributes\": {\n      \"name\": \"vcsAzDevOps\",\n      \"description\": \"vcsDescription\",\n      \"vcsType\": \"AZURE_DEVOPS\",\n      \"clientId\": \"{{azDevOpsClientId}}\",\n      \"clientSecret\": \"{{azDevOpsClientSecret}}\"\n    }\n  }\n}"
-    }
+      "raw": "{\n  \"data\": {\n    \"type\": \"vcs\",\n    \"attributes\": {\n      \"name\": \"vcsAzDevOps\",\n      \"description\": \"vcsDescription\",\n      \"vcsType\": \"AZURE_DEVOPS\",\n      \"clientId\": \"{{azDevOpsClientId}}\",\n      \"clientSecret\": \"{{azDevOpsClientSecret}}\"\n    }\n  }\n}",
+      "form": []
+    },
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
   },
   {
     "_id": "8437eda1-5950-46e7-8a08-3f3384093b46",
     "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
     "containerId": "f8b2bd0a-44ee-431d-8cfc-391c6d951a2b",
     "name": "search vcs",
-    "url": "{{server}}/api/v1/organization/{{organizationId}}/vcs",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/vcs",
     "method": "GET",
     "sortNum": 550000,
     "created": "2022-07-22T21:25:36.124Z",
-    "modified": "2022-07-22T21:25:36.124Z",
-    "headers": []
+    "modified": "2022-10-05T21:44:50.394Z",
+    "headers": [],
+    "params": [],
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
   },
   {
     "_id": "72d76e5b-423f-46e2-a875-ec6f4eed82ae",
@@ -2173,6 +2207,118 @@
     "modified": "2022-08-18T17:30:09.212Z",
     "headers": [],
     "params": [],
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
+  },
+  {
+    "_id": "1e69c61c-3fc1-4c9e-881c-ca60eb8e076e",
+    "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
+    "containerId": "f8b2bd0a-44ee-431d-8cfc-391c6d951a2b",
+    "name": "GitHub Default Callback",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/vcs",
+    "method": "POST",
+    "sortNum": 515000,
+    "created": "2022-10-05T21:56:31.461Z",
+    "modified": "2022-10-05T21:56:36.992Z",
+    "headers": [
+      {
+        "name": "Content-Type",
+        "value": "application/vnd.api+json"
+      }
+    ],
+    "params": [],
+    "body": {
+      "type": "json",
+      "raw": "{\n  \"data\": {\n    \"type\": \"vcs\",\n    \"attributes\": {\n      \"name\": \"vcsGitHub\",\n      \"description\": \"vcsGitHubDescription\",\n      \"vcsType\": \"GITHUB\",\n      \"clientId\": \"{{githubClientId}}\",\n      \"clientSecret\": \"{{githubClientSecret}}\"\n    }\n  }\n}",
+      "form": []
+    },
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
+  },
+  {
+    "_id": "20751b5e-ead3-4762-8d1c-6fd850d69b76",
+    "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
+    "containerId": "f8b2bd0a-44ee-431d-8cfc-391c6d951a2b",
+    "name": "Bitbucket Default Callback",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/vcs",
+    "method": "POST",
+    "sortNum": 525000,
+    "created": "2022-10-05T23:02:40.182Z",
+    "modified": "2022-10-05T23:15:48.452Z",
+    "headers": [
+      {
+        "name": "Content-Type",
+        "value": "application/vnd.api+json"
+      }
+    ],
+    "params": [],
+    "body": {
+      "type": "json",
+      "raw": "{\n  \"data\": {\n    \"type\": \"vcs\",\n    \"attributes\": {\n      \"name\": \"vcsBitbucket\",\n      \"description\": \"vcsDescription\",\n      \"vcsType\": \"BITBUCKET\",\n      \"clientId\": \"{{bitbucketClientId}}\",\n      \"clientSecret\": \"{{bitbucketClientSecret}}\"\n    }\n  }\n}",
+      "form": []
+    },
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
+  },
+  {
+    "_id": "c1c7f8e7-14da-4a75-a212-9cc68d0320c6",
+    "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
+    "containerId": "f8b2bd0a-44ee-431d-8cfc-391c6d951a2b",
+    "name": "GitLab Custom Callback",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/vcs",
+    "method": "POST",
+    "sortNum": 535000,
+    "created": "2022-10-05T23:20:04.760Z",
+    "modified": "2022-10-05T23:30:30.107Z",
+    "headers": [
+      {
+        "name": "Content-Type",
+        "value": "application/vnd.api+json"
+      }
+    ],
+    "params": [],
+    "body": {
+      "type": "json",
+      "raw": "{\n  \"data\": {\n    \"type\": \"vcs\",\n    \"attributes\": {\n      \"name\": \"vcsGitLabCustom\",\n      \"description\": \"vcsDescription\",\n      \"vcsType\": \"GITLAB\",\n      \"clientId\": \"{{gitlabClientId}}\",\n      \"clientSecret\": \"{{gitlabClientSecret}}\",\n      \"callback\": \"{{gitlabCallback}}\"\n    }\n  }\n}",
+      "form": []
+    },
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
+  },
+  {
+    "_id": "fe3bed63-da62-478c-99be-c82f57692ac5",
+    "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
+    "containerId": "f8b2bd0a-44ee-431d-8cfc-391c6d951a2b",
+    "name": "Azure DevOps Default Callback Copy",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/vcs",
+    "method": "POST",
+    "sortNum": 545000,
+    "created": "2022-10-05T23:35:29.661Z",
+    "modified": "2022-10-05T23:35:29.661Z",
+    "headers": [
+      {
+        "name": "Content-Type",
+        "value": "application/vnd.api+json"
+      }
+    ],
+    "params": [],
+    "body": {
+      "type": "json",
+      "raw": "{\n  \"data\": {\n    \"type\": \"vcs\",\n    \"attributes\": {\n      \"name\": \"vcsAzDevOps\",\n      \"description\": \"vcsDescription\",\n      \"vcsType\": \"AZURE_DEVOPS\",\n      \"clientId\": \"{{azDevOpsClientId}}\",\n      \"clientSecret\": \"{{azDevOpsClientSecret}}\",\n      \"callback\": \"{{devopsCallback}}\"\n    }\n  }\n}",
+      "form": []
+    },
     "auth": {
       "type": "bearer",
       "bearer": "{{access_token}}"


### PR DESCRIPTION
Adding a new field inside VCS connections to allow a custom callback instead of using the VCS id, this will allow to define the callback from the UI when need it.

```
POST {{terrakubeApi}}/api/v1/organization/{{organizationId}}/vcs
{
  "data": {
    "type": "vcs",
    "attributes": {
      "name": "vcsGitHubCustom",
      "description": "vcsGitHubDescription",
      "vcsType": "GITHUB",
      "clientId": "{{githubClientId}}",
      "clientSecret": "{{githubClientSecret}}",
      "callback": "{{githubCallback}}"
    }
  }
}
```