### PR TITLE
Adding remote backend templates in new organizations

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/manage/OrganizationManageService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/manage/OrganizationManageService.java
@@ -35,6 +35,32 @@ public class OrganizationManageService {
             "    step: 100" +
             "";
 
+    private static String TEMPLATE_APPLY_CLI ="flow:\n" +
+            "- type: \"terraformPlan\"\n" +
+            "  name: \"Terraform Plan from Terraform CLI\"\n" +
+            "  step: 100\n" +
+            "- type: \"approval\"\n" +
+            "  name: \"Approve Plan from Terraform CLI\"\n" +
+            "  step: 150\n" +
+            "  team: \"TERRAFORM_CLI\"\n" +
+            "- type: \"terraformApply\"\n" +
+            "  name: \"Terraform Apply from Terraform CLI\"\n" +
+            "  step: 200\n";
+
+    private static String TEMPLATE_DESTROY_CLI ="flow:\n" +
+            "- type: \"terraformPlanDestroy\"\n" +
+            "  name: \"Terraform Plan Destroy from Terraform CLI\"\n" +
+            "  step: 100\n" +
+            "- type: \"approval\"\n" +
+            "  name: \"Approve Plan from Terraform CLI\"\n" +
+            "  step: 150\n" +
+            "  team: \"TERRAFORM_CLI\"\n" +
+            "- type: \"terraformApply\"\n" +
+            "  name: \"Terraform Apply from Terraform CLI\"\n" +
+            "  step: 200\n";
+
+
+
     TemplateRepository templateRepository;
 
     @Transactional
@@ -42,6 +68,8 @@ public class OrganizationManageService {
         templateRepository.save(generateTemplate("Terraform-Plan", "Running Terraform plan", Base64.getEncoder().encodeToString(TEMPLATE_PLAN.getBytes()), organization));
         templateRepository.save(generateTemplate("Terraform-Plan/Apply", "Running Terraform plan and apply", Base64.getEncoder().encodeToString(TEMPLATE_APPLY.getBytes()), organization));
         templateRepository.save(generateTemplate("Terraform-Destroy", "Running Terraform destroy", Base64.getEncoder().encodeToString(TEMPLATE_DESTROY.getBytes()), organization));
+        templateRepository.save(generateTemplate("Terraform-Plan/Apply-Cli", "Running Terraform apply from Terraform CLI", Base64.getEncoder().encodeToString(TEMPLATE_APPLY_CLI.getBytes()), organization));
+        templateRepository.save(generateTemplate("Terraform-Plan/Destroy-Cli", "Running Terraform destroy from Terraform CLI", Base64.getEncoder().encodeToString(TEMPLATE_DESTROY_CLI.getBytes()), organization));
     }
 
     private Template generateTemplate(String name, String description, String tcl, Organization organization){

--- a/api/src/main/resources/db/changelog/demo-data/aws.xml
+++ b/api/src/main/resources/db/changelog/demo-data/aws.xml
@@ -72,6 +72,24 @@
             <column name="organization_id"  value="3a130a1c-d96f-4f99-83b8-58d472567e3a" />
         </insert>
 
+        <insert tableName="template">
+            <column name="id"               value="d6bb148e-757a-405b-b06e-5c628371927e" />
+            <column name="name"             value="Terraform-Plan/Apply-Cli" />
+            <column name="description"      value="Running terraform plan and apply using remote backend" />
+            <column name="version"          value="1.0.0" />
+            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBuYW1lOiAiVGVycmFmb3JtIFBsYW4gZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg==" />
+            <column name="organization_id"  value="3a130a1c-d96f-4f99-83b8-58d472567e3a" />
+        </insert>
+
+        <insert tableName="template">
+            <column name="id"               value="c9965ff5-65bc-4dfb-8995-c8fce9130360" />
+            <column name="name"             value="Terraform-Plan/Destroy-Cli" />
+            <column name="description"      value="Running terraform plan and destroy using remote backend" />
+            <column name="version"          value="1.0.0" />
+            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBuYW1lOiAiVGVycmFmb3JtIFBsYW4gZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg" />
+            <column name="organization_id"  value="3a130a1c-d96f-4f99-83b8-58d472567e3a" />
+        </insert>
+
         <!--
         *************    
         ***MODULES***

--- a/api/src/main/resources/db/changelog/demo-data/aws.xml
+++ b/api/src/main/resources/db/changelog/demo-data/aws.xml
@@ -86,7 +86,7 @@
             <column name="name"             value="Terraform-Plan/Destroy-Cli" />
             <column name="description"      value="Running terraform plan and destroy using remote backend" />
             <column name="version"          value="1.0.0" />
-            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBuYW1lOiAiVGVycmFmb3JtIFBsYW4gZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg" />
+            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbkRlc3Ryb3kiCiAgbmFtZTogIlRlcnJhZm9ybSBQbGFuIERlc3Ryb3kgZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg==" />
             <column name="organization_id"  value="3a130a1c-d96f-4f99-83b8-58d472567e3a" />
         </insert>
 

--- a/api/src/main/resources/db/changelog/demo-data/azure.xml
+++ b/api/src/main/resources/db/changelog/demo-data/azure.xml
@@ -40,6 +40,24 @@
             <column name="organization_id"  value="1c839e0a-ca5d-49a9-9c78-7a569df534b7" />
         </insert>
 
+        <insert tableName="template">
+            <column name="id"               value="d6efb260-ce6b-4df5-ad6a-32bfeb852b6f" />
+            <column name="name"             value="Terraform-Plan/Apply-Cli" />
+            <column name="description"      value="Running terraform plan and apply using remote backend" />
+            <column name="version"          value="1.0.0" />
+            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBuYW1lOiAiVGVycmFmb3JtIFBsYW4gZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg==" />
+            <column name="organization_id"  value="1c839e0a-ca5d-49a9-9c78-7a569df534b7" />
+        </insert>
+
+        <insert tableName="template">
+            <column name="id"               value="d6e8a100-7f5a-4d03-bc52-0975479d8b7e" />
+            <column name="name"             value="Terraform-Plan/Destroy-Cli" />
+            <column name="description"      value="Running terraform plan and destroy using remote backend" />
+            <column name="version"          value="1.0.0" />
+            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBuYW1lOiAiVGVycmFmb3JtIFBsYW4gZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg" />
+            <column name="organization_id"  value="1c839e0a-ca5d-49a9-9c78-7a569df534b7" />
+        </insert>
+
         <!--
         ***************   
         ***TEMPLATES***

--- a/api/src/main/resources/db/changelog/demo-data/azure.xml
+++ b/api/src/main/resources/db/changelog/demo-data/azure.xml
@@ -40,24 +40,6 @@
             <column name="organization_id"  value="1c839e0a-ca5d-49a9-9c78-7a569df534b7" />
         </insert>
 
-        <insert tableName="template">
-            <column name="id"               value="d6efb260-ce6b-4df5-ad6a-32bfeb852b6f" />
-            <column name="name"             value="Terraform-Plan/Apply-Cli" />
-            <column name="description"      value="Running terraform plan and apply using remote backend" />
-            <column name="version"          value="1.0.0" />
-            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBuYW1lOiAiVGVycmFmb3JtIFBsYW4gZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg==" />
-            <column name="organization_id"  value="1c839e0a-ca5d-49a9-9c78-7a569df534b7" />
-        </insert>
-
-        <insert tableName="template">
-            <column name="id"               value="d6e8a100-7f5a-4d03-bc52-0975479d8b7e" />
-            <column name="name"             value="Terraform-Plan/Destroy-Cli" />
-            <column name="description"      value="Running terraform plan and destroy using remote backend" />
-            <column name="version"          value="1.0.0" />
-            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBuYW1lOiAiVGVycmFmb3JtIFBsYW4gZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg" />
-            <column name="organization_id"  value="1c839e0a-ca5d-49a9-9c78-7a569df534b7" />
-        </insert>
-
         <!--
         ***************   
         ***TEMPLATES***
@@ -87,6 +69,24 @@
             <column name="description"      value="Running terraform destroy" />
             <column name="version"          value="1.0.0" />
             <column name="tcl"              value="ZmxvdzoKICAtIHR5cGU6ICJ0ZXJyYWZvcm1EZXN0cm95IgogICAgc3RlcDogMTAwCg==" />
+            <column name="organization_id"  value="1c839e0a-ca5d-49a9-9c78-7a569df534b7" />
+        </insert>
+
+        <insert tableName="template">
+            <column name="id"               value="d6efb260-ce6b-4df5-ad6a-32bfeb852b6f" />
+            <column name="name"             value="Terraform-Plan/Apply-Cli" />
+            <column name="description"      value="Running terraform plan and apply using remote backend" />
+            <column name="version"          value="1.0.0" />
+            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBuYW1lOiAiVGVycmFmb3JtIFBsYW4gZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg==" />
+            <column name="organization_id"  value="1c839e0a-ca5d-49a9-9c78-7a569df534b7" />
+        </insert>
+
+        <insert tableName="template">
+            <column name="id"               value="d6e8a100-7f5a-4d03-bc52-0975479d8b7e" />
+            <column name="name"             value="Terraform-Plan/Destroy-Cli" />
+            <column name="description"      value="Running terraform plan and destroy using remote backend" />
+            <column name="version"          value="1.0.0" />
+            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbkRlc3Ryb3kiCiAgbmFtZTogIlRlcnJhZm9ybSBQbGFuIERlc3Ryb3kgZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg==" />
             <column name="organization_id"  value="1c839e0a-ca5d-49a9-9c78-7a569df534b7" />
         </insert>
 

--- a/api/src/main/resources/db/changelog/demo-data/gcp.xml
+++ b/api/src/main/resources/db/changelog/demo-data/gcp.xml
@@ -40,24 +40,6 @@
             <column name="organization_id"  value="f5365c9e-bc11-4781-b649-45a281ccdd4a" />
         </insert>
 
-        <insert tableName="template">
-            <column name="id"               value="db8576b0-f46d-46a1-96ef-1cba6fc1685e" />
-            <column name="name"             value="Terraform-Plan/Apply-Cli" />
-            <column name="description"      value="Running terraform plan and apply using remote backend" />
-            <column name="version"          value="1.0.0" />
-            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBuYW1lOiAiVGVycmFmb3JtIFBsYW4gZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg==" />
-            <column name="organization_id"  value="f5365c9e-bc11-4781-b649-45a281ccdd4a" />
-        </insert>
-
-        <insert tableName="template">
-            <column name="id"               value="1370ef3c-edf0-4fa9-9c4c-4dcf847b572d" />
-            <column name="name"             value="Terraform-Plan/Destroy-Cli" />
-            <column name="description"      value="Running terraform plan and destroy using remote backend" />
-            <column name="version"          value="1.0.0" />
-            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBuYW1lOiAiVGVycmFmb3JtIFBsYW4gZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg" />
-            <column name="organization_id"  value="f5365c9e-bc11-4781-b649-45a281ccdd4a" />
-        </insert>
-
         <!--
         ***************   
         ***TEMPLATES***
@@ -87,6 +69,24 @@
             <column name="description"      value="Running terraform destroy" />
             <column name="version"          value="1.0.0" />
             <column name="tcl"              value="ZmxvdzoKICAtIHR5cGU6ICJ0ZXJyYWZvcm1EZXN0cm95IgogICAgc3RlcDogMTAwCg==" />
+            <column name="organization_id"  value="f5365c9e-bc11-4781-b649-45a281ccdd4a" />
+        </insert>
+
+        <insert tableName="template">
+            <column name="id"               value="db8576b0-f46d-46a1-96ef-1cba6fc1685e" />
+            <column name="name"             value="Terraform-Plan/Apply-Cli" />
+            <column name="description"      value="Running terraform plan and apply using remote backend" />
+            <column name="version"          value="1.0.0" />
+            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBuYW1lOiAiVGVycmFmb3JtIFBsYW4gZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg==" />
+            <column name="organization_id"  value="f5365c9e-bc11-4781-b649-45a281ccdd4a" />
+        </insert>
+
+        <insert tableName="template">
+            <column name="id"               value="1370ef3c-edf0-4fa9-9c4c-4dcf847b572d" />
+            <column name="name"             value="Terraform-Plan/Destroy-Cli" />
+            <column name="description"      value="Running terraform plan and destroy using remote backend" />
+            <column name="version"          value="1.0.0" />
+            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBuYW1lOiAiVGVycmFmb3JtIFBsYW4gZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg" />
             <column name="organization_id"  value="f5365c9e-bc11-4781-b649-45a281ccdd4a" />
         </insert>
 

--- a/api/src/main/resources/db/changelog/demo-data/gcp.xml
+++ b/api/src/main/resources/db/changelog/demo-data/gcp.xml
@@ -40,6 +40,24 @@
             <column name="organization_id"  value="f5365c9e-bc11-4781-b649-45a281ccdd4a" />
         </insert>
 
+        <insert tableName="template">
+            <column name="id"               value="db8576b0-f46d-46a1-96ef-1cba6fc1685e" />
+            <column name="name"             value="Terraform-Plan/Apply-Cli" />
+            <column name="description"      value="Running terraform plan and apply using remote backend" />
+            <column name="version"          value="1.0.0" />
+            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBuYW1lOiAiVGVycmFmb3JtIFBsYW4gZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg==" />
+            <column name="organization_id"  value="f5365c9e-bc11-4781-b649-45a281ccdd4a" />
+        </insert>
+
+        <insert tableName="template">
+            <column name="id"               value="1370ef3c-edf0-4fa9-9c4c-4dcf847b572d" />
+            <column name="name"             value="Terraform-Plan/Destroy-Cli" />
+            <column name="description"      value="Running terraform plan and destroy using remote backend" />
+            <column name="version"          value="1.0.0" />
+            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBuYW1lOiAiVGVycmFmb3JtIFBsYW4gZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg" />
+            <column name="organization_id"  value="f5365c9e-bc11-4781-b649-45a281ccdd4a" />
+        </insert>
+
         <!--
         ***************   
         ***TEMPLATES***

--- a/api/src/main/resources/db/changelog/demo-data/simple.xml
+++ b/api/src/main/resources/db/changelog/demo-data/simple.xml
@@ -99,7 +99,7 @@
             <column name="name"             value="Terraform-Plan/Apply-Cli" />
             <column name="description"      value="Running terraform plan and apply using remote backend" />
             <column name="version"          value="1.0.0" />
-            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBzdGVwOiAxMDAKLSB0eXBlOiAiYXBwcm92YWwiCiAgc3RlcDogMTUwCiAgdGVhbTogIlRFUlJBRk9STV9DTEkiCi0gdHlwZTogInRlcnJhZm9ybUFwcGx5IgogIHN0ZXA6IDIwMAo=" />
+            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBuYW1lOiAiVGVycmFmb3JtIFBsYW4gZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg==" />
             <column name="organization_id"  value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
         </insert>
 
@@ -108,7 +108,7 @@
             <column name="name"             value="Terraform-Plan/Destroy-Cli" />
             <column name="description"      value="Running terraform plan and destroy using remote backend" />
             <column name="version"          value="1.0.0" />
-            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbkRlc3Ryb3kiCiAgc3RlcDogMTAwCi0gdHlwZTogImFwcHJvdmFsIgogIHN0ZXA6IDE1MAogIHRlYW06ICJURVJSQUZPUk1fQ0xJIgotIHR5cGU6ICJ0ZXJyYWZvcm1BcHBseSIKICBzdGVwOiAyMDAK" />
+            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBuYW1lOiAiVGVycmFmb3JtIFBsYW4gZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg" />
             <column name="organization_id"  value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
         </insert>
 

--- a/api/src/main/resources/db/changelog/demo-data/simple.xml
+++ b/api/src/main/resources/db/changelog/demo-data/simple.xml
@@ -108,7 +108,7 @@
             <column name="name"             value="Terraform-Plan/Destroy-Cli" />
             <column name="description"      value="Running terraform plan and destroy using remote backend" />
             <column name="version"          value="1.0.0" />
-            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbiIKICBuYW1lOiAiVGVycmFmb3JtIFBsYW4gZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg" />
+            <column name="tcl"              value="ZmxvdzoKLSB0eXBlOiAidGVycmFmb3JtUGxhbkRlc3Ryb3kiCiAgbmFtZTogIlRlcnJhZm9ybSBQbGFuIERlc3Ryb3kgZnJvbSBUZXJyYWZvcm0gQ0xJIgogIHN0ZXA6IDEwMAotIHR5cGU6ICJhcHByb3ZhbCIKICBuYW1lOiAiQXBwcm92ZSBQbGFuIGZyb20gVGVycmFmb3JtIENMSSIKICBzdGVwOiAxNTAKICB0ZWFtOiAiVEVSUkFGT1JNX0NMSSIKLSB0eXBlOiAidGVycmFmb3JtQXBwbHkiCiAgbmFtZTogIlRlcnJhZm9ybSBBcHBseSBmcm9tIFRlcnJhZm9ybSBDTEkiCiAgc3RlcDogMjAwCg==" />
             <column name="organization_id"  value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
         </insert>
 


### PR DESCRIPTION
All new organizations will be created with the templates to use "Remote Backend", this can be customized later

- Terraform Apply from Terraform CLI
```yaml
flow:
- type: "terraformPlan"
  name: "Terraform Plan from Terraform CLI"
  step: 100
- type: "approval"
  name: "Approve Plan from Terraform CLI"
  step: 150
  team: "TERRAFORM_CLI"
- type: "terraformApply"
  name: "Terraform Apply from Terraform CLI"
  step: 200

```
- Terraform Destroy from Terraform CLI
```yaml
flow:
- type: "terraformPlanDestroy"
  name: "Terraform Plan Destroy from Terraform CLI"
  step: 100
- type: "approval"
  name: "Approve Plan from Terraform CLI"
  step: 150
  team: "TERRAFORM_CLI"
- type: "terraformApply"
  name: "Terraform Apply from Terraform CLI"
  step: 200

```