### PR TITLE
Initial Support Cloud Block with Tags

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -62,6 +62,7 @@ public class RemoteTfeController {
         return ResponseEntity.of(Optional.ofNullable(remoteTfeService.getWorkspace(organizationName, workspaceName, new HashMap<>())));
     }
 
+    @Transactional
     @GetMapping (produces = "application/vnd.api+json", path = "organizations/{organizationName}/workspaces")
     public ResponseEntity<WorkspaceList> listWorkspace(@PathVariable("organizationName") String organizationName, @RequestParam("search[tags]") String searchTags) {
         log.info("Searching: {} {}", organizationName, searchTags);

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -73,6 +73,19 @@ public class RemoteTfeController {
     }
 
     @Transactional
+    @PatchMapping(produces = "application/vnd.api+json", path = "workspaces/{workspacesId}")
+    public ResponseEntity<WorkspaceData> updateWorkspace(@PathVariable("workspacesId") String workspacesId, @RequestBody WorkspaceData workspaceData) {
+        log.info("Create {}", workspaceData.toString());
+        Optional<WorkspaceData> updatedWorkspace = Optional.ofNullable(remoteTfeService.updateWorkspace(workspacesId, workspaceData));
+        if(updatedWorkspace.isPresent()){
+            log.info("Created: {}", updatedWorkspace.get().toString());
+            return ResponseEntity.status(201).body(updatedWorkspace.get());
+        }else{
+            return ResponseEntity.status(500).body(new WorkspaceData());
+        }
+    }
+
+    @Transactional
     @PostMapping(produces = "application/vnd.api+json", path = "/workspaces/{workspaceId}/actions/lock")
     public ResponseEntity<WorkspaceData> lockWorkspace(@PathVariable("workspaceId") String workspaceId) {
         log.info("Lock {}", workspaceId);

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -18,6 +18,7 @@ import org.terrakube.api.plugin.state.model.runs.RunsData;
 import org.terrakube.api.plugin.state.model.state.StateData;
 import org.terrakube.api.plugin.state.model.workspace.WorkspaceData;
 import org.terrakube.api.plugin.state.model.workspace.WorkspaceList;
+import org.terrakube.api.plugin.state.model.workspace.tags.TagDataList;
 
 import java.nio.charset.StandardCharsets;
 
@@ -65,6 +66,17 @@ public class RemoteTfeController {
     public ResponseEntity<WorkspaceList> listWorkspace(@PathVariable("organizationName") String organizationName, @RequestParam("search[tags]") String searchTags) {
         log.info("Searching: {} {}", organizationName, searchTags);
         return ResponseEntity.of(Optional.ofNullable(remoteTfeService.listWorkspace(organizationName,searchTags)));
+    }
+
+    @PostMapping(produces = "application/vnd.api+json", path = "/workspaces/{workspaceId}/relationships/tags")
+    public ResponseEntity<String> updateWorkspaceTags(@PathVariable("workspaceId") String workspaceId, @RequestBody TagDataList tagDataList) {
+        log.info("Updating Workspace Tags {}", tagDataList.toString());
+        boolean workspaceTags = remoteTfeService.updateWorkspaceTags(workspaceId, tagDataList);
+        if(workspaceTags){
+            return ResponseEntity.status(204).body("");
+        }else{
+            return ResponseEntity.status(404).body("");
+        }
     }
 
     

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -17,6 +17,8 @@ import org.terrakube.api.plugin.state.model.apply.ApplyRunData;
 import org.terrakube.api.plugin.state.model.runs.RunsData;
 import org.terrakube.api.plugin.state.model.state.StateData;
 import org.terrakube.api.plugin.state.model.workspace.WorkspaceData;
+import org.terrakube.api.plugin.state.model.workspace.WorkspaceList;
+
 import java.nio.charset.StandardCharsets;
 
 import javax.servlet.http.HttpServletRequest;
@@ -57,6 +59,12 @@ public class RemoteTfeController {
     public ResponseEntity<WorkspaceData> getWorkspace(@PathVariable("organizationName") String organizationName, @PathVariable("workspaceName") String workspaceName) {
         log.info("Searching: {} {}", organizationName, workspaceName);
         return ResponseEntity.of(Optional.ofNullable(remoteTfeService.getWorkspace(organizationName, workspaceName, new HashMap<>())));
+    }
+
+    @GetMapping (produces = "application/vnd.api+json", path = "organizations/{organizationName}/workspaces")
+    public ResponseEntity<WorkspaceList> listWorkspace(@PathVariable("organizationName") String organizationName, @RequestParam("search[tags]") String searchTags) {
+        log.info("Searching: {} {}", organizationName, searchTags);
+        return ResponseEntity.of(Optional.ofNullable(remoteTfeService.listWorkspace(organizationName,searchTags)));
     }
 
     

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -232,7 +232,7 @@ public class RemoteTfeService {
             boolean includeWorkspace = true;
             for (WorkspaceTag workspaceTag : workspaceTagList) {
                 Tag tag = tagRepository.getReferenceById(UUID.fromString(workspaceTag.getTagId()));
-                if (listTags.indexOf(tag.getName()) == -1 || listTags.size() == workspaceTagList.size()) {
+                if (listTags.indexOf(tag.getName()) == -1 || listTags.size() != workspaceTagList.size()) {
                     includeWorkspace = false;
                 }
             }

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -213,6 +213,18 @@ public class RemoteTfeService {
         }
 
     }
+    WorkspaceData updateWorkspace(String workspaceId, WorkspaceData workspaceData) {
+        Optional<Workspace> workspace = Optional.ofNullable(workspaceRepository.getReferenceById(UUID.fromString(workspaceId)));
+
+        log.info("Updating existing workspace {} in {}", workspace.get().getName(), workspace.get().getOrganization().getName());
+
+        Workspace updatedWorkspace = workspace.get();
+        updatedWorkspace.setTerraformVersion(workspaceData.getData().getAttributes().get("terraform-version").toString());
+
+        workspaceRepository.save(updatedWorkspace);
+
+        return getWorkspace(updatedWorkspace.getOrganization().getName(), updatedWorkspace.getName(), new HashMap<>());
+    }
 
     WorkspaceData createWorkspace(String organizationName, WorkspaceData workspaceData) {
         Optional<Workspace> workspace = Optional.ofNullable(workspaceRepository.getByOrganizationNameAndName(
@@ -227,7 +239,7 @@ public class RemoteTfeService {
             newWorkspace.setId(UUID.randomUUID());
             newWorkspace.setName(workspaceData.getData().getAttributes().get("name").toString());
             String terraformVersion = "";
-            if(workspaceData.getData().getAttributes().get("terraform-version") != null){
+            if (workspaceData.getData().getAttributes().get("terraform-version") != null) {
                 terraformVersion = workspaceData.getData().getAttributes().get("terraform-version").toString();
             } else {
                 terraformVersion = "1.4.6";
@@ -471,9 +483,9 @@ public class RemoteTfeService {
         //    runsData.setIncluded(new ArrayList());
         //    runsData.getIncluded().add(getWorkspace(job.getOrganization().getName(), job.getWorkspace().getName(), new HashMap<>()));
         //}
-        
+
         runsData.getData().setRelationships(relationships);
-        
+
         log.info("{}", runsData.toString());
         return runsData;
     }
@@ -619,7 +631,7 @@ public class RemoteTfeService {
         return logs;
     }
 
-    byte[] getApplyLogs(int planId){
+    byte[] getApplyLogs(int planId) {
         Job job = jobRepository.getReferenceById(Integer.valueOf(planId));
         byte[] logs = "".getBytes();
         TextStringBuilder logsOutputApply = new TextStringBuilder();

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -23,6 +23,7 @@ import org.terrakube.api.plugin.state.model.runs.*;
 import org.terrakube.api.plugin.state.model.state.StateData;
 import org.terrakube.api.plugin.state.model.state.StateModel;
 import org.terrakube.api.plugin.state.model.workspace.WorkspaceData;
+import org.terrakube.api.plugin.state.model.workspace.WorkspaceList;
 import org.terrakube.api.plugin.state.model.workspace.WorkspaceModel;
 import org.terrakube.api.plugin.storage.StorageTypeService;
 import org.terrakube.api.repository.*;
@@ -211,6 +212,14 @@ public class RemoteTfeService {
         } else {
             return null;
         }
+
+    }
+
+    WorkspaceList listWorkspace(String organizationName, String searchTags) {
+        WorkspaceList workspaceList = new WorkspaceList();
+        workspaceList.setData(new ArrayList());
+
+        return workspaceList;
 
     }
     WorkspaceData updateWorkspace(String workspaceId, WorkspaceData workspaceData) {

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -25,20 +25,21 @@ import org.terrakube.api.plugin.state.model.state.StateModel;
 import org.terrakube.api.plugin.state.model.workspace.WorkspaceData;
 import org.terrakube.api.plugin.state.model.workspace.WorkspaceList;
 import org.terrakube.api.plugin.state.model.workspace.WorkspaceModel;
+import org.terrakube.api.plugin.state.model.workspace.tags.TagDataList;
+import org.terrakube.api.plugin.state.model.workspace.tags.TagModel;
 import org.terrakube.api.plugin.storage.StorageTypeService;
 import org.terrakube.api.repository.*;
 import org.terrakube.api.rs.Organization;
 import org.terrakube.api.rs.job.Job;
 import org.terrakube.api.rs.job.JobStatus;
-import org.terrakube.api.rs.job.LogStatus;
 import org.terrakube.api.rs.job.step.Step;
+import org.terrakube.api.rs.tag.Tag;
 import org.terrakube.api.rs.template.Template;
 import org.terrakube.api.rs.workspace.Workspace;
 import org.terrakube.api.rs.workspace.content.Content;
 import org.terrakube.api.rs.workspace.history.History;
-import redis.clients.jedis.exceptions.JedisDataException;
+import org.terrakube.api.rs.workspace.tag.WorkspaceTag;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
@@ -61,6 +62,10 @@ public class RemoteTfeService {
     private StepRepository stepRepository;
     private RedisTemplate redisTemplate;
 
+    private TagRepository tagRepository;
+
+    private WorkspaceTagRepository workspaceTagRepository;
+
     public RemoteTfeService(JobRepository jobRepository,
                             ContentRepository contentRepository,
                             OrganizationRepository organizationRepository,
@@ -71,7 +76,9 @@ public class RemoteTfeService {
                             @Value("${org.terrakube.hostname}") String hostname,
                             StorageTypeService storageTypeService,
                             StepRepository stepRepository,
-                            RedisTemplate redisTemplate) {
+                            RedisTemplate redisTemplate,
+                            TagRepository tagRepository,
+                            WorkspaceTagRepository workspaceTagRepository) {
         this.jobRepository = jobRepository;
         this.contentRepository = contentRepository;
         this.organizationRepository = organizationRepository;
@@ -83,7 +90,8 @@ public class RemoteTfeService {
         this.storageTypeService = storageTypeService;
         this.stepRepository = stepRepository;
         this.redisTemplate = redisTemplate;
-
+        this.tagRepository = tagRepository;
+        this.workspaceTagRepository = workspaceTagRepository;
     }
 
     EntitlementData getOrgEntitlementSet(String organizationName) {
@@ -214,14 +222,43 @@ public class RemoteTfeService {
         }
 
     }
-
     WorkspaceList listWorkspace(String organizationName, String searchTags) {
         WorkspaceList workspaceList = new WorkspaceList();
         workspaceList.setData(new ArrayList());
-
         return workspaceList;
-
     }
+
+    boolean updateWorkspaceTags(String workspaceId, TagDataList tagDataList) {
+        Workspace workspace = workspaceRepository.getReferenceById(UUID.fromString(workspaceId));
+        for(TagModel tagModel : tagDataList.getData()){
+            Tag tag = tagRepository.getByOrganizationNameAndName(workspace.getOrganization().getName(), tagModel.getAttributes().get("name"));
+            if(tag!= null){
+                log.info("Updating tag {} in Workspace {}", tagModel.getAttributes().get("name"), workspace.getName());
+
+                WorkspaceTag newWorkspaceTag = new WorkspaceTag();
+                newWorkspaceTag.setId(UUID.randomUUID());
+                newWorkspaceTag.setTagId(tag.getId().toString());
+                newWorkspaceTag.setWorkspace(workspace);
+
+                workspaceTagRepository.save(newWorkspaceTag);
+            } else {
+                log.info("Creating new tag {} in Org {}", tagModel.getAttributes().get("name"), workspace.getOrganization().getName());
+                Tag newTag = new Tag();
+                newTag.setId(UUID.randomUUID());
+                newTag.setName(tagModel.getAttributes().get("name"));
+                newTag = tagRepository.save(newTag);
+
+                WorkspaceTag newWorkspaceTag = new WorkspaceTag();
+                newWorkspaceTag.setId(UUID.randomUUID());
+                newWorkspaceTag.setTagId(newTag.getId().toString());
+                newWorkspaceTag.setWorkspace(workspace);
+
+                workspaceTagRepository.save(newWorkspaceTag);
+            }
+        }
+        return true;
+    }
+
     WorkspaceData updateWorkspace(String workspaceId, WorkspaceData workspaceData) {
         Optional<Workspace> workspace = Optional.ofNullable(workspaceRepository.getReferenceById(UUID.fromString(workspaceId)));
 

--- a/api/src/main/java/org/terrakube/api/plugin/state/model/workspace/WorkspaceList.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/model/workspace/WorkspaceList.java
@@ -1,0 +1,13 @@
+package org.terrakube.api.plugin.state.model.workspace;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class WorkspaceList {
+
+    List<WorkspaceModel> data;
+}

--- a/api/src/main/java/org/terrakube/api/plugin/state/model/workspace/tags/TagDataList.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/model/workspace/tags/TagDataList.java
@@ -1,0 +1,14 @@
+package org.terrakube.api.plugin.state.model.workspace.tags;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+public class TagDataList {
+    List<TagModel> data;
+}

--- a/api/src/main/java/org/terrakube/api/plugin/state/model/workspace/tags/TagModel.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/model/workspace/tags/TagModel.java
@@ -1,0 +1,15 @@
+package org.terrakube.api.plugin.state.model.workspace.tags;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.terrakube.api.plugin.state.model.generic.Resource;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@ToString
+public class TagModel extends Resource {
+    Map<String, String> attributes;
+}

--- a/api/src/main/java/org/terrakube/api/repository/TagRepository.java
+++ b/api/src/main/java/org/terrakube/api/repository/TagRepository.java
@@ -1,0 +1,10 @@
+package org.terrakube.api.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.terrakube.api.rs.tag.Tag;
+
+import java.util.UUID;
+
+public interface TagRepository extends JpaRepository<Tag, UUID> {
+    Tag getByOrganizationNameAndName(String organizationName, String name);
+}

--- a/api/src/main/java/org/terrakube/api/repository/WorkspaceTagRepository.java
+++ b/api/src/main/java/org/terrakube/api/repository/WorkspaceTagRepository.java
@@ -1,0 +1,9 @@
+package org.terrakube.api.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.terrakube.api.rs.workspace.tag.WorkspaceTag;
+
+import java.util.UUID;
+
+public interface WorkspaceTagRepository extends JpaRepository<WorkspaceTag, UUID> {
+}

--- a/api/src/main/java/org/terrakube/api/repository/WorkspaceTagRepository.java
+++ b/api/src/main/java/org/terrakube/api/repository/WorkspaceTagRepository.java
@@ -1,9 +1,14 @@
 package org.terrakube.api.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.terrakube.api.rs.workspace.Workspace;
 import org.terrakube.api.rs.workspace.tag.WorkspaceTag;
 
 import java.util.UUID;
 
 public interface WorkspaceTagRepository extends JpaRepository<WorkspaceTag, UUID> {
+
+    WorkspaceTag getByWorkspaceAndTagId(Workspace workspace, String tagId);
+
+    void deleteByWorkspace(Workspace workspace);
 }

--- a/api/src/main/resources/db/changelog/changelog-demo.xml
+++ b/api/src/main/resources/db/changelog/changelog-demo.xml
@@ -12,4 +12,5 @@
     <include file="/db/changelog/demo-data/aws.xml"/>
     <include file="/db/changelog/demo-data/gcp.xml"/>
     <include file="/db/changelog/demo-data/simple.xml"/>
+    <include file="/db/changelog/demo-data/simple-tag.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/demo-data/simple-tag.xml
+++ b/api/src/main/resources/db/changelog/demo-data/simple-tag.xml
@@ -7,25 +7,25 @@
         ***TAGS***
         **********
         -->
-        <insert tableName="tags">
+        <insert tableName="tag">
             <column name="id"               value="58529721-425e-44d7-8b0d-1d515043c2f7" />
             <column name="name"             value="development" />
             <column name="organization_id"  value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
         </insert>
 
-        <insert tableName="tags">
+        <insert tableName="tag">
             <column name="id"               value="0d7e4a6a-560e-40f1-a6dd-c7433a04f088" />
             <column name="name"             value="staging" />
             <column name="organization_id"  value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
         </insert>
 
-        <insert tableName="tags">
+        <insert tableName="tag">
             <column name="id"               value="2edcb0b0-3d25-453b-bcbc-21baa7780cf7" />
             <column name="name"             value="production" />
             <column name="organization_id"  value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
         </insert>
 
-        <insert tableName="tags">
+        <insert tableName="tag">
             <column name="id"               value="89f11ea7-322d-43f4-9575-2544d56d9614" />
             <column name="name"             value="networking" />
             <column name="organization_id"  value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
@@ -38,10 +38,10 @@
         -->
         <insert tableName="workspace">
             <column name="id"                value="c20633b2-82cc-4105-9806-16e23ad0e1df" />
-            <column name="name"              value="sample_simple_tag" />
-            <column name="description"       value="sample workspace with tags" />
-            <column name="source"            value="https://github.com/AzBuilder/terrakube-docker-compose.git" />
-            <column name="branch"            value="main" />
+            <column name="name"              value="simple_tag1" />
+            <column name="description"       value="cli driven example 1" />
+            <column name="source"            value="empty" />
+            <column name="branch"            value="remote-content" />
             <column name="terraform_version" value="1.5.3" />
             <column name="organization_id"   value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
         </insert>
@@ -61,6 +61,66 @@
             <column name="id"               value="6b22c1bf-4737-4826-9034-6f9ee1a45283" />
             <column name="tag_id"           value="89f11ea7-322d-43f4-9575-2544d56d9614" />
             <column name="workspace_id"     value="c20633b2-82cc-4105-9806-16e23ad0e1df" />
+        </insert>
+
+
+        <!--
+        ***************
+        ***WORKSPACE***
+        ***************
+        -->
+        <insert tableName="workspace">
+            <column name="id"                value="5a7873bd-9fd3-4193-b3df-33ba586fb146" />
+            <column name="name"              value="simple_tag2" />
+            <column name="description"       value="cli driven example 2" />
+            <column name="source"            value="empty" />
+            <column name="branch"            value="remote-content" />
+            <column name="terraform_version" value="1.5.3" />
+            <column name="organization_id"   value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
+        </insert>
+
+        <!--
+        ********************
+        ***WORKSPACE TAGS***
+        ********************
+        -->
+        <insert tableName="workspacetag">
+            <column name="id"               value="50c2b56b-bdb0-4fb1-b030-f5920c580ee3" />
+            <column name="tag_id"           value="58529721-425e-44d7-8b0d-1d515043c2f7" />
+            <column name="workspace_id"     value="5a7873bd-9fd3-4193-b3df-33ba586fb146" />
+        </insert>
+
+        <insert tableName="workspacetag">
+            <column name="id"               value="6c6904c1-b2a3-4c5a-9803-eced8678d288" />
+            <column name="tag_id"           value="89f11ea7-322d-43f4-9575-2544d56d9614" />
+            <column name="workspace_id"     value="5a7873bd-9fd3-4193-b3df-33ba586fb146" />
+        </insert>
+
+
+        <!--
+        ***************
+        ***WORKSPACE***
+        ***************
+        -->
+        <insert tableName="workspace">
+            <column name="id"                value="24480d33-2649-4c34-aabd-cbc988eb6265" />
+            <column name="name"              value="simple_tag3" />
+            <column name="description"       value="cli driven example 3" />
+            <column name="source"            value="empty" />
+            <column name="branch"            value="remote-content" />
+            <column name="terraform_version" value="1.5.3" />
+            <column name="organization_id"   value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
+        </insert>
+
+        <!--
+        ********************
+        ***WORKSPACE TAGS***
+        ********************
+        -->
+        <insert tableName="workspacetag">
+            <column name="id"               value="81b1cdd5-5432-4bbc-87a4-3e02cdad0c89" />
+            <column name="tag_id"           value="58529721-425e-44d7-8b0d-1d515043c2f7" />
+            <column name="workspace_id"     value="24480d33-2649-4c34-aabd-cbc988eb6265" />
         </insert>
 
     </changeSet>

--- a/api/src/main/resources/db/changelog/demo-data/simple-tag.xml
+++ b/api/src/main/resources/db/changelog/demo-data/simple-tag.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet author="demo-data" id="demo-4">
+        <!--
+        **********
+        ***TAGS***
+        **********
+        -->
+        <insert tableName="tags">
+            <column name="id"               value="58529721-425e-44d7-8b0d-1d515043c2f7" />
+            <column name="name"             value="development" />
+            <column name="organization_id"  value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
+        </insert>
+
+        <insert tableName="tags">
+            <column name="id"               value="0d7e4a6a-560e-40f1-a6dd-c7433a04f088" />
+            <column name="name"             value="staging" />
+            <column name="organization_id"  value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
+        </insert>
+
+        <insert tableName="tags">
+            <column name="id"               value="2edcb0b0-3d25-453b-bcbc-21baa7780cf7" />
+            <column name="name"             value="production" />
+            <column name="organization_id"  value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
+        </insert>
+
+        <insert tableName="tags">
+            <column name="id"               value="89f11ea7-322d-43f4-9575-2544d56d9614" />
+            <column name="name"             value="networking" />
+            <column name="organization_id"  value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
+        </insert>
+
+        <!--
+        ***************    
+        ***WORKSPACE***
+        ***************
+        -->
+        <insert tableName="workspace">
+            <column name="id"                value="c20633b2-82cc-4105-9806-16e23ad0e1df" />
+            <column name="name"              value="sample_simple_tag" />
+            <column name="description"       value="sample workspace with tags" />
+            <column name="source"            value="https://github.com/AzBuilder/terrakube-docker-compose.git" />
+            <column name="branch"            value="main" />
+            <column name="terraform_version" value="1.5.3" />
+            <column name="organization_id"   value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
+        </insert>
+
+       <!--
+       ********************
+       ***WORKSPACE TAGS***
+       ********************
+       -->
+        <insert tableName="workspacetag">
+            <column name="id"               value="e982f999-f68f-4635-a44a-e8b32c122ae8" />
+            <column name="tag_id"           value="58529721-425e-44d7-8b0d-1d515043c2f7" />
+            <column name="workspace_id"     value="c20633b2-82cc-4105-9806-16e23ad0e1df" />
+        </insert>
+
+        <insert tableName="workspacetag">
+            <column name="id"               value="6b22c1bf-4737-4826-9034-6f9ee1a45283" />
+            <column name="tag_id"           value="89f11ea7-322d-43f4-9575-2544d56d9614" />
+            <column name="workspace_id"     value="c20633b2-82cc-4105-9806-16e23ad0e1df" />
+        </insert>
+
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Adding support to use cloud block and tags to find workspaces when running "terraform init"

```terraform
terraform {
  cloud {
    organization = "simple"
    hostname = "8080-azbuilder-terrakube-md8dylvuzta.ws-us101.gitpod.io"

    workspaces {
      tags = ["networking", "development"]
    }
  }
}
```

Adding example data in simple organization to test using terraform remote state or cloud block.