### PR TITLE
Adding SSL mode parameter to postgresql datasource

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/datasource/DataSourceAutoConfiguration.java
+++ b/api/src/main/java/org/terrakube/api/plugin/datasource/DataSourceAutoConfiguration.java
@@ -35,12 +35,13 @@ public class DataSourceAutoConfiguration {
                 dataSource = sqlServerDataSource;
                 break;
             case POSTGRESQL:
+                log.info("postgresql datasource using SSL Mode: {}", dataSourceConfigurationProperties.getSslMode());
                 PGSimpleDataSource ds = new PGSimpleDataSource();
                 ds.setServerNames(new String[]{dataSourceConfigurationProperties.getHostname()});
                 ds.setDatabaseName(dataSourceConfigurationProperties.getDatabaseName());
                 ds.setUser(dataSourceConfigurationProperties.getDatabaseUser());
                 ds.setPassword(dataSourceConfigurationProperties.getDatabasePassword());
-                ds.setSslMode("disable");
+                ds.setSslMode(dataSourceConfigurationProperties.getSslMode());
                 dataSource = ds;
                 break;
             case MYSQL:

--- a/api/src/main/java/org/terrakube/api/plugin/datasource/DataSourceConfigurationProperties.java
+++ b/api/src/main/java/org/terrakube/api/plugin/datasource/DataSourceConfigurationProperties.java
@@ -18,4 +18,5 @@ public class DataSourceConfigurationProperties {
     private String databaseName;
     private String databaseUser;
     private String databasePassword;
+    private String sslMode;
 }

--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -44,6 +44,7 @@ org.terrakube.api.plugin.datasource.hostname=${DatasourceHostname}
 org.terrakube.api.plugin.datasource.databaseName=${DatasourceDatabase}
 org.terrakube.api.plugin.datasource.databaseUser=${DatasourceUser}
 org.terrakube.api.plugin.datasource.databasePassword=${DatasourcePassword}
+org.terrakube.api.plugin.datasource.sslMode=${DatasourceSslMode:disable}
 
 ################
 #OWNER INSTANCE#

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -44,6 +44,7 @@ org.terrakube.api.plugin.datasource.hostname=${DatasourceHostname}
 org.terrakube.api.plugin.datasource.databaseName=${DatasourceDatabase}
 org.terrakube.api.plugin.datasource.databaseUser=${DatasourceUser}
 org.terrakube.api.plugin.datasource.databasePassword=${DatasourcePassword}
+org.terrakube.api.plugin.datasource.sslMode=${DatasourceSslMode:disable}
 
 ################
 #OWNER INSTANCE#


### PR DESCRIPTION
Parameter governing the use of SSL. The allowed values are disable, allow, prefer, require, verify-ca, verify-full. Default mode is "disable".

The parameter use the environment variable DatasourceSslMode.

This parameter is only used with postgresql