### PR TITLE
Import template logic

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/TclService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/TclService.java
@@ -125,8 +125,10 @@ public class TclService {
                 ImportComands importComands = finalFlow.getImportComands();
                 if (importComands != null) {
                     log.info("Import commands from {} branch {} folder {}", importComands.getRepository(), importComands.getBranch(), importComands.getFolder());
-                    nextFlow.get().setCommands(importCommands(importComands.getRepository(), importComands.getBranch(), importComands.getFolder()));
+                    finalFlow.setCommands(importCommands(importComands.getRepository(), importComands.getBranch(), importComands.getFolder()));
                 }
+
+                return finalFlow;
 
             } else
                 return null;

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/TclService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/TclService.java
@@ -130,8 +130,9 @@ public class TclService {
 
                 return finalFlow;
 
-            } else
+            } else {
                 return null;
+            }
         } else
             return null;
     }
@@ -162,7 +163,7 @@ public class TclService {
     private String getCommandList(String repository, String branch, String folder, File folderImport) {
         String commandList = "";
         try {
-            log.info("Cloning template import repository")
+            log.info("Cloning template import repository");
             Git.cloneRepository()
                     .setURI(repository)
                     .setDirectory(folderImport)

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/TclService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/TclService.java
@@ -4,10 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
 import org.springframework.stereotype.Service;
-import org.terrakube.api.plugin.scheduler.job.tcl.model.Flow;
-import org.terrakube.api.plugin.scheduler.job.tcl.model.FlowConfig;
-import org.terrakube.api.plugin.scheduler.job.tcl.model.FlowType;
+import org.terrakube.api.plugin.scheduler.job.tcl.model.*;
 import org.terrakube.api.repository.JobRepository;
 import org.terrakube.api.repository.StepRepository;
 import org.terrakube.api.repository.TemplateRepository;
@@ -18,6 +19,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.*;
 
 @AllArgsConstructor
@@ -26,6 +30,8 @@ import java.util.*;
 @Setter
 @Slf4j
 public class TclService {
+
+    private static final String IMPORT_DIRECTORY = "%s/.terraform-spring-boot/importCommands/%s";
 
     JobRepository jobRepository;
     StepRepository stepRepository;
@@ -76,7 +82,7 @@ public class TclService {
             log.info("FlowConfig: \n {}", temp);
             flowConfig = yaml.load(new String(Base64.getDecoder().decode(tcl)));
 
-            if(flowConfig.getFlow().isEmpty()){
+            if (flowConfig.getFlow().isEmpty()) {
                 log.error("Exception parsing yaml: template with no flows");
                 return setErrorFlowYaml("Yaml Template does not have any flow");
             }
@@ -113,9 +119,74 @@ public class TclService {
                     .filter(flow -> flow.getStep() == map.firstKey())
                     .findFirst();
 
+            ImportComands importComands = nextFlow.get().getImportComands();
+            if (importComands != null) {
+                log.info("Import commands from {} branch {} folder {}", importComands.getRepository(), importComands.getBranch(), importComands.getFolder());
+
+                nextFlow.get().setCommands(importCommands(importComands.getRepository(), importComands.getBranch(), importComands.getFolder()));
+            }
+
             return nextFlow.isPresent() ? nextFlow.get() : null;
         } else
             return null;
+    }
+
+    private List<Command> importCommands(String repository, String branch, String folder) {
+        List<Command> commands = new ArrayList();
+        try {
+            File importFolder = generateImportFolder();
+            String commandsText = getCommandList(repository, branch, folder, generateImportFolder());
+
+            Yaml yaml = new Yaml(new Constructor(CommandConfig.class));
+            CommandConfig temp = yaml.load(commandsText);
+
+            commands = temp.getCommands();
+
+            log.info("Importing commands \n{}\n", commandsText);
+
+            FileUtils.cleanDirectory(importFolder);
+        } catch (IOException e) {
+            log.error(e.getMessage());
+        }
+        return commands;
+    }
+
+    private String getCommandList(String repository, String branch, String folder, File folderImport) {
+        String commandList = "";
+        try {
+            Git.cloneRepository()
+                    .setURI(repository)
+                    .setDirectory(folderImport)
+                    .setBranch(branch)
+                    .call();
+            File importData = null;
+            if (folder.equals("/")) {
+                importData = new File(String.format("%s/commands.yaml", folderImport.getCanonicalPath()));
+            } else {
+                importData = new File(String.format("%s/%s/commands.yaml", folderImport.getCanonicalPath(), folder));
+            }
+
+            commandList = FileUtils.readFileToString(importData, Charset.defaultCharset());
+        } catch (IOException | GitAPIException e) {
+            log.error(e.getMessage());
+        }
+        return commandList;
+    }
+
+    private File generateImportFolder() {
+        String importCommandFolder = String.format(IMPORT_DIRECTORY, FileUtils.getUserDirectoryPath(), UUID.randomUUID());
+        File importFolder = new File(importCommandFolder);
+        try {
+            if (!importFolder.exists()) {
+                log.info("Creating new import folder for {}", importCommandFolder);
+                FileUtils.forceMkdir(importFolder);
+            } else {
+                FileUtils.cleanDirectory(importFolder);
+            }
+        } catch (IOException e) {
+            log.error(e.getMessage());
+        }
+        return importFolder;
     }
 
     private TreeMap<Integer, Step> getPendingSteps(Job job) {

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/CommandConfig.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/CommandConfig.java
@@ -9,14 +9,6 @@ import java.util.List;
 @ToString
 @Getter
 @Setter
-public class Flow {
-    private String type;
-    private String team;
-    private String name;
-
-    private String error;
-    private int step;
+public class CommandConfig {
     List<Command> commands;
-
-    ImportComands importComands;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/ImportComands.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/ImportComands.java
@@ -1,0 +1,14 @@
+package org.terrakube.api.plugin.scheduler.job.tcl.model;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Setter
+public class ImportComands {
+    String repository;
+    String folder;
+    String branch;
+}


### PR DESCRIPTION
Adding support to import template logics using an external git repository.

Example before template import:
```yaml
flow:
- type: "terraformPlan"
  step: 100
  commands:
    - runtime: "GROOVY"
      priority: 100
      before: true
      script: |
        import TerraTag
        new TerraTag().loadTool(
          "$workingDirectory",
          "$bashToolsDirectory",
          "0.1.30")
        "Terratag download completed"
    - runtime: "BASH"
      priority: 200
      before: true
      script: |
        cd $workingDirectory
        terratag -tags="{\"environment_id\": \"development\"}"
- type: "terraformApply"
  step: 300
```

Using templates import:
```yaml
flow:
  - type: "terraformPlan"
    step: 100
    importComands:
      repository: "https://github.com/AzBuilder/terrakube-extensions"
      folder: "templates/terratag"
      branch: "import-template"
  - type: "terraformApply"
    step: 200
```

The sample template can be found [here](https://github.com/AzBuilder/terrakube-extensions/blob/main/templates/terratag/commands.yaml)

> There is one restriction for now, the import commands are using a public repository, we will add support for private repositories in the future.

