### PR TITLE
Adding support for local execution mode

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -133,7 +133,7 @@ public class RemoteTfeController {
     @GetMapping(produces = "application/vnd.api+json", path = "/workspaces/{workspaceId}/current-state-version")
     public ResponseEntity<StateData> getCurrentWorkspaceState(@PathVariable("workspaceId") String workspaceId) {
         log.info("Get current workspace state {}", workspaceId);
-        return ResponseEntity.of(Optional.of(remoteTfeService.getCurrentWorkspaceState(workspaceId)));
+        return ResponseEntity.of(Optional.ofNullable(remoteTfeService.getCurrentWorkspaceState(workspaceId)));
     }
 
     @Transactional

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -56,17 +56,17 @@ public class RemoteTfeController {
         return ResponseEntity.of(Optional.ofNullable(remoteTfeService.getOrgInformation(organizationName)));
     }
 
-    @GetMapping (produces = "application/vnd.api+json", path = "organizations/{organizationName}/workspaces/{workspaceName}")
+    @GetMapping(produces = "application/vnd.api+json", path = "organizations/{organizationName}/workspaces/{workspaceName}")
     public ResponseEntity<WorkspaceData> getWorkspace(@PathVariable("organizationName") String organizationName, @PathVariable("workspaceName") String workspaceName) {
         log.info("Searching: {} {}", organizationName, workspaceName);
         return ResponseEntity.of(Optional.ofNullable(remoteTfeService.getWorkspace(organizationName, workspaceName, new HashMap<>())));
     }
 
     @Transactional
-    @GetMapping (produces = "application/vnd.api+json", path = "organizations/{organizationName}/workspaces")
+    @GetMapping(produces = "application/vnd.api+json", path = "organizations/{organizationName}/workspaces")
     public ResponseEntity<WorkspaceList> listWorkspace(@PathVariable("organizationName") String organizationName, @RequestParam("search[tags]") String searchTags) {
         log.info("Searching: {} {}", organizationName, searchTags);
-        return ResponseEntity.of(Optional.ofNullable(remoteTfeService.listWorkspace(organizationName,searchTags)));
+        return ResponseEntity.of(Optional.ofNullable(remoteTfeService.listWorkspace(organizationName, searchTags)));
     }
 
     @Transactional
@@ -74,22 +74,22 @@ public class RemoteTfeController {
     public ResponseEntity<String> updateWorkspaceTags(@PathVariable("workspaceId") String workspaceId, @RequestBody TagDataList tagDataList) {
         log.info("Updating Workspace Tags {}", tagDataList.toString());
         boolean workspaceTags = remoteTfeService.updateWorkspaceTags(workspaceId, tagDataList);
-        if(workspaceTags){
+        if (workspaceTags) {
             return ResponseEntity.status(204).body("");
-        }else{
+        } else {
             return ResponseEntity.status(404).body("");
         }
     }
 
-    
+
     @PostMapping(produces = "application/vnd.api+json", path = "organizations/{organizationName}/workspaces")
     public ResponseEntity<WorkspaceData> createWorkspace(@PathVariable("organizationName") String organizationName, @RequestBody WorkspaceData workspaceData) {
         log.info("Create {}", workspaceData.toString());
         Optional<WorkspaceData> newWorkspace = Optional.ofNullable(remoteTfeService.createWorkspace(organizationName, workspaceData));
-        if(newWorkspace.isPresent()){
+        if (newWorkspace.isPresent()) {
             log.info("Created: {}", newWorkspace.get().toString());
             return ResponseEntity.status(201).body(newWorkspace.get());
-        }else{
+        } else {
             return ResponseEntity.status(500).body(new WorkspaceData());
         }
     }
@@ -99,10 +99,10 @@ public class RemoteTfeController {
     public ResponseEntity<WorkspaceData> updateWorkspace(@PathVariable("workspacesId") String workspacesId, @RequestBody WorkspaceData workspaceData) {
         log.info("Create {}", workspaceData.toString());
         Optional<WorkspaceData> updatedWorkspace = Optional.ofNullable(remoteTfeService.updateWorkspace(workspacesId, workspaceData));
-        if(updatedWorkspace.isPresent()){
+        if (updatedWorkspace.isPresent()) {
             log.info("Created: {}", updatedWorkspace.get().toString());
             return ResponseEntity.status(201).body(updatedWorkspace.get());
-        }else{
+        } else {
             return ResponseEntity.status(500).body(new WorkspaceData());
         }
     }
@@ -130,6 +130,13 @@ public class RemoteTfeController {
     }
 
     @Transactional
+    @GetMapping(produces = "application/vnd.api+json", path = "/workspaces/{workspaceId}/current-state-version")
+    public ResponseEntity<StateData> getCurrentWorkspaceState(@PathVariable("workspaceId") String workspaceId) {
+        log.info("Get current workspace state {}", workspaceId);
+        return ResponseEntity.of(Optional.of(remoteTfeService.getCurrentWorkspaceState(workspaceId)));
+    }
+
+    @Transactional
     @PostMapping(produces = "application/vnd.api+json", path = "/workspaces/{workspaceId}/configuration-versions")
     public ResponseEntity<ConfigurationData> createConfigurationVersion(@PathVariable("workspaceId") String workspaceId, @RequestBody ConfigurationData configurationData) {
         log.info("Creating Configuration Version for worspaceId {}", workspaceId);
@@ -144,60 +151,60 @@ public class RemoteTfeController {
     }
 
     @Transactional
-    @PutMapping (path = "/configuration-versions/{configurationid}")
+    @PutMapping(path = "/configuration-versions/{configurationid}")
     public ResponseEntity<String> uploadConfiguration(HttpServletRequest httpServletRequest, @PathVariable("configurationid") String configurationId) throws IOException {
-        log.info("Uploading Id {} file", configurationId );
+        log.info("Uploading Id {} file", configurationId);
         remoteTfeService.uploadFile(configurationId, httpServletRequest.getInputStream());
         log.info("File created");
         return ResponseEntity.ok().body("");
     }
 
     @Transactional
-    @PostMapping (produces = "application/vnd.api+json", path = "/runs")
+    @PostMapping(produces = "application/vnd.api+json", path = "/runs")
     public ResponseEntity<RunsData> createRun(@RequestBody RunsData runsData) throws SchedulerException, ParseException {
         log.info("Create new run");
         return ResponseEntity.status(201).body(remoteTfeService.createRun(runsData));
     }
 
     @Transactional
-    @GetMapping (produces = "application/vnd.api+json", path = "/runs/{runId}")
-    public ResponseEntity<RunsData> getRun(@PathVariable("runId") int runId,@RequestParam(name = "include", required = false) String include) {
+    @GetMapping(produces = "application/vnd.api+json", path = "/runs/{runId}")
+    public ResponseEntity<RunsData> getRun(@PathVariable("runId") int runId, @RequestParam(name = "include", required = false) String include) {
         return ResponseEntity.ok(remoteTfeService.getRun(runId, include));
     }
 
     @Transactional
-    @PostMapping (produces = "application/vnd.api+json", path = "/runs/{runId}/actions/apply")
+    @PostMapping(produces = "application/vnd.api+json", path = "/runs/{runId}/actions/apply")
     public ResponseEntity<RunsData> runApply(@PathVariable("runId") int runId) {
         return ResponseEntity.ok(remoteTfeService.runApply(runId));
     }
 
     @Transactional
-    @PostMapping (produces = "application/vnd.api+json", path = "/runs/{runId}/actions/discard")
+    @PostMapping(produces = "application/vnd.api+json", path = "/runs/{runId}/actions/discard")
     public ResponseEntity<RunsData> runDiscard(@PathVariable("runId") int runId) {
         return ResponseEntity.ok(remoteTfeService.runDiscard(runId));
     }
 
 
     @Transactional
-    @GetMapping (produces = "application/vnd.api+json", path = "/plans/{planId}")
+    @GetMapping(produces = "application/vnd.api+json", path = "/plans/{planId}")
     public ResponseEntity<PlanRunData> getPlan(@PathVariable("planId") int planId) {
         return ResponseEntity.ok(remoteTfeService.getPlan(planId));
     }
 
     @Transactional
-    @GetMapping (produces = "application/vnd.api+json", path = "/applies/{applyId}")
+    @GetMapping(produces = "application/vnd.api+json", path = "/applies/{applyId}")
     public ResponseEntity<ApplyRunData> getApply(@PathVariable("applyId") int applyId) {
         return ResponseEntity.ok(remoteTfeService.getApply(applyId));
     }
 
     @Transactional
-    @GetMapping (produces = "application/vnd.api+json", path = "/plans/{planId}/logs")
+    @GetMapping(produces = "application/vnd.api+json", path = "/plans/{planId}/logs")
     public ResponseEntity<String> getPlanLogs(@PathVariable("planId") int planId) throws IOException {
         return ResponseEntity.of(Optional.ofNullable(new String(remoteTfeService.getPlanLogs(planId), StandardCharsets.UTF_8)));
     }
 
     @Transactional
-    @GetMapping (produces = "application/vnd.api+json", path = "/applies/{applyId}/logs")
+    @GetMapping(produces = "application/vnd.api+json", path = "/applies/{applyId}/logs")
     public ResponseEntity<String> getApplyLogs(@PathVariable("applyId") int planId) throws IOException {
         return ResponseEntity.of(Optional.ofNullable(new String(remoteTfeService.getApplyLogs(planId), StandardCharsets.UTF_8)));
     }

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -187,8 +187,9 @@ public class RemoteTfeService {
             attributes.put("terraform-version", workspace.get().getTerraformVersion());
             attributes.put("locked", workspace.get().isLocked());
             attributes.put("auto-apply", false);
+            attributes.put("execution-mode", workspace.get().getExecutionMode());
 
-            Map<String, Boolean> defaultAttributes = new HashMap<String, Boolean>();
+            Map<String, Boolean> defaultAttributes = new HashMap<>();
             defaultAttributes.put("can-create-state-versions", true);
             defaultAttributes.put("can-destroy", true);
             defaultAttributes.put("can-force-unlock", true);
@@ -238,8 +239,8 @@ public class RemoteTfeService {
                 }
             }
 
-            if(includeWorkspace){
-                workspaceList.getData().add(getWorkspace(organizationName,workspace.getName(), new HashMap()).getData());
+            if (includeWorkspace) {
+                workspaceList.getData().add(getWorkspace(organizationName, workspace.getName(), new HashMap()).getData());
             }
         }
         return workspaceList;
@@ -252,7 +253,7 @@ public class RemoteTfeService {
             Tag tag = tagRepository.getByOrganizationNameAndName(workspace.getOrganization().getName(), tagModel.getAttributes().get("name"));
             if (tag != null) {
                 log.info("Updating tag {} in Workspace {}", tagModel.getAttributes().get("name"), workspace.getName());
-                if(workspaceTagRepository.getByWorkspaceAndTagId(workspace, tag.getName()) == null) {
+                if (workspaceTagRepository.getByWorkspaceAndTagId(workspace, tag.getName()) == null) {
                     WorkspaceTag newWorkspaceTag = new WorkspaceTag();
                     newWorkspaceTag.setId(UUID.randomUUID());
                     newWorkspaceTag.setTagId(tag.getId().toString());
@@ -342,17 +343,45 @@ public class RemoteTfeService {
         byte[] decodedBytes = stateData.getData().getAttributes().get("state").toString().getBytes();
         String terraformState = new String(Base64.getMimeDecoder().decode(decodedBytes));
 
+        //According to API docs json-state is optional so if the value is not available we will upload a default "{}"
+        byte[] decodedBytesJson = (stateData.getData().getAttributes().get("json-state") != null) ? stateData.getData().getAttributes().get("json-state").toString().getBytes() : "{}".getBytes(StandardCharsets.UTF_8);
+        String terraformStateJson = new String(Base64.getMimeDecoder().decode(decodedBytesJson));
+
         //upload state to backend storage
         storageTypeService.uploadState(workspace.getOrganization().getId().toString(), workspace.getId().toString(), terraformState);
 
-        //create history
+        //create dummy job
+        Job job = new Job();
+        job.setWorkspace(workspace);
+        job.setOrganization(workspace.getOrganization());
+        job.setStatus(JobStatus.completed);
+        job = jobRepository.save(job);
+
+        //dummy step
+        Step step = new Step();
+        step.setId(UUID.randomUUID());
+        step.setJob(job);
+        step.setName("Dummy State Uploaded");
+        step.setStatus(JobStatus.completed);
+        step.setStepNumber(100);
+        stepRepository.save(step);
+
+        //create dummy history
         History history = new History();
         UUID historyId = UUID.randomUUID();
         history.setId(historyId);
-        //history.setOutput(terraformState);
-        history.setJobReference("0");
+        history.setOutput(String
+                .format("https://%s/tfstate/v1/organization/%s/workspace/%s/state/%s.json",
+                        hostname,
+                        workspace.getOrganization().getId().toString(),
+                        workspace.getId().toString(),
+                        historyId));
+        history.setJobReference(String.valueOf(job.getId()));
         history.setWorkspace(workspace);
-        historyRepository.save(history);
+        history = historyRepository.save(history);
+
+        //upload json state to backend storage
+        storageTypeService.uploadTerraformStateJson(workspace.getOrganization().getId().toString(), workspace.getId().toString(), terraformStateJson, history.getId().toString());
 
         StateData response = new StateData();
         response.setData(new StateModel());
@@ -368,10 +397,11 @@ public class RemoteTfeService {
                         workspace.getOrganization().getId().toString(),
                         workspace.getId().toString()));
         responseAttributes.put("hosted-json-state-download-url", String
-                .format("https://%s/tfstate/v1/organization/%s/workspace/%s/state/terraform.tfstate",
+                .format("https://%s/tfstate/v1/organization/%s/workspace/%s/state/%s.json",
                         hostname,
                         workspace.getOrganization().getId().toString(),
-                        workspace.getId().toString()));
+                        workspace.getId().toString(),
+                        historyId));
         responseAttributes.put("serial", 1);
         response.getData().setAttributes(responseAttributes);
 
@@ -380,7 +410,49 @@ public class RemoteTfeService {
                         hostname,
                         workspace.getOrganization().getId().toString(),
                         workspace.getId().toString()));
+
+        log.info("Download State JSON URL: {}", String
+                .format("https://%s/tfstate/v1/organization/%s/workspace/%s/state/%s.json",
+                        hostname,
+                        workspace.getOrganization().getId().toString(),
+                        workspace.getId().toString(),
+                        historyId));
         return response;
+    }
+
+    StateData getCurrentWorkspaceState(String workspaceId) {
+        Workspace workspace = workspaceRepository.getReferenceById(UUID.fromString(workspaceId));
+
+        log.info("Searching for existing terraform state for {} in the storage service", workspace.getId());
+        byte[] currentState;
+        try {
+            currentState = storageTypeService.getCurrentTerraformState(workspace.getOrganization().getId().toString(), workspaceId);
+        } catch (Exception ex) {
+            log.error("Exception searching state in storage");
+            log.error(ex.getMessage());
+            currentState = new byte[0];
+        }
+        if (currentState.length > 0) {
+            String historyId = UUID.randomUUID().toString();
+            StateData currentStateData = new StateData();
+            currentStateData.setData(new StateModel());
+            currentStateData.getData().setId(historyId);
+            currentStateData.getData().setType("state-versions");
+
+            Map<String, Object> responseAttributes = new HashMap<>();
+            responseAttributes.put("vcs-commit-url", null);
+            responseAttributes.put("vcs-commit-sha", null);
+            responseAttributes.put("hosted-state-download-url", String
+                    .format("https://%s/tfstate/v1/organization/%s/workspace/%s/state/terraform.tfstate",
+                            hostname,
+                            workspace.getOrganization().getId().toString(),
+                            workspace.getId().toString()));
+            responseAttributes.put("serial", 1);
+            currentStateData.getData().setAttributes(responseAttributes);
+
+            return currentStateData;
+        } else
+            return null;
     }
 
     ConfigurationData createConfigurationVersion(String workspaceId, ConfigurationData configurationData) {

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -187,7 +187,7 @@ public class RemoteTfeService {
             attributes.put("terraform-version", workspace.get().getTerraformVersion());
             attributes.put("locked", workspace.get().isLocked());
             attributes.put("auto-apply", false);
-            attributes.put("execution-mode", workspace.get().getExecutionMode());
+            attributes.put("execution-mode", "local");
 
             Map<String, Boolean> defaultAttributes = new HashMap<>();
             defaultAttributes.put("can-create-state-versions", true);
@@ -370,15 +370,17 @@ public class RemoteTfeService {
         History history = new History();
         UUID historyId = UUID.randomUUID();
         history.setId(historyId);
+        history.setOutput("");
+        history.setJobReference(String.valueOf(job.getId()));
+        history.setWorkspace(workspace);
+        history = historyRepository.save(history);
+
         history.setOutput(String
                 .format("https://%s/tfstate/v1/organization/%s/workspace/%s/state/%s.json",
                         hostname,
                         workspace.getOrganization().getId().toString(),
                         workspace.getId().toString(),
-                        historyId));
-        history.setJobReference(String.valueOf(job.getId()));
-        history.setWorkspace(workspace);
-        history = historyRepository.save(history);
+                        history.getId().toString()));
 
         //upload json state to backend storage
         storageTypeService.uploadTerraformStateJson(workspace.getOrganization().getId().toString(), workspace.getId().toString(), terraformStateJson, history.getId().toString());
@@ -401,7 +403,7 @@ public class RemoteTfeService {
                         hostname,
                         workspace.getOrganization().getId().toString(),
                         workspace.getId().toString(),
-                        historyId));
+                        history.getId().toString()));
         responseAttributes.put("serial", 1);
         response.getData().setAttributes(responseAttributes);
 
@@ -416,7 +418,7 @@ public class RemoteTfeService {
                         hostname,
                         workspace.getOrganization().getId().toString(),
                         workspace.getId().toString(),
-                        historyId));
+                        history.getId().toString()));
         return response;
     }
 

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -187,7 +187,7 @@ public class RemoteTfeService {
             attributes.put("terraform-version", workspace.get().getTerraformVersion());
             attributes.put("locked", workspace.get().isLocked());
             attributes.put("auto-apply", false);
-            attributes.put("execution-mode", "local");
+            attributes.put("execution-mode", workspace.get().getExecutionMode());
 
             Map<String, Boolean> defaultAttributes = new HashMap<>();
             defaultAttributes.put("can-create-state-versions", true);

--- a/api/src/main/java/org/terrakube/api/plugin/storage/StorageTypeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/StorageTypeService.java
@@ -10,6 +10,8 @@ public interface StorageTypeService {
 
     byte[] getTerraformStateJson(String organizationId, String workspaceId, String stateFileName);
 
+    void uploadTerraformStateJson(String organizationId, String workspaceId, String stateJson, String stateJsonHistoryId);
+
     byte[] getCurrentTerraformState(String organizationId, String workspaceId);
 
     void uploadState(String organizationId, String workspaceId, String terraformState);

--- a/api/src/main/java/org/terrakube/api/plugin/storage/aws/AwsStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/aws/AwsStorageTypeServiceImpl.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.StringUtils;
 import org.terrakube.api.plugin.storage.StorageTypeService;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -84,7 +83,9 @@ public class AwsStorageTypeServiceImpl implements StorageTypeService {
 
     @Override
     public void uploadTerraformStateJson(String organizationId, String workspaceId, String stateJson, String stateJsonHistoryId) {
-
+        String blobKey = String.format("tfstate/%s/%s/state/%s.json", organizationId, workspaceId, stateJsonHistoryId);
+        log.info("terraformStateFile: {}", blobKey);
+        s3client.putObject(bucketName, blobKey, stateJson);
     }
 
     @Override

--- a/api/src/main/java/org/terrakube/api/plugin/storage/aws/AwsStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/aws/AwsStorageTypeServiceImpl.java
@@ -84,7 +84,7 @@ public class AwsStorageTypeServiceImpl implements StorageTypeService {
     @Override
     public void uploadTerraformStateJson(String organizationId, String workspaceId, String stateJson, String stateJsonHistoryId) {
         String blobKey = String.format("tfstate/%s/%s/state/%s.json", organizationId, workspaceId, stateJsonHistoryId);
-        log.info("terraformStateFile: {}", blobKey);
+        log.info("terraformJsonStateFile: {}", blobKey);
         s3client.putObject(bucketName, blobKey, stateJson);
     }
 

--- a/api/src/main/java/org/terrakube/api/plugin/storage/aws/AwsStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/aws/AwsStorageTypeServiceImpl.java
@@ -83,6 +83,11 @@ public class AwsStorageTypeServiceImpl implements StorageTypeService {
     }
 
     @Override
+    public void uploadTerraformStateJson(String organizationId, String workspaceId, String stateJson, String stateJsonHistoryId) {
+
+    }
+
+    @Override
     public byte[] getCurrentTerraformState(String organizationId, String workspaceId) {
         byte[] data;
         try {

--- a/api/src/main/java/org/terrakube/api/plugin/storage/azure/AzureStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/azure/AzureStorageTypeServiceImpl.java
@@ -51,7 +51,14 @@ public class AzureStorageTypeServiceImpl implements StorageTypeService {
 
     @Override
     public void uploadTerraformStateJson(String organizationId, String workspaceId, String stateJson, String stateJsonHistoryId) {
+        BlobContainerClient contextContainerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME_STATE);
 
+        String stateFileName = String.format("%s/%s/state/%s.json", organizationId, workspaceId, stateJsonHistoryId);
+        log.info("New State File JSON Az Storage: {}", stateFileName);
+        BlobClient blobClient = contextContainerClient.getBlobClient(stateFileName);
+
+        BinaryData binaryData = BinaryData.fromBytes(stateJson.getBytes());
+        blobClient.upload(binaryData, true);
     }
 
     @Override

--- a/api/src/main/java/org/terrakube/api/plugin/storage/azure/AzureStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/azure/AzureStorageTypeServiceImpl.java
@@ -50,6 +50,11 @@ public class AzureStorageTypeServiceImpl implements StorageTypeService {
     }
 
     @Override
+    public void uploadTerraformStateJson(String organizationId, String workspaceId, String stateJson, String stateJsonHistoryId) {
+
+    }
+
+    @Override
     public byte[] getCurrentTerraformState(String organizationId, String workspaceId) {
         BlobContainerClient containerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME_STATE);
         log.info("Searching: /{}/{}/terraform.tfstate", organizationId, workspaceId);

--- a/api/src/main/java/org/terrakube/api/plugin/storage/azure/AzureStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/azure/AzureStorageTypeServiceImpl.java
@@ -54,7 +54,7 @@ public class AzureStorageTypeServiceImpl implements StorageTypeService {
         BlobContainerClient contextContainerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME_STATE);
 
         String stateFileName = String.format("%s/%s/state/%s.json", organizationId, workspaceId, stateJsonHistoryId);
-        log.info("New State File JSON Az Storage: {}", stateFileName);
+        log.info("New State JSON Az Storage: {}", stateFileName);
         BlobClient blobClient = contextContainerClient.getBlobClient(stateFileName);
 
         BinaryData binaryData = BinaryData.fromBytes(stateJson.getBytes());

--- a/api/src/main/java/org/terrakube/api/plugin/storage/gcp/GcpStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/gcp/GcpStorageTypeServiceImpl.java
@@ -8,7 +8,6 @@ import lombok.Builder;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.StringUtils;
-import org.springframework.web.multipart.MultipartFile;
 import org.terrakube.api.plugin.storage.StorageTypeService;
 
 import java.io.IOException;
@@ -68,7 +67,21 @@ public class GcpStorageTypeServiceImpl implements StorageTypeService {
 
     @Override
     public void uploadTerraformStateJson(String organizationId, String workspaceId, String stateJson, String stateJsonHistoryId) {
+        String currentStateKey = String.format(GCP_STATE_JSON, organizationId, workspaceId, stateJsonHistoryId);
+        log.info("Define new Json State File: {}", currentStateKey);
 
+        BlobId blobId = BlobId.of(bucketName, currentStateKey);
+        Blob blob = storage.get(blobId);
+        if (blob != null) {
+            log.info("Creating new JSON state...");
+            try {
+                WritableByteChannel channel = blob.writer();
+                channel.write(ByteBuffer.wrap(stateJson.getBytes(Charset.defaultCharset())));
+                channel.close();
+            } catch (IOException e) {
+                log.error(e.getMessage());
+            }
+        }
     }
 
     @Override

--- a/api/src/main/java/org/terrakube/api/plugin/storage/gcp/GcpStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/gcp/GcpStorageTypeServiceImpl.java
@@ -67,6 +67,11 @@ public class GcpStorageTypeServiceImpl implements StorageTypeService {
     }
 
     @Override
+    public void uploadTerraformStateJson(String organizationId, String workspaceId, String stateJson, String stateJsonHistoryId) {
+
+    }
+
+    @Override
     public byte[] getCurrentTerraformState(String organizationId, String workspaceId) {
         log.info("getTerraformStateJson {}", String.format(GCP_CURRENT_STATE, organizationId, workspaceId));
         return storage.get(

--- a/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 
 @Slf4j
 @AllArgsConstructor
@@ -48,6 +49,19 @@ public class LocalStorageTypeServiceImpl implements StorageTypeService {
         log.info("Searching: /.terraform-spring-boot/local/tfstate/{}/{}/state/{}.json", organizationId, workspaceId, stateFileName);
         String outputFilePath = String.format(STATE_DIRECTORY_JSON, organizationId, workspaceId, stateFileName);
         return getOutputBytes(outputFilePath);
+    }
+
+    @Override
+    public void uploadTerraformStateJson(String organizationId, String workspaceId, String stateJson, String stateJsonHistoryId) {
+        try {
+            String newStateFileJson = String.format(STATE_DIRECTORY_JSON, organizationId, workspaceId, stateJsonHistoryId);
+            log.info("newFileJson: {}", newStateFileJson);
+            File stateFile = new File(FileUtils.getUserDirectoryPath().concat(FilenameUtils.separatorsToSystem(newStateFileJson)));
+            FileUtils.forceMkdir(stateFile.getParentFile());
+            FileUtils.writeStringToFile(stateFile, stateJson, Charset.defaultCharset().toString());
+        } catch (IOException e) {
+            log.error(e.getMessage());
+        }
     }
 
     @Override

--- a/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
@@ -62,6 +62,9 @@ public class Workspace extends GenericAuditFields {
     @Column(name = "terraform_version")
     private String terraformVersion;
 
+    @Column(name = "execution_mode")
+    private String executionMode;
+
     @ManyToOne
     private Organization organization;
 
@@ -90,4 +93,8 @@ public class Workspace extends GenericAuditFields {
 
     @OneToOne
     private Ssh ssh;
+
+    public String getExecutionMode(){
+        return this.executionMode == null ? "local":this.executionMode;
+    }
 }

--- a/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
@@ -93,8 +93,5 @@ public class Workspace extends GenericAuditFields {
 
     @OneToOne
     private Ssh ssh;
-
-    public String getExecutionMode(){
-        return this.executionMode == null ? "local":this.executionMode;
-    }
+    
 }

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -34,5 +34,6 @@
     <include file="/db/changelog/local/changelog-2.14.0-vcs-redirect-url.xml"/>
    <include file="/db/changelog/local/changelog-2.14.0-tags.xml"/>
     <include file="/db/changelog/local/changelog-2.15.0-tags-constraint.xml"/>
+    <include file="/db/changelog/local/changelog-2.15.0-execution-mode.xml"/>
 
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.15.0-execution-mode.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.15.0-execution-mode.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="23" author="alfespa17@gmail.com">
+        <addColumn tableName="workspace" >
+            <column name="execution_mode" type="varchar2(16)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.15.0-execution-mode.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.15.0-execution-mode.xml
@@ -6,7 +6,15 @@
             http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
     <changeSet id="23" author="alfespa17@gmail.com">
         <addColumn tableName="workspace" >
-            <column name="execution_mode" type="varchar2(16)"/>
+            <column name="execution_mode" type="varchar2(16)" />
         </addColumn>
+        <update tableName="workspace">
+            <column name="execution_mode" value="remote"/>
+        </update>
+        <addDefaultValue
+            columnDataType="varchar2(16)"  
+            columnName="execution_mode"  
+            defaultValue="remote"    
+            tableName="workspace"/>  
     </changeSet>
 </databaseChangeLog>

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -83,6 +83,7 @@ export const WorkspaceDetails = (props) => {
   const [waiting, setWaiting] = useState(false);
   const [templates, setTemplates] = useState([]);
   const [lastRun, setLastRun] = useState("");
+  const [executionMode, setExecutionMode] = useState("...");
 
   const terraformVersionsApi = `${
     new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin
@@ -164,6 +165,7 @@ export const WorkspaceDetails = (props) => {
             }
             setOrganizationName(localStorage.getItem(ORGANIZATION_NAME));
             setWorkspaceName(response.data.data.attributes.name);
+            setExecutionMode(response.data.data.attributes.executionMode);
           });
       });
   };
@@ -179,6 +181,7 @@ export const WorkspaceDetails = (props) => {
           description: values.description,
           folder: values.folder,
           locked: values.locked,
+          executionMode: values.executionMode,
           terraformVersion: values.terraformVersion,
         },
       },
@@ -399,7 +402,7 @@ export const WorkspaceDetails = (props) => {
                       <Space direction="vertical">
                         <br />
                         <span className="App-text">
-                          <ThunderboltOutlined /> Execution Mode: <a>Remote</a>{" "}
+                          <ThunderboltOutlined /> Execution Mode: <a>{executionMode}</a>{" "}
                         </span>
                         <span className="App-text">
                           <PlayCircleOutlined /> Auto apply: <a>Off</a>{" "}
@@ -521,6 +524,7 @@ export const WorkspaceDetails = (props) => {
                           description: workspace.data.attributes.description,
                           folder: workspace.data.attributes.folder,
                           locked: workspace.data.attributes.locked,
+                          executionMode: workspace.data.attributes.executionMode
                         }}
                         layout="vertical"
                         name="form-settings"
@@ -579,6 +583,21 @@ export const WorkspaceDetails = (props) => {
                           <Switch />
                         </Form.Item>
 
+                        <Form.Item
+                          name="executionMode"
+                          label="Execution Mode"
+                          extra="Use this option with terraform remote state/cloud block if you want to execute Terraform CLI remotely and just upload the state to Terrakube"
+                        >
+                          <Select
+                            defaultValue={
+                              workspace.data.attributes.executionMode
+                            }
+                            style={{ width: 250 }}
+                          >
+                             <Option key="remote">remote</Option>
+                             <Option key="local">local</Option>
+                          </Select>
+                        </Form.Item>
                         <Form.Item>
                           <Button type="primary" htmlType="submit">
                             Save settings


### PR DESCRIPTION
Adding support for local execution mode when using remote state back-end or cloud block and implementing plugin storage for local, azure, aws and gcp.

![image](https://github.com/AzBuilder/terrakube/assets/4461895/9d83165e-4f85-4ccb-8e16-5ce39a5479cc)

![image](https://github.com/AzBuilder/terrakube/assets/4461895/491ac494-137c-458b-b707-8a83f06591cd)

Tested with Terraform CLI 1.4.6

Fixes #451 

> There is a bug when using Terraform 1.5.X we need to add support for this line of code https://github.com/hashicorp/terraform/blob/main/internal/cloud/backend_plan.go#L314