### PR TITLE
Terraform init -migrate-state (Local Storage)

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -77,13 +77,10 @@ public class RemoteTfeController {
 
     @Transactional
     @PostMapping(produces = "application/vnd.api+json", path = "/workspaces/{workspaceId}/state-versions")
-    public ResponseEntity<String> createWorkspaceState(@PathVariable("workspaceId") String workspaceId, @RequestBody StateData stateData) {
+    public ResponseEntity<StateData> createWorkspaceState(@PathVariable("workspaceId") String workspaceId, @RequestBody StateData stateData) {
         log.info("Create State /remote/tfe/v2/ {}", workspaceId);
         log.info("Body: {}", stateData.toString());
-
-        remoteTfeService.createWorkspaceState(workspaceId, stateData);
-
-        return ResponseEntity.status(201).body("");
+        return ResponseEntity.of(Optional.of(remoteTfeService.createWorkspaceState(workspaceId, stateData)));
     }
 
     @Transactional

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -13,6 +13,7 @@ import org.terrakube.api.plugin.state.model.organization.OrganizationData;
 import org.terrakube.api.plugin.state.model.plan.PlanRunData;
 import org.terrakube.api.plugin.state.model.apply.ApplyRunData;
 import org.terrakube.api.plugin.state.model.runs.RunsData;
+import org.terrakube.api.plugin.state.model.state.StateData;
 import org.terrakube.api.plugin.state.model.workspace.WorkspaceData;
 import java.nio.charset.StandardCharsets;
 
@@ -76,27 +77,13 @@ public class RemoteTfeController {
 
     @Transactional
     @PostMapping(produces = "application/vnd.api+json", path = "/workspaces/{workspaceId}/state-versions")
-    public ResponseEntity<String> createWorkspaceState(@PathVariable("workspaceId") String workspaceId, @RequestBody String StateData) {
+    public ResponseEntity<String> createWorkspaceState(@PathVariable("workspaceId") String workspaceId, @RequestBody StateData stateData) {
         log.info("Create State /remote/tfe/v2/ {}", workspaceId);
-        log.info("Body: {}", StateData);
+        log.info("Body: {}", stateData.toString());
 
-        return ResponseEntity.ok("{\n" +
-        "    \"data\": {\n" +
-        "        \"id\": \"sv-DmoXecHePnNznaA4\",\n" +
-        "        \"type\": \"state-versions\",\n" +
-        "        \"attributes\": {\n" +
-        "            \"vcs-commit-sha\": null,\n" +
-        "            \"vcs-commit-url\": null,\n" +
-        "            \"created-at\": \"2018-07-12T20:32:01.490Z\",\n" +
-        "            \"hosted-state-download-url\": \"https://archivist.terraform.io/v1/object/f55b739b-ff03-4716-b436-726466b96dc4\",\n" +
-        "            \"hosted-json-state-download-url\": \"https://archivist.terraform.io/v1/object/4fde7951-93c0-4414-9a40-f3abc4bac490\",\n" +
-        "            \"serial\": 1\n" +
-        "        },\n" +
-        "        \"links\": {\n" +
-        "            \"self\": \"/api/v2/state-versions/sv-DmoXecHePnNznaA4\"\n" +
-        "        }\n" +
-        "    }\n" +
-        "}");
+        remoteTfeService.createWorkspaceState(workspaceId, stateData);
+
+        return ResponseEntity.status(201).body("");
     }
 
     @Transactional

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -42,6 +42,8 @@ import java.util.*;
 @Slf4j
 @Service
 public class RemoteTfeService {
+
+    private static final String GENERIC_STATE_PATH = "%s/tfstate/v1/organization/%s/workspace/%s/jobId/%s/step/%s/terraform.tfstate";
     private JobRepository jobRepository;
     private ContentRepository contentRepository;
     private OrganizationRepository organizationRepository;
@@ -54,15 +56,16 @@ public class RemoteTfeService {
     private StepRepository stepRepository;
 
     public RemoteTfeService(JobRepository jobRepository,
-            ContentRepository contentRepository,
-            OrganizationRepository organizationRepository,
-            WorkspaceRepository workspaceRepository,
-            HistoryRepository historyRepository,
-            TemplateRepository templateRepository,
-            ScheduleJobService scheduleJobService,
-            @Value("${org.terrakube.hostname}") String hostname,
-            StorageTypeService storageTypeService,
-            StepRepository stepRepository) {
+                            ContentRepository contentRepository,
+                            OrganizationRepository organizationRepository,
+                            WorkspaceRepository workspaceRepository,
+                            HistoryRepository historyRepository,
+                            TemplateRepository templateRepository,
+                            ScheduleJobService scheduleJobService,
+                            @Value("${org.terrakube.hostname}") String hostname,
+                            @Value("${org.terrakube.hostname}") String hostname,
+                            StorageTypeService storageTypeService,
+                            StepRepository stepRepository) {
         this.jobRepository = jobRepository;
         this.contentRepository = contentRepository;
         this.organizationRepository = organizationRepository;
@@ -244,10 +247,19 @@ public class RemoteTfeService {
 
     StateData createWorkspaceState(String workspaceId, StateData stateData) {
         Workspace workspace = workspaceRepository.getReferenceById(UUID.fromString(workspaceId));
+
+        byte[] decodedBytes = Base64.getUrlDecoder().decode(stateData.getData().getAttributes().get("state").toString());
+        String terraformState = new String(decodedBytes);
+
+        //upload state to backend storage
+        storageTypeService.uploadState(workspace.getOrganization().getId().toString(), workspace.getId().toString(), terraformState);
+
+        //create history
         History history = new History();
         UUID historyId = UUID.randomUUID();
         history.setId(historyId);
-        history.setOutput(stateData.getData().getAttributes().get("state").toString());
+        history.setOutput(terraformState);
+        history.setJobReference("0");
         history.setWorkspace(workspace);
         historyRepository.save(history);
 
@@ -259,10 +271,16 @@ public class RemoteTfeService {
         Map<String, Object> responseAttributes = new HashMap<>();
         responseAttributes.put("vcs-commit-sha", null);
         responseAttributes.put("vcs-commit-url", null);
-        responseAttributes.put("hosted-state-download-url",
-                "https://archivist.terraform.io/v1/object/4fde7951-93c0-4414-9a40-f3abc4bac490");
-        responseAttributes.put("hosted-json-state-download-url",
-                "https://archivist.terraform.io/v1/object/4fde7951-93c0-4414-9a40-f3abc4bac490");
+        responseAttributes.put("hosted-state-download-url", String
+                .format("https://%s/tfstate/v1/organization/%s/workspace/%s/state/terraform.tfstate",
+                        hostname,
+                        workspace.getOrganization().getId().toString(),
+                        workspace.getId().toString()));
+        responseAttributes.put("hosted-json-state-download-url", String
+                .format("https://%s/tfstate/v1/organization/%s/workspace/%s/state/terraform.tfstate",
+                        hostname,
+                        workspace.getOrganization().getId().toString(),
+                        workspace.getId().toString()));
         responseAttributes.put("serial", 1);
         response.getData().setAttributes(responseAttributes);
         return response;

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -63,7 +63,6 @@ public class RemoteTfeService {
                             TemplateRepository templateRepository,
                             ScheduleJobService scheduleJobService,
                             @Value("${org.terrakube.hostname}") String hostname,
-                            @Value("${org.terrakube.hostname}") String hostname,
                             StorageTypeService storageTypeService,
                             StepRepository stepRepository) {
         this.jobRepository = jobRepository;
@@ -258,7 +257,7 @@ public class RemoteTfeService {
         History history = new History();
         UUID historyId = UUID.randomUUID();
         history.setId(historyId);
-        history.setOutput(terraformState);
+        //history.setOutput(terraformState);
         history.setJobReference("0");
         history.setWorkspace(workspace);
         historyRepository.save(history);

--- a/api/src/main/java/org/terrakube/api/plugin/storage/StorageTypeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/StorageTypeService.java
@@ -10,6 +10,8 @@ public interface StorageTypeService {
 
     byte[] getTerraformStateJson(String organizationId, String workspaceId, String stateFileName);
 
+    void uploadState(String organizationId, String workspaceId, String terraformState);
+
     String saveContext(int jobId, String jobContext);
 
     String getContext(int jobId);

--- a/api/src/main/java/org/terrakube/api/plugin/storage/aws/AwsStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/aws/AwsStorageTypeServiceImpl.java
@@ -82,6 +82,11 @@ public class AwsStorageTypeServiceImpl implements StorageTypeService {
     }
 
     @Override
+    public void uploadState(String organizationId, String workspaceId, String terraformState) {
+
+    }
+
+    @Override
     public String saveContext(int jobId, String jobContext) {
         String blobKey = String.format(CONTEXT_JSON, jobId);
         log.info("context file: {}", String.format(CONTEXT_JSON, jobId));

--- a/api/src/main/java/org/terrakube/api/plugin/storage/azure/AzureStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/azure/AzureStorageTypeServiceImpl.java
@@ -50,6 +50,11 @@ public class AzureStorageTypeServiceImpl implements StorageTypeService {
     }
 
     @Override
+    public void uploadState(String organizationId, String workspaceId, String terraformState) {
+
+    }
+
+    @Override
     public String saveContext(int jobId, String jobContext) {
         BlobContainerClient contextContainerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME_OUTPUT);
 

--- a/api/src/main/java/org/terrakube/api/plugin/storage/controller/TerraformStateController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/controller/TerraformStateController.java
@@ -27,4 +27,12 @@ public class TerraformStateController {
     public @ResponseBody byte[] getTerraformStateJson(@PathVariable("organizationId") String organizationId, @PathVariable("workspaceId") String workspaceId, @PathVariable("stateFilename") String stateFilename) {
         return storageTypeService.getTerraformStateJson(organizationId, workspaceId, stateFilename);
     }
+
+    @GetMapping(
+            value = "/organization/{organizationId}/workspace/{workspaceId}/state/terraform.tfstate",
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public @ResponseBody byte[] getTerraformState(@PathVariable("organizationId") String organizationId, @PathVariable("workspaceId") String workspaceId, @PathVariable("stateFilename") String stateFilename) {
+        return storageTypeService.getTerraformStateJson(organizationId, workspaceId, stateFilename);
+    }
 }

--- a/api/src/main/java/org/terrakube/api/plugin/storage/gcp/GcpStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/gcp/GcpStorageTypeServiceImpl.java
@@ -66,6 +66,11 @@ public class GcpStorageTypeServiceImpl implements StorageTypeService {
     }
 
     @Override
+    public void uploadState(String organizationId, String workspaceId, String terraformState) {
+
+    }
+
+    @Override
     public String saveContext(int jobId, String jobContext) {
         String blobKey = String.format(CONTEXT_JSON, jobId);
         log.info("context file: {}", blobKey);

--- a/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
@@ -17,13 +17,13 @@ import java.nio.charset.StandardCharsets;
 public class LocalStorageTypeServiceImpl implements StorageTypeService {
 
     private static final String OUTPUT_DIRECTORY = "/.terraform-spring-boot/local/output/%s/%s/%s.tfoutput";
-
     private static final String CONTENT_DIRECTORY = "/.terraform-spring-boot/local/content/%s/terraformContent.tar.gz";
     private static final String CONTEXT_DIRECTORY = "/.terraform-spring-boot/local/output/context/%s/context.json";
     private static final String STATE_DIRECTORY = "/.terraform-spring-boot/local/state/%s/%s/%s/%s/terraformLibrary.tfPlan";
     private static final String STATE_DIRECTORY_JSON = "/.terraform-spring-boot/local/state/%s/%s/state/%s.json";
     private static final String NO_DATA_FOUND = "";
     private static final String NO_CONTEXT_FOUND = "{}";
+    private static final String LOCAL_BACKEND_DIRECTORY = "/.terraform-spring-boot/local/backend/%s/%s/terraform.tfstate";
 
     @Override
     public byte[] getStepOutput(String organizationId, String jobId, String stepId) {
@@ -44,6 +44,19 @@ public class LocalStorageTypeServiceImpl implements StorageTypeService {
         log.info("Searching: /.terraform-spring-boot/local/tfstate/{}/{}/state/{}.json", organizationId, workspaceId, stateFileName);
         String outputFilePath = String.format(STATE_DIRECTORY_JSON, organizationId, workspaceId, stateFileName);
         return getOutputBytes(outputFilePath);
+    }
+
+    @Override
+    public void uploadState(String organizationId, String workspaceId, String terraformState) {
+        try {
+            String newStateFile = String.format(LOCAL_BACKEND_DIRECTORY, organizationId, workspaceId);
+            log.info("newFilename: {}", newStateFile);
+            File stateFile = new File(FileUtils.getUserDirectoryPath().concat(FilenameUtils.separatorsToSystem(newStateFile)));
+            FileUtils.forceMkdir(stateFile.getParentFile());
+            FileUtils.writeStringToFile(stateFile, terraformState, Charset.defaultCharset().toString());
+        } catch (IOException e) {
+            log.error(e.getMessage());
+        }
     }
 
     @Override

--- a/executor/src/main/java/org/terrakube/executor/plugin/tfstate/local/LocalTerraformStateImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/plugin/tfstate/local/LocalTerraformStateImpl.java
@@ -31,11 +31,10 @@ import org.terrakube.executor.service.mode.TerraformJob;
 public class LocalTerraformStateImpl implements TerraformState {
 
     private static final String TERRAFORM_PLAN_FILE = "terraformLibrary.tfPlan";
-    private static final String LOCAL_BACKEND_DIRECTORY = "/.terraform-spring-boot/local/backend/%s/%s/"
-            + TERRAFORM_PLAN_FILE;
-    private static final String LOCAL_STATE_DIRECTORY = "/.terraform-spring-boot/local/state/%s/%s/%s/%s/"
-            + TERRAFORM_PLAN_FILE;
-    private static final String LOCAL_STATE_DIRECTORY_JSON = "/.terraform-spring-boot/local/state/%s/%s/state/%s.json";
+    private static final String TERRAFORM_STATE_FILE = "terraform.tfstate";
+    private static final String LOCAL_BACKEND_DIRECTORY = "/.terraform-spring-boot/local/backend/%s/%s/" + TERRAFORM_STATE_FILE;
+    private static final String LOCAL_PLAN_DIRECTORY = "/.terraform-spring-boot/local/state/%s/%s/%s/%s/" + TERRAFORM_PLAN_FILE;
+    private static final String LOCAL_PLAN_DIRECTORY_JSON = "/.terraform-spring-boot/local/state/%s/%s/state/%s.json";
     private static final String BACKEND_FILE_NAME = "terrakube_override.tf";
 
     @NonNull
@@ -75,9 +74,9 @@ public class LocalTerraformStateImpl implements TerraformState {
 
     @Override
     public String saveTerraformPlan(String organizationId, String workspaceId, String jobId, String stepId,
-            File workingDirectory) {
+                                    File workingDirectory) {
 
-        String localStateFilePath = String.format(LOCAL_STATE_DIRECTORY, organizationId, workspaceId, jobId, stepId);
+        String localStateFilePath = String.format(LOCAL_PLAN_DIRECTORY, organizationId, workspaceId, jobId, stepId);
 
         String stepStateDirectory = FileUtils.getUserDirectoryPath().concat(
                 FilenameUtils.separatorsToSystem(
@@ -103,10 +102,10 @@ public class LocalTerraformStateImpl implements TerraformState {
 
     @Override
     public boolean downloadTerraformPlan(String organizationId, String workspaceId, String jobId, String stepId,
-            File workingDirectory) {
+                                         File workingDirectory) {
         AtomicBoolean planExists = new AtomicBoolean(false);
         Optional.ofNullable(
-                terrakubeClient.getJobById(organizationId, jobId).getData().getAttributes().getTerraformPlan())
+                        terrakubeClient.getJobById(organizationId, jobId).getData().getAttributes().getTerraformPlan())
                 .ifPresent(stateFilePath -> {
                     try {
                         log.info("Copying state from {}:", stateFilePath);
@@ -129,7 +128,7 @@ public class LocalTerraformStateImpl implements TerraformState {
     public void saveStateJson(TerraformJob terraformJob, String applyJSON) {
         if (applyJSON != null) {
             String stateFilenameUUID = UUID.randomUUID().toString();
-            String stateFileName = String.format(LOCAL_STATE_DIRECTORY_JSON, terraformJob.getOrganizationId(),
+            String stateFileName = String.format(LOCAL_PLAN_DIRECTORY_JSON, terraformJob.getOrganizationId(),
                     terraformJob.getWorkspaceId(), stateFilenameUUID);
             log.info("terraformStateFile: {}", stateFileName);
 


### PR DESCRIPTION
Adding support to migrate the state to terrakube using 

```bash
terraform init -migrate-state
```

This is usefull for migrating the state from other storage backends like terraform cloud

Initial setup
```terraform
terraform {
  backend "remote" {
    hostname = "app.terraform.io"
    organization = "XXXXXX"

    workspaces {
      name = "migrate-state"
    }
  }
}
```

When running the flag "-migrate-state"
```terraform
terraform {
  backend "remote" {
    hostname = "8080-azbuilder-terrakube-q8aleg88vlc.ws-us94.gitpod.io"
    organization = "XXXXXX"

    workspaces {
      name = "migrate-state"
    }
  }
}
```

The state from terraform was copied to the local storage backend