### PR TITLE
URL with .git is optional

### DIFF
--- a/ui/src/domain/Modules/Create.jsx
+++ b/ui/src/domain/Modules/Create.jsx
@@ -387,7 +387,7 @@ export const CreateModule = () => {
                   {
                     required: true,
                     pattern:
-                      "((git|ssh|http(s)?)|(git@[\\w\\.]+))(:(//)?)([\\w\\.@\\:/\\-~]+)(\\.git)(/)?",
+                      "((git|ssh|http(s)?)|(git@[\\w\\.]+))(:(//)?)([\\w\\.@\\:/\\-~]+)(\\.git)?(/)?",
                   },
                 ]}
               >

--- a/ui/src/domain/Workspaces/Create.jsx
+++ b/ui/src/domain/Workspaces/Create.jsx
@@ -463,7 +463,7 @@ export const CreateWorkspace = () => {
                   {
                     required: true,
                     pattern:
-                      "(empty)|(((git|ssh|http(s)?)|(git@[\\w\\.]+))(:(//)?)([\\w\\.@\\:/\\-~]+)(\\.git)(/)?)",
+                      "(empty)|(((git|ssh|http(s)?)|(git@[\\w\\.]+))(:(//)?)([\\w\\.@\\:/\\-~]+)(\\.git)?(/)?)",
                   },
                 ]}
               >


### PR DESCRIPTION
Repository URL ending in ".git" should be optional

Fix #444 