### PR TITLE
Cloud Block  set terraform version

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -72,6 +72,18 @@ public class RemoteTfeController {
         }
     }
 
+    @PatchMapping(produces = "application/vnd.api+json", path = "workspaces/{workspacesId}")
+    public ResponseEntity<WorkspaceData> updateWorkspace(@PathVariable("workspacesId") String workspacesId, @RequestBody WorkspaceData workspaceData) {
+        log.info("Create {}", workspaceData.toString());
+        Optional<WorkspaceData> updatedWorkspace = Optional.ofNullable(remoteTfeService.updateWorkspace(workspacesId, workspaceData));
+        if(updatedWorkspace.isPresent()){
+            log.info("Created: {}", updatedWorkspace.get().toString());
+            return ResponseEntity.status(201).body(updatedWorkspace.get());
+        }else{
+            return ResponseEntity.status(500).body(new WorkspaceData());
+        }
+    }
+
     @Transactional
     @PostMapping(produces = "application/vnd.api+json", path = "/workspaces/{workspaceId}/actions/lock")
     public ResponseEntity<WorkspaceData> lockWorkspace(@PathVariable("workspaceId") String workspaceId) {

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -72,6 +72,7 @@ public class RemoteTfeController {
         }
     }
 
+    @Transactional
     @PatchMapping(produces = "application/vnd.api+json", path = "workspaces/{workspacesId}")
     public ResponseEntity<WorkspaceData> updateWorkspace(@PathVariable("workspacesId") String workspacesId, @RequestBody WorkspaceData workspaceData) {
         log.info("Create {}", workspaceData.toString());

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -213,6 +213,18 @@ public class RemoteTfeService {
         }
 
     }
+    WorkspaceData updateWorkspace(String workspaceId, WorkspaceData workspaceData) {
+        Optional<Workspace> workspace = Optional.ofNullable(workspaceRepository.getReferenceById(UUID.fromString(workspaceId)));
+
+        log.info("Updating existing workspace {} in {}", workspace.get().getName(), workspace.get().getOrganization().getName());
+
+        Workspace updatedWorkspace = workspace.get();
+        updatedWorkspace.setTerraformVersion(workspaceData.getData().getAttributes().get("terraform-version").toString());
+
+        workspaceRepository.save(updatedWorkspace);
+
+        return getWorkspace(updatedWorkspace.getOrganization().getName(), updatedWorkspace.getName(), new HashMap<>());
+    }
 
     WorkspaceData createWorkspace(String organizationName, WorkspaceData workspaceData) {
         Optional<Workspace> workspace = Optional.ofNullable(workspaceRepository.getByOrganizationNameAndName(
@@ -227,7 +239,7 @@ public class RemoteTfeService {
             newWorkspace.setId(UUID.randomUUID());
             newWorkspace.setName(workspaceData.getData().getAttributes().get("name").toString());
             String terraformVersion = "";
-            if(workspaceData.getData().getAttributes().get("terraform-version") != null){
+            if (workspaceData.getData().getAttributes().get("terraform-version") != null) {
                 terraformVersion = workspaceData.getData().getAttributes().get("terraform-version").toString();
             } else {
                 terraformVersion = "1.4.6";
@@ -471,9 +483,9 @@ public class RemoteTfeService {
         //    runsData.setIncluded(new ArrayList());
         //    runsData.getIncluded().add(getWorkspace(job.getOrganization().getName(), job.getWorkspace().getName(), new HashMap<>()));
         //}
-        
+
         runsData.getData().setRelationships(relationships);
-        
+
         log.info("{}", runsData.toString());
         return runsData;
     }
@@ -619,7 +631,7 @@ public class RemoteTfeService {
         return logs;
     }
 
-    byte[] getApplyLogs(int planId){
+    byte[] getApplyLogs(int planId) {
         Job job = jobRepository.getReferenceById(Integer.valueOf(planId));
         byte[] logs = "".getBytes();
         TextStringBuilder logsOutputApply = new TextStringBuilder();


### PR DESCRIPTION
Fix warning message and set correct terraform version when using terraform init with cloud block

```bash
The local Terraform version (%s) is not available in Terraform Cloud, or your
organization does not have access to it. The new workspace will use %s. You can
change this later in the workspace settings.
```