### PR TITLE
Terraform Remote Backend Support (Destroy)

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -93,6 +93,7 @@ public class ScheduleJob implements org.quartz.Job {
             FlowType tempFlowType = FlowType.valueOf(flow.get().getType());
 
             switch (tempFlowType) {
+                case terraformPlanDestroy:
                 case terraformPlan:
                 case terraformApply:
                 case terraformDestroy:

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/FlowType.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/FlowType.java
@@ -2,6 +2,7 @@ package org.terrakube.api.plugin.scheduler.job.tcl.model;
 
 public enum FlowType {
     terraformPlan,
+    terraformPlanDestroy,
     terraformApply,
     terraformDestroy,
     customScripts,

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -62,7 +62,7 @@ public class RemoteTfeService {
                             ScheduleJobService scheduleJobService,
                             @Value("${org.terrakube.hostname}") String hostname,
                             StorageTypeService storageTypeService,
-                            StepRepository stepRepository){
+                            StepRepository stepRepository) {
         this.jobRepository = jobRepository;
         this.contentRepository = contentRepository;
         this.organizationRepository = organizationRepository;
@@ -319,13 +319,18 @@ public class RemoteTfeService {
     }
 
     RunsData createRun(RunsData runsData) throws SchedulerException, ParseException {
-        log.info("Creating new Terrakube Job");
-        log.info("Workspace {} Configuration {}", runsData.getData().getRelationships().getWorkspace().getData().getId(), runsData.getData().getRelationships().getConfigurationVersion().getData().getId());
         String workspaceId = runsData.getData().getRelationships().getWorkspace().getData().getId();
+        String configurationId = runsData.getData().getRelationships().getConfigurationVersion().getData().getId();
+        boolean isDestroy = (boolean) runsData.getData().getAttributes().get("is-destroy");
+        log.info("Creating new Terrakube Job");
+        log.info("Workspace {} Configuration {}",workspaceId, configurationId);
         Workspace workspace = workspaceRepository.getReferenceById(UUID.fromString(workspaceId));
-        workspace.setSource(String.format("https://%s/remote/tfe/v2/configuration-versions/%s/terraformContent.tar.gz", hostname, runsData.getData().getRelationships().getConfigurationVersion().getData().getId()));
+        workspace.setSource(String.format("https://%s/remote/tfe/v2/configuration-versions/%s/terraformContent.tar.gz", hostname, configurationId));
         workspace = workspaceRepository.save(workspace);
-        Template template = templateRepository.getByOrganizationNameAndName(workspace.getOrganization().getName(), getTemplateName(runsData.getData().getRelationships().getConfigurationVersion().getData().getId()));
+        Template template = templateRepository.getByOrganizationNameAndName(
+                workspace.getOrganization().getName(),
+                getTemplateName(configurationId, isDestroy)
+        );
         log.info("Creating Job");
         Job job = new Job();
         job.setWorkspace(workspace);
@@ -341,10 +346,12 @@ public class RemoteTfeService {
     }
 
 
-    private String getTemplateName(String configurationId){
-        // get run speculative if false get Terraform Plan/Apply else just Plan
+    private String getTemplateName(String configurationId, boolean isDestroy) {
+        // get run speculative if false get Terraform Plan/Apply else just Plan or destroy
         Content content = contentRepository.getReferenceById(UUID.fromString(configurationId));
-        if(content.isSpeculative()){
+        if (isDestroy) {
+            return "Terraform-Plan/Destroy-Cli";
+        } else if (content.isSpeculative()) {
             return "Terraform-Plan";
         } else {
             return "Terraform-Plan/Apply-Cli";
@@ -397,20 +404,20 @@ public class RemoteTfeService {
 
         runsModel.getAttributes().put("status", planStatus);
         runsModel.getAttributes().put("has-changes", true);
-            runsModel.getAttributes().put("resource-additions", 1);
-            runsModel.getAttributes().put("resource-changes", 1);
-            runsModel.getAttributes().put("resource-destructions", 0);
+        runsModel.getAttributes().put("resource-additions", 1);
+        runsModel.getAttributes().put("resource-changes", 1);
+        runsModel.getAttributes().put("resource-destructions", 0);
 
 
-            HashMap<String, Object> actions = new HashMap<>();
-            actions.put("is-confirmable", true);
-            actions.put("is-discardable", false);
-            runsModel.getAttributes().put("actions", actions);
+        HashMap<String, Object> actions = new HashMap<>();
+        actions.put("is-confirmable", true);
+        actions.put("is-discardable", false);
+        runsModel.getAttributes().put("actions", actions);
 
 
-            HashMap<String, Object> permissions = new HashMap<>();
-            permissions.put("can-apply", true);
-            runsModel.getAttributes().put("permissions", permissions);
+        HashMap<String, Object> permissions = new HashMap<>();
+        permissions.put("can-apply", true);
+        runsModel.getAttributes().put("permissions", permissions);
 
 
         runsData.setData(runsModel);
@@ -603,7 +610,7 @@ public class RemoteTfeService {
         Job job = jobRepository.getReferenceById(Integer.valueOf(planId));
         byte[] logs = "".getBytes();
         if (checkPlanLogStatus(planId).equals(LogStatus.BEGIN))
-            if (job.getStep() != null && !job.getStep().isEmpty()) 
+            if (job.getStep() != null && !job.getStep().isEmpty())
                 for (Step step : job.getStep()) {
                     log.info("Current Job State {}", job.getStatus());
                     if (step.getStepNumber() == 100 && step.getStatus().equals(JobStatus.completed) || step.getStatus().equals(JobStatus.failed)) {

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -321,7 +321,7 @@ public class RemoteTfeService {
     RunsData createRun(RunsData runsData) throws SchedulerException, ParseException {
         String workspaceId = runsData.getData().getRelationships().getWorkspace().getData().getId();
         String configurationId = runsData.getData().getRelationships().getConfigurationVersion().getData().getId();
-        boolean isDestroy = (boolean) runsData.getData().getAttributes().get("is-destroy");
+        boolean isDestroy =  runsData.getData().getAttributes().get("is-destroy") != null ? (boolean) runsData.getData().getAttributes().get("is-destroy"): false;
         log.info("Creating new Terrakube Job");
         log.info("Workspace {} Configuration {}",workspaceId, configurationId);
         Workspace workspace = workspaceRepository.getReferenceById(UUID.fromString(workspaceId));

--- a/api/src/main/resources/db/changelog/demo-data/simple.xml
+++ b/api/src/main/resources/db/changelog/demo-data/simple.xml
@@ -103,6 +103,15 @@
             <column name="organization_id"  value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
         </insert>
 
+        <insert tableName="template">
+            <column name="id"               value="cc8de820-4734-4fec-b1a5-a4014da6c846" />
+            <column name="name"             value="Terraform-Plan/Destroy-Cli" />
+            <column name="description"      value="Running terraform plan and destroy using remote backend" />
+            <column name="version"          value="1.0.0" />
+            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbkRlc3Ryb3kiCiAgc3RlcDogMTAwCi0gdHlwZTogImFwcHJvdmFsIgogIHN0ZXA6IDE1MAogIHRlYW06ICJURVJSQUZPUk1fQ0xJIgotIHR5cGU6ICJ0ZXJyYWZvcm1BcHBseSIKICBzdGVwOiAyMDAK" />
+            <column name="organization_id"  value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
+        </insert>
+
         <!--
         ***************    
         ***WORKSPACE***

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<java.version>11</java.version>
 		<commons-text.version>1.10.0</commons-text.version>
-		<terraform-spring-boot-starter.version>0.6.5</terraform-spring-boot-starter.version>
+		<terraform-spring-boot-starter.version>0.7.0</terraform-spring-boot-starter.version>
 		<terrakube-client-starter.version>0.11.0</terrakube-client-starter.version>
 		<commons-io.version>2.8.0</commons-io.version>
 		<commons-codec>1.15</commons-codec>

--- a/executor/src/main/java/org/terrakube/executor/service/executor/ExecutorJobImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/executor/ExecutorJobImpl.java
@@ -47,9 +47,10 @@ public class ExecutorJobImpl implements ExecutorJob {
         updateJobStatus.setRunningStatus(terraformJob, commitId);
 
         switch (terraformJob.getType()) {
+            case "terraformPlanDestroy":
             case "terraformPlan":
                 log.info("Execute Plan for Organization {} Workspace {} ", terraformJob.getOrganizationId(), terraformJob.getWorkspaceId());
-                terraformResult = terraformExecutor.plan(terraformJob, workspaceFolder);
+                terraformResult = terraformExecutor.plan(terraformJob, workspaceFolder, terraformJob.getType().equals("terraformPlanDestroy"));
                 break;
             case "terraformApply":
                 log.info("Execute Apply for Organization {} Workspace {} ", terraformJob.getOrganizationId(), terraformJob.getWorkspaceId());

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutor.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutor.java
@@ -7,7 +7,7 @@ import java.io.File;
 
 public interface TerraformExecutor {
 
-    ExecutorJobResult plan(TerraformJob terraformJob, File workingDirectory);
+    ExecutorJobResult plan(TerraformJob terraformJob, File workingDirectory, boolean isDestroy);
 
     ExecutorJobResult apply(TerraformJob terraformJob, File workingDirectory);
 


### PR DESCRIPTION
This will allow to run a remote Destroy in Terrakube from the Terraform CLI

```terraform
terraform {
  backend "remote" {
    hostname = "8080-azbuilder-terrakube-is9q8gqdg8x.ws-us84.gitpod.io"
    organization = "simple"
    workspaces {
      name = "workspace1"
    }
  }
}


resource "random_string" "random" {
  length           = 16
  special          = true
  override_special = "/@£$"
}
```

Example
```bash
terraform init
terraform plan
terraform destroy
```
![image](https://user-images.githubusercontent.com/4461895/214698491-fa11f07d-2bae-43b6-bac2-55610cd05579.png)
