### PR TITLE
Simplify Dockerfile UI using bitnami/nginx

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -8,35 +8,7 @@ COPY . .
 RUN yarn build
 
 # => Run container
-FROM nginx:mainline-alpine
-
-# Nginx config
-RUN rm -rf /etc/nginx/conf.d
-COPY conf /etc/nginx
+FROM bitnami/nginx:latest
 
 # Static build
-COPY --from=builder /app/build /usr/share/nginx/html/
-
-# Default port exposure
-EXPOSE 8080
-
-# Copy .env file and shell script to container
-WORKDIR /usr/share/nginx/html
-COPY ./env.sh .
-
-# Generate empty file for parameters
-RUN echo "REACT_APP_TERRAKUBE_API_URL=" >> .env &&\
-    echo "REACT_APP_CLIENT_ID=" >> .env &&\
-    echo "REACT_APP_AUTHORITY=" >> .env &&\
-    echo "REACT_APP_REDIRECT_URI=" >>.env &&\
-    echo "REACT_APP_REGISTRY_URI=" >>.env &&\
-    echo "REACT_APP_SCOPE=" >>.env
-
-# Add bash
-RUN apk add --no-cache bash
-
-# Make our shell script executable
-RUN chmod +x env.sh
-
-# Start Nginx server
-CMD ["/bin/bash", "-c", "/usr/share/nginx/html/env.sh && nginx -g \"daemon off;\""]
+COPY --from=builder /app/build /app

--- a/ui/README.md
+++ b/ui/README.md
@@ -53,30 +53,18 @@ docker build -t terrakube-ui:latest  .
 
 > If you are a Windows user and face the following error when building the UI ***Bash script and /bin/bash^M: bad interpreter: No such file or directory*** run the following command to fix the issue ***sed -i -e 's/\r$//' env.sh***
 
-### Run Image
-
-```bash
-docker run -p 127.0.0.1:8080:8080/tcp -it --env-file=.env terrakube-ui:latest
-```
-
 > Make sure to run the script  **setupEnv.sh** first to generate the **.env** file
 
-### Docker Compose
+### Run the image with Docker Compose
 
 ```dockerfile
-
 version: "3.8"
 services:
   terrakube-ui:
-    image: azbuilder/terrakube-ui:latest
+    image: terrakube-ui:latest
     container_name: terrakube-ui
-    environment:
-      - REACT_APP_TERRAKUBE_API_URL=https://terrakubeUrl/api/v1/
-      - REACT_APP_CLIENT_ID=terrakube-app
-      - REACT_APP_AUTHORITY=https://dexUrl.com
-      - REACT_APP_REDIRECT_URI=http://localhost:3000
-      - REACT_APP_REGISTRY_URI=https://registryUrl.com
-      - REACT_APP_SCOPE=email openid profile offline_access groups
+    volumes:
+      - ./env-config.js:/app/env-config.js
     ports:
       - 8080:8080 
 ```

--- a/ui/docker-compose.yml
+++ b/ui/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+services:
+  terrakube-ui:
+    image: terrakube-ui:latest
+    container_name: terrakube-ui
+    volumes:
+      - ./env-config.js:/app/env-config.js
+    ports:
+      - 8080:8080 


### PR DESCRIPTION
The container for the UI was running as "root" user.

![image](https://user-images.githubusercontent.com/4461895/221302352-faf0db71-d5d8-4558-89f2-0ab689b99194.png)

The Dockerfile now is using the bitnami/nginx image and is running as user 1001

![image](https://user-images.githubusercontent.com/4461895/221302600-c607a84d-5554-432f-a9ef-25a2b606c330.png)

![image](https://user-images.githubusercontent.com/4461895/221303187-17708827-a01f-4738-8036-ffdd63191c1b.png)

The env-config.js should be mount as a volume to load the parameters needed for the react application instead of running the script to generate the file

Example using docker-compose:

```yaml
version: "3.8"
services:
  terrakube-ui:
    image: terrakube-ui:latest
    container_name: terrakube-ui
    volumes:
      - ./env-config.js:/app/env-config.js
    ports:
      - 8080:8080 
```

![image](https://user-images.githubusercontent.com/4461895/221302897-b5dbdc73-5b58-4244-8d4a-b5d23205f051.png)


