### PR TITLE
Filter global variables import

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -122,11 +122,11 @@ public class ExecutorService {
     private HashMap<String, String> loadOtherEnvironmentVariables(Job job, Flow flow, HashMap<String, String> workspaceEnvVariables) {
         if (flow.getInputsEnv() != null || (flow.getImportComands() != null && flow.getImportComands().getInputsEnv() != null)) {
             if (flow.getImportComands() != null && flow.getImportComands().getInputsEnv() != null) {
-                workspaceEnvVariables = loadInputData(job, Category.ENV, flow.getImportComands().getInputsEnv(), workspaceEnvVariables);
+                workspaceEnvVariables = loadInputData(job, Category.ENV, new HashMap(flow.getImportComands().getInputsEnv()), workspaceEnvVariables);
             }
 
             if (flow.getInputsEnv() != null) {
-                workspaceEnvVariables = loadInputData(job, Category.ENV, flow.getInputsEnv(), workspaceEnvVariables);
+                workspaceEnvVariables = loadInputData(job, Category.ENV, new HashMap(flow.getInputsEnv()), workspaceEnvVariables);
             }
 
         } else {
@@ -138,11 +138,11 @@ public class ExecutorService {
     private HashMap<String, String> loadOtherTerraformVariables(Job job, Flow flow, HashMap<String, String> workspaceTerraformVariables) {
         if (flow.getInputsTerraform() != null || (flow.getImportComands() != null && flow.getImportComands().getInputsTerraform() != null)) {
             if (flow.getImportComands() != null && flow.getImportComands().getInputsTerraform() != null) {
-                workspaceTerraformVariables = loadInputData(job, Category.TERRAFORM, flow.getImportComands().getInputsTerraform(), workspaceTerraformVariables);
+                workspaceTerraformVariables = loadInputData(job, Category.TERRAFORM, new HashMap(flow.getImportComands().getInputsTerraform()), workspaceTerraformVariables);
             }
 
             if (flow.getInputsEnv() != null) {
-                workspaceTerraformVariables = loadInputData(job, Category.TERRAFORM, flow.getInputsTerraform(), workspaceTerraformVariables);
+                workspaceTerraformVariables = loadInputData(job, Category.TERRAFORM, new HashMap(flow.getInputsTerraform()), workspaceTerraformVariables);
             }
 
         } else {

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/Flow.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/Flow.java
@@ -4,8 +4,8 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @ToString
 @Getter
@@ -19,9 +19,9 @@ public class Flow {
     private int step;
     List<Command> commands;
 
-    Map<String, String> inputsEnv;
+    HashMap<String, String> inputsEnv;
 
-    Map<String, String> inputsTerraform;
+    HashMap<String, String> inputsTerraform;
 
     ImportComands importComands;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/Flow.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/Flow.java
@@ -5,6 +5,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 import java.util.List;
+import java.util.Map;
 
 @ToString
 @Getter
@@ -17,6 +18,10 @@ public class Flow {
     private String error;
     private int step;
     List<Command> commands;
+
+    Map<String, String> inputsEnv;
+
+    Map<String, String> inputsTerraform;
 
     ImportComands importComands;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/Flow.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/Flow.java
@@ -4,8 +4,8 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @ToString
 @Getter
@@ -19,9 +19,9 @@ public class Flow {
     private int step;
     List<Command> commands;
 
-    HashMap<String, String> inputsEnv;
+    Map<String, String> inputsEnv;
 
-    HashMap<String, String> inputsTerraform;
+    Map<String, String> inputsTerraform;
 
     ImportComands importComands;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/ImportComands.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/ImportComands.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
-import java.util.HashMap;
+import java.util.Map;
 
 @ToString
 @Getter
@@ -13,6 +13,6 @@ public class ImportComands {
     String repository;
     String folder;
     String branch;
-    HashMap<String, String> inputsEnv;
-    HashMap<String, String> inputsTerraform;
+    Map<String, String> inputsEnv;
+    Map<String, String> inputsTerraform;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/ImportComands.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/ImportComands.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
-import java.util.Map;
+import java.util.HashMap;
 
 @ToString
 @Getter
@@ -13,6 +13,6 @@ public class ImportComands {
     String repository;
     String folder;
     String branch;
-    Map<String, String> inputsEnv;
-    Map<String, String> inputsTerraform;
+    HashMap<String, String> inputsEnv;
+    HashMap<String, String> inputsTerraform;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/ImportComands.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/ImportComands.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.Map;
+
 @ToString
 @Getter
 @Setter
@@ -11,4 +13,6 @@ public class ImportComands {
     String repository;
     String folder;
     String branch;
+    Map<String, String> inputsEnv;
+    Map<String, String> inputsTerraform;
 }

--- a/api/src/main/java/org/terrakube/api/repository/GlobalVarRepository.java
+++ b/api/src/main/java/org/terrakube/api/repository/GlobalVarRepository.java
@@ -1,0 +1,13 @@
+package org.terrakube.api.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.terrakube.api.rs.Organization;
+import org.terrakube.api.rs.globalvar.Globalvar;
+import org.terrakube.api.rs.workspace.parameters.Category;
+
+import java.util.UUID;
+
+public interface GlobalVarRepository extends JpaRepository<Globalvar, UUID> {
+
+    Globalvar getGlobalvarByOrganizationAndCategoryAndKey(Organization organization, Category category, String key);
+}


### PR DESCRIPTION
Adding support to filter global variables used inside the templates

## Template Configuration

```yaml
flow:
  - type: "customScripts"
    step: 100
    inputsEnv:
      INPUT_IMPORT1: $IMPORT1
      INPUT_IMPORT2: $IMPORT2
    commands:
      - runtime: "BASH"
        priority: 100
        before: true
        script: |
          echo $INPUT_IMPORT1
          echo $INPUT_IMPORT2

```

> $IMPORT1 and $IMPORT2 will be added to the job context as env variable INPUT_IMPORT1 and INPUT_IMPORT2

## Global Variables Setup
![image](https://user-images.githubusercontent.com/4461895/225455685-4b060f97-e802-44df-97c2-dd5c2be06b7a.png)

## Running Workspace
![image](https://user-images.githubusercontent.com/4461895/225455661-d6b0143b-c758-4ea4-b511-e943183aeaba.png)

## Other configuration Options.
Import terraform variables
```yaml
flow:
  - type: "customScripts"
    step: 100
    inputsTerraform:
      INPUT_IMPORT1: $IMPORT1
      INPUT_IMPORT2: $IMPORT2
    commands:
      ....

```

Import when importing the template
```yaml
flow:
  - type: "terraformPlan"
    step: 100
    importComands:
      repository: "https://github.com/AzBuilder/terrakube-extensions"
      folder: "templates/terratag"
      branch: "import-template"
      inputsEnv:
        INPUT_IMPORT1: $IMPORT1
        INPUT_IMPORT2: $IMPORT2
      inputsTerraform:
        INPUT_IMPORT1: $IMPORT1
        INPUT_IMPORT2: $IMPORT2
  - type: "terraformApply"
    step: 200
```

## Import Precedence

workspace env variables > importComands env variables > Flow env variables
workspace terraform variables > importComands terraform variables > Flow terraform variables