### PR TITLE
Cloud Block Support for Terraform 1.5.X

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -166,6 +166,14 @@ public class RemoteTfeController {
         return ResponseEntity.status(201).body(remoteTfeService.createRun(runsData));
     }
 
+    @GetMapping(produces = "application/vnd.api+json", path = "/runs/{runsId}/run-events")
+    public ResponseEntity<String> getRunEvents(@PathVariable("runsId") String runsId) {
+        log.info("Gettinng Runs Events for Run Id {}", runsId);
+        return ResponseEntity.status(200).body("{\n" +
+                "  \"data\": []\n" +
+                "}");
+    }
+
     @Transactional
     @GetMapping(produces = "application/vnd.api+json", path = "/runs/{runId}")
     public ResponseEntity<RunsData> getRun(@PathVariable("runId") int runId, @RequestParam(name = "include", required = false) String include) {

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -617,6 +617,10 @@ public class RemoteTfeService {
         workspaceModel.getData().setType("workspaces");
         relationships.setWorkspace(workspaceModel);
 
+        RunEventsModel runEventsModel = new RunEventsModel();
+        runEventsModel.setData(new ArrayList());
+        relationships.setRunEventsModel(runEventsModel);
+
         log.info("Included: {}", include);
         //if(include != null && include.equals("workspace")){
         //    runsData.setIncluded(new ArrayList());

--- a/api/src/main/java/org/terrakube/api/plugin/state/model/runs/Relationships.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/model/runs/Relationships.java
@@ -14,6 +14,7 @@ public class Relationships {
     ConfigurationModel configurationVersion;
     WorkspaceModel workspace;
     PlanModel plan;
-
     ApplyModel apply;
+    @JsonProperty("run-events")
+    RunEventsModel runEventsModel;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/state/model/runs/RunEventsModel.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/model/runs/RunEventsModel.java
@@ -1,0 +1,14 @@
+package org.terrakube.api.plugin.state.model.runs;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.terrakube.api.plugin.state.model.generic.Resource;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class RunEventsModel {
+
+    List<Resource> data;
+}


### PR DESCRIPTION
Fixing issues when using cloud block with Terraform 1.5.X

Adding missing endpoint "run-events" to fix the issue.

This will fix the issue
![image](https://github.com/AzBuilder/terrakube/assets/4461895/dff08ddc-3e69-4b2a-a031-525cd283b9b9)
