### PR TITLE
Fix script to setup gcp bucket for testing

### DIFF
--- a/scripts/setupDevelopmentEnvironmentGcp.sh
+++ b/scripts/setupDevelopmentEnvironmentGcp.sh
@@ -49,6 +49,9 @@ function generateApiVars(){
   echo "spring_profiles_active=demo" >> .envApi
   echo "DexClientId=$DexClientId" >> .envApi
   echo "CustomTerraformReleasesUrl=\"https://releases.hashicorp.com/terraform/index.json\"" >> .envApi
+  echo "TerrakubeRedisHostname=localhost" >> .envApi
+  echo "TerrakubeRedisPort=6379" >> .envApi
+  echo "TerrakubeRedisPassword=password123456" >> .envApi
   echo "#TERRAKUBE_ADMIN_GROUP=$TERRAKUBE_ADMIN_GROUP" >> .envApi
 }
 
@@ -101,6 +104,9 @@ function generateExecutorVars(){
   echo "TerrakubeRegistryDomain=$TerrakubeRegistryDomain" >> .envExecutor
   echo "TerrakubeApiUrl=$TerrakubeApiUrl" >> .envExecutor
   echo "CustomTerraformReleasesUrl=\"https://releases.hashicorp.com/terraform/index.json\"" >> .envExecutor
+  echo "TerrakubeRedisHostname=localhost" >> .envExecutor
+  echo "TerrakubeRedisPort=6379" >> .envExecutor
+  echo "TerrakubeRedisPassword=password123456" >> .envExecutor
   echo "JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS" >> .envExecutor
 }
 


### PR DESCRIPTION
Fix script to setup gcp bucket in the GITPOD testing environment, adding missing values for the redis cache added recently