### PR TITLE
Support to share terraform state between workspaces

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -18,6 +18,7 @@ import org.terrakube.api.plugin.state.model.runs.RunsData;
 import org.terrakube.api.plugin.state.model.state.StateData;
 import org.terrakube.api.plugin.state.model.workspace.WorkspaceData;
 import org.terrakube.api.plugin.state.model.workspace.WorkspaceList;
+import org.terrakube.api.plugin.state.model.workspace.state.consumers.StateConsumerList;
 import org.terrakube.api.plugin.state.model.workspace.tags.TagDataList;
 
 import java.nio.charset.StandardCharsets;
@@ -60,6 +61,13 @@ public class RemoteTfeController {
     public ResponseEntity<WorkspaceData> getWorkspace(@PathVariable("organizationName") String organizationName, @PathVariable("workspaceName") String workspaceName) {
         log.info("Searching: {} {}", organizationName, workspaceName);
         return ResponseEntity.of(Optional.ofNullable(remoteTfeService.getWorkspace(organizationName, workspaceName, new HashMap<>())));
+    }
+
+    @Transactional
+    @GetMapping(produces = "application/vnd.api+json", path = "workspaces/{workspaceId}/relationships/remote-state-consumers")
+    public ResponseEntity<StateConsumerList> getWorkspaceStateConsumers(@PathVariable("workspaceId") String workspaceId) {
+        log.info("Searching Workspace Consumers for Id: {}", workspaceId);
+        return ResponseEntity.of(Optional.ofNullable(remoteTfeService.getWorkspaceStateConsumers(workspaceId)));
     }
 
     @Transactional

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -25,6 +25,7 @@ import org.terrakube.api.plugin.state.model.state.StateModel;
 import org.terrakube.api.plugin.state.model.workspace.WorkspaceData;
 import org.terrakube.api.plugin.state.model.workspace.WorkspaceList;
 import org.terrakube.api.plugin.state.model.workspace.WorkspaceModel;
+import org.terrakube.api.plugin.state.model.workspace.state.consumers.StateConsumerList;
 import org.terrakube.api.plugin.state.model.workspace.tags.TagDataList;
 import org.terrakube.api.plugin.state.model.workspace.tags.TagModel;
 import org.terrakube.api.plugin.storage.StorageTypeService;
@@ -188,6 +189,7 @@ public class RemoteTfeService {
             attributes.put("locked", workspace.get().isLocked());
             attributes.put("auto-apply", false);
             attributes.put("execution-mode", workspace.get().getExecutionMode());
+            attributes.put("global-remote-state", true);
 
             Map<String, Boolean> defaultAttributes = new HashMap<>();
             defaultAttributes.put("can-create-state-versions", true);
@@ -219,6 +221,25 @@ public class RemoteTfeService {
             return workspaceData;
         } else {
             return null;
+        }
+
+    }
+
+    StateConsumerList getWorkspaceStateConsumers(String workspaceId) {
+        Optional<Workspace> workspace = Optional
+                .ofNullable(workspaceRepository.getReferenceById(UUID.fromString(workspaceId)));
+
+        StateConsumerList stateConsumerList = new StateConsumerList();
+        stateConsumerList.setData(new ArrayList());
+        if (workspace.isPresent()) {
+            workspace.get().getOrganization().getWorkspace().forEach(workspaceData -> {
+                if (workspaceData.getId().toString().equals(workspaceId)){
+                    stateConsumerList.getData().add(getWorkspace(workspace.get().getOrganization().getName(), workspace.get().getName(), new HashMap()).getData());
+                }
+            });
+            return stateConsumerList;
+        } else {
+            return stateConsumerList;
         }
 
     }

--- a/api/src/main/java/org/terrakube/api/plugin/state/model/workspace/state/consumers/StateConsumerList.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/model/workspace/state/consumers/StateConsumerList.java
@@ -1,0 +1,16 @@
+package org.terrakube.api.plugin.state.model.workspace.state.consumers;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.terrakube.api.plugin.state.model.workspace.WorkspaceModel;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+public class StateConsumerList {
+
+    List<WorkspaceModel> data;
+}


### PR DESCRIPTION
Adding support to share the terraform state with other workspace inside the same organization using the following:

```terraform
data "terraform_remote_state" "remote_creation_time" {
  backend = "remote"
  config = {
    organization = "simple"
    hostname = "8080-azbuilder-terrakube-vg8s9w8fhaj.ws-us102.gitpod.io"
    workspaces = {
      name = "simple_tag1"
    }
  }
}

resource "null_resource" "previous" {}

resource "time_sleep" "wait_30_seconds" {
  depends_on = [null_resource.previous]

  create_duration = data.terraform_remote_state.remote_creation_time.outputs.creation_time
}

resource "null_resource" "next" {
  depends_on = [time_sleep.wait_30_seconds]
}
```

Example:
![image](https://github.com/AzBuilder/terrakube/assets/4461895/2af10b5d-21b6-4c01-9598-dc60ebe730ef)

Fixes #457 
