### PR TITLE
Support Cloud Block (Terraform Init)

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -1,6 +1,5 @@
 package org.terrakube.api.plugin.state;
 
-import com.amazonaws.Response;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.SchedulerException;
@@ -45,7 +44,7 @@ public class RemoteTfeController {
         HttpHeaders responseHeaders = new HttpHeaders();
         responseHeaders.set("TFP-API-Version", "2.5");
         responseHeaders.set("TFP-AppName", "Terrakube");
-        ResponseEntity response = new ResponseEntity<>(responseHeaders, HttpStatus.NOT_FOUND);
+        ResponseEntity response = new ResponseEntity<>(responseHeaders, HttpStatus.NO_CONTENT);
         return response;
     }
 

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -1,8 +1,11 @@
 package org.terrakube.api.plugin.state;
 
+import com.amazonaws.Response;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.SchedulerException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +38,15 @@ public class RemoteTfeController {
     @GetMapping(produces = "application/vnd.api+json", path = "organizations/{organizationName}/entitlement-set")
     public ResponseEntity<EntitlementData> getOrgEntitlementSet(@PathVariable("organizationName") String organizationName) {
         return ResponseEntity.of(Optional.ofNullable(remoteTfeService.getOrgEntitlementSet(organizationName)));
+    }
+
+    @GetMapping(produces = "application/vnd.api+json", path = "ping")
+    public ResponseEntity<String> ping() {
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.set("TFP-API-Version", "2.5");
+        responseHeaders.set("TFP-AppName", "Terrakube");
+        ResponseEntity response = new ResponseEntity<>(responseHeaders, HttpStatus.NOT_FOUND);
+        return response;
     }
 
     @GetMapping(produces = "application/vnd.api+json", path = "organizations/{organizationName}")

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -217,8 +217,14 @@ public class RemoteTfeService {
             Workspace newWorkspace = new Workspace();
             newWorkspace.setId(UUID.randomUUID());
             newWorkspace.setName(workspaceData.getData().getAttributes().get("name").toString());
-            newWorkspace
-                    .setTerraformVersion(workspaceData.getData().getAttributes().get("terraform-version").toString());
+            String terraformVersion = "";
+            if(workspaceData.getData().getAttributes().get("terraform-version") != null){
+                terraformVersion = workspaceData.getData().getAttributes().get("terraform-version").toString();
+            } else {
+                terraformVersion = "1.4.6";
+                log.warn("Using default terraform version: {}", terraformVersion);
+            }
+            newWorkspace.setTerraformVersion(terraformVersion);
             newWorkspace.setSource("empty");
             newWorkspace.setBranch("remote-content");
             newWorkspace.setOrganization(organization);

--- a/api/src/main/java/org/terrakube/api/plugin/state/WellKnownWebServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/WellKnownWebServiceImpl.java
@@ -19,6 +19,7 @@ public class WellKnownWebServiceImpl {
             "    \"ports\": [10000, 10001]\n" +
             "    }, \n" +
             "  \"state.v2\": \"/remote/state/v2/\"\n," +
+            "  \"tfe.v2\": \"/remote/tfe/v2/\"\n," +
             "  \"tfe.v2.1\": \"/remote/tfe/v2/\"\n" +
             "}";
 

--- a/scripts/setupDevelopmentEnvironmentMinio.sh
+++ b/scripts/setupDevelopmentEnvironmentMinio.sh
@@ -54,6 +54,9 @@ function generateApiVars(){
   echo "spring_profiles_active=demo" >> .envApi
   echo "DexClientId=$DexClientId" >> .envApi
   echo "CustomTerraformReleasesUrl=\"https://releases.hashicorp.com/terraform/index.json\"" >> .envApi
+  echo "TerrakubeRedisHostname=localhost" >> .envApi
+  echo "TerrakubeRedisPort=6379" >> .envApi
+  echo "TerrakubeRedisPassword=password123456" >> .envApi
   echo "#TERRAKUBE_ADMIN_GROUP=$TERRAKUBE_ADMIN_GROUP" >> .envApi
 }
 
@@ -124,6 +127,9 @@ function generateExecutorVars(){
   echo "TerrakubeRegistryDomain=$TerrakubeRegistryDomain" >> .envExecutor
   echo "TerrakubeApiUrl=$TerrakubeApiUrl" >> .envExecutor
   echo "CustomTerraformReleasesUrl=\"https://releases.hashicorp.com/terraform/index.json\"" >> .envExecutor
+  echo "TerrakubeRedisHostname=localhost" >> .envExecutor
+  echo "TerrakubeRedisPort=6379" >> .envExecutor
+  echo "TerrakubeRedisPassword=password123456" >> .envExecutor
   echo "#JAVA_TOOL_OPTIONS=\"$JAVA_TOOL_OPTIONS\"" >> .envExecutor
 }
 


### PR DESCRIPTION
Adding support to use terraform init with the cloud block like the following example:

```terraform
terraform {
  cloud {
    organization = "simple"
    hostname = "8080-azbuilder-terrakube-sscrnu9jbie.ws-us99.gitpod.io"

    workspaces {
      name = "samplecloud"
    }
  }
}
```

> By default the terraform CLI does not send the terraform version while creating the workspace, by default terrakube will set 1.4.6.