### PR TITLE
Fix contraint tags

### DIFF
--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -33,4 +33,6 @@
     <include file="/db/changelog/local/changelog-2.10.0-workspace-audit.xml"/>
     <include file="/db/changelog/local/changelog-2.14.0-vcs-redirect-url.xml"/>
    <include file="/db/changelog/local/changelog-2.14.0-tags.xml"/>
+    <include file="/db/changelog/local/changelog-2.15.0-tags-constraint.xml"/>
+
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.15.0-tags-constraint.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.15.0-tags-constraint.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="22" author="alfespa17@gmail.com">
+        <dropUniqueConstraint
+                constraintName="const_tag"
+                tableName="tag"
+                uniqueColumns="name"/>
+        <addUniqueConstraint
+                columnNames="organization_id, name"
+                constraintName="const_tag_org"
+                deferrable="true"
+                disabled="true"
+                initiallyDeferred="true"
+                tableName="tag"
+                validate="true"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Fixing the tags constraint to include the **"organization_id and name"** so tag name can be duplicated between organizations.

This will fix the logic in this constraint
https://github.com/AzBuilder/terrakube/blob/main/api/src/main/resources/db/changelog/local/changelog-2.14.0-tags.xml#L44