### PR TITLE
Fixing logic when searching tags

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -251,18 +251,19 @@ public class RemoteTfeService {
         workspaceList.setData(new ArrayList());
 
         List<String> listTags = Arrays.stream(searchTags.split(",")).toList();
-
+        log.info("Searching workspaces with tags: {}", searchTags);
         for (Workspace workspace : organizationRepository.getOrganizationByName(organizationName).getWorkspace()) {
             List<WorkspaceTag> workspaceTagList = workspace.getWorkspaceTag();
-            boolean includeWorkspace = false;
+            int matchingTags = 0;
+
             for (WorkspaceTag workspaceTag : workspaceTagList) {
                 Tag tag = tagRepository.getReferenceById(UUID.fromString(workspaceTag.getTagId()));
-                if (listTags.indexOf(tag.getName()) > -1 && listTags.size() == workspaceTagList.size()) {
-                    includeWorkspace = true;
+                if (listTags.indexOf(tag.getName()) > -1) {
+                    matchingTags++;
                 }
             }
-
-            if (includeWorkspace) {
+            log.info("Workspace {} Tags Count {} Searching Tag Quantity {} Matched {}", workspace.getName(), workspaceTagList.size(), listTags.size(), matchingTags);
+            if (matchingTags == listTags.size()) {
                 workspaceList.getData().add(getWorkspace(organizationName, workspace.getName(), new HashMap()).getData());
             }
         }


### PR DESCRIPTION
This pull request will fix the logic when searching workspace by tags when using cloud block

The workspace should contain the tags, but it wont matter if the workspace has additional tags.

```terraform
terraform {
  cloud {
    organization = "simple"
    hostname = "8080-azbuilder-terrakube-0mkeox1yjhv.ws-us104.gitpod.io"

    workspaces {
      tags = ["development", "networking"]
    }
  }
}
```

For example when using some sample data like the following:
![image](https://github.com/AzBuilder/terrakube/assets/4461895/01287d92-13b6-470a-ba5a-ba7ebd866fdf)

![image](https://github.com/AzBuilder/terrakube/assets/4461895/61050a93-29b2-4e3d-88ed-4d39074ed7bd)

![image](https://github.com/AzBuilder/terrakube/assets/4461895/111a04d3-4085-4a48-93a0-ef0dfbadeb6d)

![image](https://github.com/AzBuilder/terrakube/assets/4461895/a0725ef2-2b11-4cc2-9a96-ab78c2411fc9)


Result when using the Terraform CLI will be:
![image](https://github.com/AzBuilder/terrakube/assets/4461895/f17736a1-5d1a-4c49-b1d0-716141f6bdb0)
