### PR TITLE
Import sh files from workspace

### DIFF
--- a/executor/src/main/java/org/terrakube/executor/service/scripts/bash/BashEngine.java
+++ b/executor/src/main/java/org/terrakube/executor/service/scripts/bash/BashEngine.java
@@ -117,6 +117,14 @@ public class BashEngine implements CommandExecution {
                 .map(bash -> bash.getParentFile().getAbsolutePath())
                 .collect(Collectors.joining(":"));
 
+        // Loading Bash scripts from working directory if the terraform module has some sh files
+        Collection<File> bashToolsWorkspace = FileUtils.listFiles(workingDirectory, new String[]{"sh"}, true);
+        bashToolsWorkspace.stream().forEach(bash -> bash.setExecutable(true));
+
+        String bashToolsWorkspacePath = bashToolsWorkspace.stream()
+                .map(bash -> bash.getParentFile().getAbsolutePath())
+                .collect(Collectors.joining(":"));
+
         String externalToolsCompletePath = "";
 
         // Search all external tools inside folder /.terrakube/tools
@@ -136,7 +144,7 @@ public class BashEngine implements CommandExecution {
             .collect(Collectors.joining(":"));
         }
 
-        bashToolsCompletePath = String.join(":", externalToolsCompletePath, bashToolsCompletePath);
+        bashToolsCompletePath = String.join(":", externalToolsCompletePath, bashToolsCompletePath, bashToolsWorkspacePath);
         return bashToolsCompletePath;
     }
 

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -52,6 +52,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             HashMap<String, String> terraformParametersPlan = getWorkspaceParameters(terraformJob.getVariables());
             HashMap<String, String> environmentVariablesPlan = getWorkspaceParameters(terraformJob.getEnvironmentVariables());
 
+            environmentVariablesPlan.put("GIT_SSH_COMMAND", "ssh -i ~/.ssh/id_rsa");
+
             Consumer<String> planOutput = LogsConsumer.builder()
                     .jobId(Integer.valueOf(terraformJob.getJobId()))
                     .terraformOutput(jobOutput)

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -52,8 +52,6 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             HashMap<String, String> terraformParametersPlan = getWorkspaceParameters(terraformJob.getVariables());
             HashMap<String, String> environmentVariablesPlan = getWorkspaceParameters(terraformJob.getEnvironmentVariables());
 
-            environmentVariablesPlan.put("GIT_SSH_COMMAND", "ssh -i ~/.ssh/id_rsa");
-
             Consumer<String> planOutput = LogsConsumer.builder()
                     .jobId(Integer.valueOf(terraformJob.getJobId()))
                     .terraformOutput(jobOutput)


### PR DESCRIPTION
Adding support to import sh files that are inside the workspace. Currently Terrakube only support to load the sh files from the extension repository


Example:
```yaml
flow:
  - type: "terraformPlan"
    name: "Plan"
    step: 100
  - type: "customScripts"
    step: 200
    commands:
      - runtime: "BASH"
        priority: 200
        before: true
        script: |
          helloWorldTerrakube.sh
          helloWorld.sh

```

Repository with SH files (helloWorldTerrakube.sh):
https://github.com/AzBuilder/terrakube-docker-compose

Repository with SH File(helloWorld.sh)
https://github.com/AzBuilder/terrakube-extensions/tree/main/bash/helloWorld

![image](https://github.com/AzBuilder/terrakube/assets/4461895/ad514ebf-a6f9-403f-a7c1-4e5a2f3a446f)
