### PR TITLE
Fix untar issue with private registry

### DIFF
--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -133,6 +133,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
             while ((entry = (TarArchiveEntry) tarIn.getNextEntry()) != null) {
                 if (entry.isDirectory()) {
                     File f = new File(String.format("%s/%s", destinationFilePath, entry.getName()));
+                    log.info("Creating folder: {}", f.getCanonicalPath());
                     String canonicalDestinationPath = f.getCanonicalPath();
 
                     if( !canonicalDestinationPath.startsWith(destinationFilePath)){
@@ -151,6 +152,10 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
 
                     if( !canonicalDestinationPath.startsWith(destinationFilePath)){
                         throw new IOException("Entry is outside of the target directory");
+                    }
+                    if (!f.exists()) {
+                        f.getParentFile().mkdirs();
+                        f.createNewFile();
                     }
                     FileOutputStream fos = new FileOutputStream(f.getCanonicalPath(), false);
                     log.info("Adding file {} to workspace context", destinationFilePath + "/" + entry.getName());


### PR DESCRIPTION
The untar is failing when using terraform remote backend with modules from the private registry

Define credentials as Global Variables
![image](https://github.com/AzBuilder/terrakube/assets/4461895/32965a5d-8a0e-411f-a048-9fb5b2af62e6)

```bash
terraform login 8080-azbuilder-terrakube-sscrnu9jbie.ws-us98.gitpod.io //login for the remote state backend
terraform login 8075-azbuilder-terrakube-sscrnu9jbie.ws-us98.gitpod.io //login to download modules from private registry
terraform init
terraform plan
terraform apply
terraform destroy
```

Terraform backend configuratoin
```terraform
terraform {
  backend "remote" {
    hostname = "8080-azbuilder-terrakube-sscrnu9jbie.ws-us98.gitpod.io"
    organization = "simple"

    workspaces {
      name = "test-registry"
    }
  }
}
```

Terraform modules from the private registry
```terraform
module "network" { 
  source = "8075-azbuilder-terrakube-sscrnu9jtfe.ws-us98.gitpod.io/gcp/network/google" 
  version = "v7.0.0" 

  project_id   = "playground-s-11-223ebb0d"
  network_name = "example-vpc"
  routing_mode = "GLOBAL"

    subnets = [
        {
            subnet_name           = "subnet-01"
            subnet_ip             = "10.10.10.0/24"
            subnet_region         = "us-east1"
        },
        {
            subnet_name           = "subnet-02"
            subnet_ip             = "10.10.20.0/24"
            subnet_region         = "us-east1"
            subnet_private_access = "true"
            subnet_flow_logs      = "true"
            description           = "This subnet has a description"
        },
        {
            subnet_name               = "subnet-03"
            subnet_ip                 = "10.10.30.0/24"
            subnet_region             = "us-east1"
            subnet_flow_logs          = "true"
            subnet_flow_logs_interval = "INTERVAL_10_MIN"
            subnet_flow_logs_sampling = 0.7
            subnet_flow_logs_metadata = "INCLUDE_ALL_METADATA"
        }
    ]

    secondary_ranges = {
        subnet-01 = [
            {
                range_name    = "subnet-01-secondary-01"
                ip_cidr_range = "192.168.64.0/24"
            },
        ]

        subnet-02 = []
    }

    routes = [
        {
            name                   = "egress-internet"
            description            = "route through IGW to access internet"
            destination_range      = "0.0.0.0/0"
            tags                   = "egress-inet"
            next_hop_internet      = "true"
        } 
    ]
}

```

Running example
![image](https://github.com/AzBuilder/terrakube/assets/4461895/04787163-6e2d-42e0-822d-9081fb6e336a)

