### PR TITLE
Support for custom terraform cli builds

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/json/TerraformJsonController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/json/TerraformJsonController.java
@@ -1,5 +1,6 @@
 package org.terrakube.api.plugin.json;
 
+import lombok.AllArgsConstructor;
 import org.apache.commons.io.IOUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -10,13 +11,21 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.Charset;
 
+@AllArgsConstructor
 @RestController
 @RequestMapping("/terraform")
 public class TerraformJsonController {
 
+    TerraformJsonProperties terraformJsonProperties;
+
     @GetMapping(value= "/index.json", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<String> createToken() throws IOException {
-        String terraformIndex = IOUtils.toString(URI.create("https://releases.hashicorp.com/terraform/index.json"), Charset.defaultCharset().toString());
+        String terraformIndex = "";
+        if(terraformJsonProperties.getReleasesUrl() != null && !terraformJsonProperties.getReleasesUrl().isEmpty()) {
+            terraformIndex = IOUtils.toString(URI.create(terraformJsonProperties.getReleasesUrl()), Charset.defaultCharset().toString());
+        } else {
+            terraformIndex = IOUtils.toString(URI.create("https://releases.hashicorp.com/terraform/index.json"), Charset.defaultCharset().toString());
+        }
         return new ResponseEntity<>(terraformIndex, HttpStatus.OK);
     }
 }

--- a/api/src/main/java/org/terrakube/api/plugin/json/TerraformJsonController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/json/TerraformJsonController.java
@@ -1,6 +1,8 @@
 package org.terrakube.api.plugin.json;
 
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.io.IOUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -11,6 +13,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.Charset;
 
+@Slf4j
 @AllArgsConstructor
 @RestController
 @RequestMapping("/terraform")
@@ -22,9 +25,12 @@ public class TerraformJsonController {
     public ResponseEntity<String> createToken() throws IOException {
         String terraformIndex = "";
         if(terraformJsonProperties.getReleasesUrl() != null && !terraformJsonProperties.getReleasesUrl().isEmpty()) {
+            log.info("Using terraform releases URL {}", terraformJsonProperties.getReleasesUrl());
             terraformIndex = IOUtils.toString(URI.create(terraformJsonProperties.getReleasesUrl()), Charset.defaultCharset().toString());
         } else {
-            terraformIndex = IOUtils.toString(URI.create("https://releases.hashicorp.com/terraform/index.json"), Charset.defaultCharset().toString());
+            String defaultUrl="https://releases.hashicorp.com/terraform/index.json";
+            log.warn("Using terraform releases URL {}", defaultUrl);
+            terraformIndex = IOUtils.toString(URI.create(defaultUrl), Charset.defaultCharset().toString());
         }
         return new ResponseEntity<>(terraformIndex, HttpStatus.OK);
     }

--- a/api/src/main/java/org/terrakube/api/plugin/json/TerraformJsonProperties.java
+++ b/api/src/main/java/org/terrakube/api/plugin/json/TerraformJsonProperties.java
@@ -1,0 +1,17 @@
+package org.terrakube.api.plugin.json;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@Setter
+@PropertySource(value = "classpath:application.properties", ignoreResourceNotFound = true)
+@PropertySource(value = "classpath:application-${spring.profiles.active}.properties", ignoreResourceNotFound = true)
+@ConfigurationProperties(prefix = "org.terrakube.terraform.json")
+public class TerraformJsonProperties {
+    private String releasesUrl;
+}

--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -124,3 +124,8 @@ org.terrakube.token.pat=${PatSecret}
 org.terrakube.token.internal=${InternalSecret}
 org.terrakube.token.issuer-uri=${DexIssuerUri}
 #spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${DexJwtSetUri}
+
+######################
+# Terraform Releases #
+######################
+org.terrakube.terraform.json.releasesUrl=

--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -128,4 +128,4 @@ org.terrakube.token.issuer-uri=${DexIssuerUri}
 ######################
 # Terraform Releases #
 ######################
-org.terrakube.terraform.json.releasesUrl=
+org.terrakube.terraform.json.releasesUrl=${CustomTerraformReleasesUrl}

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -125,3 +125,8 @@ org.terrakube.token.internal=${InternalSecret}
 org.terrakube.token.issuer-uri=${DexIssuerUri}
 org.terrakube.token.client-id=${DexClientId}
 #spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${DexJwtSetUri}
+
+######################
+# Terraform Releases #
+######################
+org.terrakube.terraform.json.releasesUrl=${CustomTerraformReleasesUrl}

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<commons-text.version>1.10.0</commons-text.version>
-		<terraform-spring-boot-starter.version>0.7.0</terraform-spring-boot-starter.version>
+		<terraform-spring-boot-starter.version>0.8.0</terraform-spring-boot-starter.version>
 		<terrakube-client-starter.version>0.11.0</terrakube-client-starter.version>
 		<commons-io.version>2.8.0</commons-io.version>
 		<commons-codec>1.15</commons-codec>

--- a/executor/src/main/resources/application.properties
+++ b/executor/src/main/resources/application.properties
@@ -5,6 +5,7 @@ server.port=8090
 ########################
 org.terrakube.terraform.flags.enableColor=true
 org.terrakube.terraform.flags.jsonOutput=false
+org.terrakube.terraform.flags.terraformReleasesUrl=${CustomTerraformReleasesUrl}
 
 ###########################
 #General Settings Executor#

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>2.11.0</revision>
+        <revision>2.12.0</revision>
         <sonar.organization>azbuilder</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.project.key>AzBuilder_azb-server</sonar.project.key>

--- a/scripts/setupDevelopmentEnvironment.sh
+++ b/scripts/setupDevelopmentEnvironment.sh
@@ -42,6 +42,7 @@ function generateApiVars(){
   echo "TerrakubeUiURL=$TerrakubeUiURL" >> .envApi
   echo "spring_profiles_active=demo" >> .envApi
   echo "DexClientId=$DexClientId" >> .envApi
+  echo "CustomTerraformReleasesUrl=\"https://releases.hashicorp.com/terraform/index.json\"" >> .envApi
   echo "#TERRAKUBE_ADMIN_GROUP=$TERRAKUBE_ADMIN_GROUP" >> .envApi
 }
 
@@ -81,6 +82,7 @@ function generateRegistryVars(){
   echo "TerrakubeToolsBranch=$TerrakubeToolsBranch" >> .envExecutor
   echo "TerrakubeRegistryDomain=$TerrakubeRegistryDomain" >> .envExecutor
   echo "TerrakubeApiUrl=$TerrakubeApiUrl" >> .envExecutor
+  echo "CustomTerraformReleasesUrl=\"https://releases.hashicorp.com/terraform/index.json\"" >> .envExecutor
   echo "JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS" >> .envExecutor
 }
 

--- a/scripts/setupDevelopmentEnvironmentAzure.sh
+++ b/scripts/setupDevelopmentEnvironmentAzure.sh
@@ -45,7 +45,8 @@ function generateApiVars(){
 
   echo "TerrakubeUiURL=$TerrakubeUiURL" >> .envApi
   echo "spring_profiles_active=demo" >> .envApi
-    echo "DexClientId=$DexClientId" >> .envApi
+  echo "DexClientId=$DexClientId" >> .envApi
+  echo "CustomTerraformReleasesUrl=\"https://releases.hashicorp.com/terraform/index.json\"" >> .envApi
   echo "#TERRAKUBE_ADMIN_GROUP=$TERRAKUBE_ADMIN_GROUP" >> .envApi
 }
 
@@ -96,6 +97,7 @@ function generateExecutorVars(){
   echo "TerrakubeToolsBranch=$TerrakubeToolsBranch" >> .envExecutor
   echo "TerrakubeRegistryDomain=$TerrakubeRegistryDomain" >> .envExecutor
   echo "TerrakubeApiUrl=$TerrakubeApiUrl" >> .envExecutor
+  echo "CustomTerraformReleasesUrl=\"https://releases.hashicorp.com/terraform/index.json\"" >> .envExecutor
   echo "JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS" >> .envExecutor
 }
 

--- a/scripts/setupDevelopmentEnvironmentGcp.sh
+++ b/scripts/setupDevelopmentEnvironmentGcp.sh
@@ -48,6 +48,7 @@ function generateApiVars(){
   echo "TerrakubeUiURL=$TerrakubeUiURL" >> .envApi
   echo "spring_profiles_active=demo" >> .envApi
   echo "DexClientId=$DexClientId" >> .envApi
+  echo "CustomTerraformReleasesUrl=\"https://releases.hashicorp.com/terraform/index.json\"" >> .envApi
   echo "#TERRAKUBE_ADMIN_GROUP=$TERRAKUBE_ADMIN_GROUP" >> .envApi
 }
 
@@ -99,6 +100,7 @@ function generateExecutorVars(){
   echo "TerrakubeToolsBranch=$TerrakubeToolsBranch" >> .envExecutor
   echo "TerrakubeRegistryDomain=$TerrakubeRegistryDomain" >> .envExecutor
   echo "TerrakubeApiUrl=$TerrakubeApiUrl" >> .envExecutor
+  echo "CustomTerraformReleasesUrl=\"https://releases.hashicorp.com/terraform/index.json\"" >> .envExecutor
   echo "JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS" >> .envExecutor
 }
 

--- a/scripts/setupDevelopmentEnvironmentMinio.sh
+++ b/scripts/setupDevelopmentEnvironmentMinio.sh
@@ -53,6 +53,7 @@ function generateApiVars(){
   echo "TerrakubeUiURL=$TerrakubeUiURL" >> .envApi
   echo "spring_profiles_active=demo" >> .envApi
   echo "DexClientId=$DexClientId" >> .envApi
+  echo "CustomTerraformReleasesUrl=\"https://releases.hashicorp.com/terraform/index.json\"" >> .envApi
   echo "#TERRAKUBE_ADMIN_GROUP=$TERRAKUBE_ADMIN_GROUP" >> .envApi
 }
 
@@ -122,6 +123,7 @@ function generateExecutorVars(){
   echo "TerrakubeToolsBranch=$TerrakubeToolsBranch" >> .envExecutor
   echo "TerrakubeRegistryDomain=$TerrakubeRegistryDomain" >> .envExecutor
   echo "TerrakubeApiUrl=$TerrakubeApiUrl" >> .envExecutor
+  echo "CustomTerraformReleasesUrl=\"https://releases.hashicorp.com/terraform/index.json\"" >> .envExecutor
   echo "#JAVA_TOOL_OPTIONS=\"$JAVA_TOOL_OPTIONS\"" >> .envExecutor
 }
 


### PR DESCRIPTION
Terrakube will support terraform cli custom builds or custom cli mirrors, the only requirement is to expose an endpoint with the following structure

Example Endpoint: https://eov1ys4sxa1bfy9.m.pipedream.net/
```json
{
   "name":"terraform",
   "versions":{
      "1.3.9":{
         "builds":[
            {
               "arch":"amd64",
               "filename":"terraform_1.3.9_linux_amd64.zip",
               "name":"terraform",
               "os":"linux",
               "url":"https://releases.hashicorp.com/terraform/1.3.9/terraform_1.3.9_linux_amd64.zip",
               "version":"1.3.9"
            }
         ],
         "name":"terraform",
         "shasums":"terraform_1.3.9_SHA256SUMS",
         "shasums_signature":"terraform_1.3.9_SHA256SUMS.sig",
         "shasums_signatures":[
            "terraform_1.3.9_SHA256SUMS.72D7468F.sig",
            "terraform_1.3.9_SHA256SUMS.sig"
         ],
         "version":"1.3.9"
      }
   }
}
```

The API and Executor component will use the environment variable CustomTerraformReleasesUrl to load the terraform CLI builds information, by default it will use https://releases.hashicorp.com/terraform/index.json