### PR TITLE
Support Cloud Block (Terraform Plan/Apply/Destroy)

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -127,7 +127,7 @@ public class RemoteTfeController {
 
     @Transactional
     @GetMapping (produces = "application/vnd.api+json", path = "/runs/{runId}")
-    public ResponseEntity<RunsData> getRun(@PathVariable("runId") int runId,@RequestParam(name = "include") String include) {
+    public ResponseEntity<RunsData> getRun(@PathVariable("runId") int runId,@RequestParam(name = "include", required = false) String include) {
         return ResponseEntity.ok(remoteTfeService.getRun(runId, include));
     }
 

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -1,5 +1,6 @@
 package org.terrakube.api.plugin.state;
 
+import com.amazonaws.Response;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.SchedulerException;
@@ -44,7 +45,7 @@ public class RemoteTfeController {
         HttpHeaders responseHeaders = new HttpHeaders();
         responseHeaders.set("TFP-API-Version", "2.5");
         responseHeaders.set("TFP-AppName", "Terrakube");
-        ResponseEntity response = new ResponseEntity<>(responseHeaders, HttpStatus.NO_CONTENT);
+        ResponseEntity response = new ResponseEntity<>(responseHeaders, HttpStatus.NOT_FOUND);
         return response;
     }
 
@@ -126,8 +127,8 @@ public class RemoteTfeController {
 
     @Transactional
     @GetMapping (produces = "application/vnd.api+json", path = "/runs/{runId}")
-    public ResponseEntity<RunsData> getRun(@PathVariable("runId") int runId) {
-        return ResponseEntity.ok(remoteTfeService.getRun(runId));
+    public ResponseEntity<RunsData> getRun(@PathVariable("runId") int runId,@RequestParam(name = "include") String include) {
+        return ResponseEntity.ok(remoteTfeService.getRun(runId, include));
     }
 
     @Transactional

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -451,7 +451,14 @@ public class RemoteTfeService {
         workspaceModel.setData(new Resource());
         relationships.setWorkspace(workspaceModel);
 
+        runsData.setIncluded(new ArrayList());
+
+        if(include.equals("workspace")){
+            runsData.getIncluded().add(getWorkspace(job.getOrganization().getName(), job.getWorkspace().getName(), new HashMap<>()));
+        }
+        
         runsData.getData().setRelationships(relationships);
+        
         log.info("{}", runsData.toString());
         return runsData;
     }

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -190,7 +190,7 @@ public class RemoteTfeService {
             defaultAttributes.put("can-update-variable", true);
             defaultAttributes.put("can-read-assessment-result", true);
             defaultAttributes.put("can-force-delete", true);
-            defaultAttributes.put("structured-run-output-enabled", true);
+            //defaultAttributes.put("structured-run-output-enabled", true);
 
 
             attributes.put("permissions", defaultAttributes);
@@ -455,13 +455,15 @@ public class RemoteTfeService {
 
         org.terrakube.api.plugin.state.model.runs.WorkspaceModel workspaceModel = new org.terrakube.api.plugin.state.model.runs.WorkspaceModel();
         workspaceModel.setData(new Resource());
+        workspaceModel.getData().setId(job.getWorkspace().getId().toString());
+        workspaceModel.getData().setType("workspaces");
         relationships.setWorkspace(workspaceModel);
 
-        runsData.setIncluded(new ArrayList());
-
-        if(include.equals("workspace")){
-            runsData.getIncluded().add(getWorkspace(job.getOrganization().getName(), job.getWorkspace().getName(), new HashMap<>()));
-        }
+        log.info("Included: {}", include);
+        //if(include != null && include.equals("workspace")){
+        //    runsData.setIncluded(new ArrayList());
+        //    runsData.getIncluded().add(getWorkspace(job.getOrganization().getName(), job.getWorkspace().getName(), new HashMap<>()));
+        //}
         
         runsData.getData().setRelationships(relationships);
         

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -190,6 +190,8 @@ public class RemoteTfeService {
             defaultAttributes.put("can-update-variable", true);
             defaultAttributes.put("can-read-assessment-result", true);
             defaultAttributes.put("can-force-delete", true);
+            defaultAttributes.put("structured-run-output-enabled", true);
+
 
             attributes.put("permissions", defaultAttributes);
 

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -219,8 +219,14 @@ public class RemoteTfeService {
             Workspace newWorkspace = new Workspace();
             newWorkspace.setId(UUID.randomUUID());
             newWorkspace.setName(workspaceData.getData().getAttributes().get("name").toString());
-            newWorkspace
-                    .setTerraformVersion(workspaceData.getData().getAttributes().get("terraform-version").toString());
+            String terraformVersion = "";
+            if(workspaceData.getData().getAttributes().get("terraform-version") != null){
+                terraformVersion = workspaceData.getData().getAttributes().get("terraform-version").toString();
+            } else {
+                terraformVersion = "1.4.6";
+                log.warn("Using default terraform version: {}", terraformVersion);
+            }
+            newWorkspace.setTerraformVersion(terraformVersion);
             newWorkspace.setSource("empty");
             newWorkspace.setBranch("remote-content");
             newWorkspace.setOrganization(organization);

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -217,14 +217,8 @@ public class RemoteTfeService {
             Workspace newWorkspace = new Workspace();
             newWorkspace.setId(UUID.randomUUID());
             newWorkspace.setName(workspaceData.getData().getAttributes().get("name").toString());
-            String terraformVersion = "";
-            if(workspaceData.getData().getAttributes().get("terraform-version") != null){
-                terraformVersion = workspaceData.getData().getAttributes().get("terraform-version").toString();
-            } else {
-                terraformVersion = "1.4.6";
-                log.warn("Using default terraform version: {}", terraformVersion);
-            }
-            newWorkspace.setTerraformVersion(terraformVersion);
+            newWorkspace
+                    .setTerraformVersion(workspaceData.getData().getAttributes().get("terraform-version").toString());
             newWorkspace.setSource("empty");
             newWorkspace.setBranch("remote-content");
             newWorkspace.setOrganization(organization);
@@ -382,7 +376,7 @@ public class RemoteTfeService {
         log.info("Job Created");
         scheduleJobService.createJobContext(job);
         log.info("Job Context Created");
-        return getRun(job.getId());
+        return getRun(job.getId(), null);
     }
 
     private String getTemplateName(String configurationId, boolean isDestroy) {
@@ -398,7 +392,7 @@ public class RemoteTfeService {
         }
     }
 
-    RunsData getRun(int runId) {
+    RunsData getRun(int runId, String include) {
         log.info("Searching Run {}", runId);
         RunsData runsData = new RunsData();
         RunsModel runsModel = new RunsModel();
@@ -408,27 +402,7 @@ public class RemoteTfeService {
 
         String planStatus = "running";
         Job job = jobRepository.getReferenceById(Integer.valueOf(runId));
-        /*
-         * if (job.getStep() != null && !job.getStep().isEmpty()) {
-         * List<Step> stepList = job.getStep();
-         * for (Step step : stepList) {
-         * if (step.getStepNumber() == 100) {
-         * switch (step.getStatus()) {
-         * case completed:
-         * planStatus = "finished";
-         * break;
-         * case running:
-         * case queue:
-         * planStatus = "running";
-         * break;
-         * case failed:
-         * planStatus = "errored";
-         * break;
-         * }
-         * }
-         * }
-         * }
-         */
+
         switch (job.getStatus()) {
             case completed:
                 planStatus = "finished";
@@ -471,6 +445,10 @@ public class RemoteTfeService {
         applyModel.getData().setId(String.valueOf(runId));
         relationships.setApply(applyModel);
 
+        org.terrakube.api.plugin.state.model.runs.WorkspaceModel workspaceModel = new org.terrakube.api.plugin.state.model.runs.WorkspaceModel();
+        workspaceModel.setData(new Resource());
+        relationships.setWorkspace(workspaceModel);
+
         runsData.getData().setRelationships(relationships);
         log.info("{}", runsData.toString());
         return runsData;
@@ -491,7 +469,7 @@ public class RemoteTfeService {
                 }
             }
         }
-        return getRun(runId);
+        return getRun(runId, null);
     }
 
     RunsData runDiscard(int runId) {
@@ -504,7 +482,7 @@ public class RemoteTfeService {
         } catch (ParseException | SchedulerException e) {
             throw new RuntimeException(e);
         }
-        return getRun(runId);
+        return getRun(runId, null);
     }
 
     PlanRunData getPlan(int planId) {

--- a/api/src/main/java/org/terrakube/api/plugin/state/model/runs/RunsData.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/model/runs/RunsData.java
@@ -4,9 +4,12 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.List;
+
 @Getter
 @Setter
 @ToString
 public class RunsData {
     RunsModel data;
+    List included;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/state/model/runs/RunsData.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/model/runs/RunsData.java
@@ -1,5 +1,6 @@
 package org.terrakube.api.plugin.state.model.runs;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -11,5 +12,6 @@ import java.util.List;
 @ToString
 public class RunsData {
     RunsModel data;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     List included;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/state/model/runs/WorkspaceModel.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/model/runs/WorkspaceModel.java
@@ -4,6 +4,9 @@ import lombok.Getter;
 import lombok.Setter;
 import org.terrakube.api.plugin.state.model.generic.Resource;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Getter
 @Setter
 public class WorkspaceModel {

--- a/api/src/main/java/org/terrakube/api/plugin/state/model/runs/WorkspaceModel.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/model/runs/WorkspaceModel.java
@@ -4,9 +4,6 @@ import lombok.Getter;
 import lombok.Setter;
 import org.terrakube.api.plugin.state.model.generic.Resource;
 
-import java.util.HashMap;
-import java.util.Map;
-
 @Getter
 @Setter
 public class WorkspaceModel {

--- a/thunder-tests/thunderCollection.json
+++ b/thunder-tests/thunderCollection.json
@@ -228,6 +228,13 @@
         "containerId": "",
         "created": "2022-12-19T20:35:56.077Z",
         "sortNum": 132497.5
+      },
+      {
+        "_id": "d1bb220a-b9b1-4ca5-a767-07eb6e29f872",
+        "name": "cloud",
+        "containerId": "05bfce07-b1e7-4742-85b0-b0ac6dad7cc6",
+        "created": "2023-06-08T22:44:33.583Z",
+        "sortNum": 310000
       }
     ],
     "settings": {

--- a/thunder-tests/thunderclient.json
+++ b/thunder-tests/thunderclient.json
@@ -2570,5 +2570,41 @@
       "bearer": "{{access_token}}"
     },
     "tests": []
+  },
+  {
+    "_id": "09d0577b-3ebf-4b8b-8920-f9e86b8beeda",
+    "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
+    "containerId": "d1bb220a-b9b1-4ca5-a767-07eb6e29f872",
+    "name": "ping",
+    "url": "{{terrakubeApi}}/remote/tfe/v2/ping",
+    "method": "GET",
+    "sortNum": 840000,
+    "created": "2023-06-08T22:44:50.795Z",
+    "modified": "2023-06-08T23:37:47.004Z",
+    "headers": [],
+    "params": [],
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
+  },
+  {
+    "_id": "591f54e4-48ef-47e9-908c-7b3133ff7244",
+    "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
+    "containerId": "d1bb220a-b9b1-4ca5-a767-07eb6e29f872",
+    "name": "terraform.json",
+    "url": "{{terrakubeApi}}/.well-known/terraform.json",
+    "method": "GET",
+    "sortNum": 420000,
+    "created": "2023-06-08T23:17:02.253Z",
+    "modified": "2023-06-08T23:26:53.792Z",
+    "headers": [],
+    "params": [],
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
   }
 ]

--- a/thunder-tests/thunderclient.json
+++ b/thunder-tests/thunderclient.json
@@ -2606,5 +2606,40 @@
       "bearer": "{{access_token}}"
     },
     "tests": []
+  },
+  {
+    "_id": "8b8abb72-6aba-49b4-b0f5-10045b9cc363",
+    "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
+    "containerId": "d1bb220a-b9b1-4ca5-a767-07eb6e29f872",
+    "name": "ping Copy",
+    "url": "{{terrakubeApi}}/remote/tfe/v2/runs/1?include=workspaces",
+    "method": "GET",
+    "sortNum": 850000,
+    "created": "2023-06-14T23:02:33.685Z",
+    "modified": "2023-06-14T23:50:13.461Z",
+    "headers": [
+      {
+        "name": "Accept",
+        "value": "*/*",
+        "isDisabled": true
+      },
+      {
+        "name": "User-Agent",
+        "value": "Thunder Client (https://www.thunderclient.com)",
+        "isDisabled": true
+      }
+    ],
+    "params": [
+      {
+        "name": "include",
+        "value": "workspaces",
+        "isPath": false
+      }
+    ],
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
   }
 ]


### PR DESCRIPTION
Adding support to use terraform plan/apply/destroy with the cloud block like the following example:

```terraform
terraform {
  cloud {
    organization = "simple"
    hostname = "8080-azbuilder-terrakube-sscrnu9jbie.ws-us99.gitpod.io"

    workspaces {
      name = "samplecloud"
    }
  }
}
```

> By default the terraform CLI does not send the terraform version while creating the workspace, by default terrakube will set 1.4.6.