### PR TITLE
Fix Terraform registry authentication logic

### DIFF
--- a/registry/src/main/java/org/terrakube/registry/configuration/authentication/dex/DexWebSecurityAdapter.java
+++ b/registry/src/main/java/org/terrakube/registry/configuration/authentication/dex/DexWebSecurityAdapter.java
@@ -43,6 +43,7 @@ public class DexWebSecurityAdapter extends WebSecurityConfigurerAdapter {
                         .antMatchers("/actuator/**").permitAll()
                         .antMatchers("/terraform/modules/v1/download/**").permitAll()
                         .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .anyRequest().authenticated()
                 )
                 .oauth2ResourceServer(oauth2 -> {
                     AuthenticationManagerResolver<HttpServletRequest> authenticationManagerResolver = RegistryAuthenticationManagerResolver


### PR DESCRIPTION
This will fix the issue with the registry and require authentication to use the following endpoints used by the terraform CLI when using the module protocol.

Search version endpoint:
```bash
{{terrakubeRegistry}}/terraform/modules/v1/{{registryModuleOrg}}/{{registryModuleName}}/{{registryModuleProvider}}
```

Get module.zip URL:
```bash
{{terrakubeRegistry}}/terraform/modules/v1/{{registryModuleOrg}}/{{registryModuleName}}/{{registryModuleProvider}}/{{registryModuleVersion}}
```

Searching without token will return 401 error:
![image](https://github.com/AzBuilder/terrakube/assets/4461895/f9556ffd-b94f-4997-917d-d5af01c7a322)

![image](https://github.com/AzBuilder/terrakube/assets/4461895/8e8cbaee-ce02-48bf-99d2-e08ff52c5872)

Searching using a token:
![image](https://github.com/AzBuilder/terrakube/assets/4461895/9b7b9b65-5b41-44f4-a4e5-2409e96095e1)

![image](https://github.com/AzBuilder/terrakube/assets/4461895/05a12a60-3b23-4022-b9b6-14710351a5b2)

Using the following will return 401
```terraform
module "iam" { 
  source = "8075-azbuilder-terrakube-cebsv4s4ehg.ws-us104.gitpod.io/aws/iam/aws" 
  version = "v5.30.0" 
  # insert required variables here 
}
```
![image](https://github.com/AzBuilder/terrakube/assets/4461895/33cc810f-84c7-4cff-b4ab-2bdb5349e194)

After terraform login
```bash
terraform login 8075-azbuilder-terrakube-cebsv4s4ehg.ws-us104.gitpod.io
Terraform will request an API token for 8075-azbuilder-terrakube-cebsv4s4ehg.ws-us104.gitpod.io using OAuth.

This will work only if you are able to use a web browser on this computer to
complete a login process. If not, you must obtain an API token by another
means and configure it in the CLI configuration manually.

If login is successful, Terraform will store the token in plain text in
the following file for use by subsequent commands:
    /home/user/.terraform.d/credentials.tfrc.json

Do you want to proceed?
  Only 'yes' will be accepted to confirm.

  Enter a value: yes

Terraform must now open a web browser to the login page for 8075-azbuilder-terrakube-cebsv4s4ehg.ws-us104.gitpod.io.

If a browser does not open this automatically, open the following URL to proceed:
    https://5556-azbuilder-terrakube-cebsv4s4ehg.ws-us104.gitpod.io/dex/auth?scope=openid+profile+email+offline_access+groups&client_id=example-app&code_challenge=fynTeeOaNpx6na0tnC4DJy6WaTNq9QnLwjxzWnsEl-g&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost%3A10000%2Flogin&response_type=code&state=cce3bade-0f07-8d6b-45cf-d320efeb9337

Terraform will now wait for the host to signal that login was successful.


---------------------------------------------------------------------------------

Success! Terraform has obtained and saved an API token.

The new API token will be used for any future Terraform command that must make
authenticated requests to 8075-azbuilder-terrakube-cebsv4s4ehg.ws-us104.gitpod.io.
```
With authentication:
```
terraform init

Initializing the backend...
Initializing modules...
Downloading 8075-azbuilder-terrakube-cebsv4s4ehg.ws-us104.gitpod.io/aws/iam/aws 5.30.0 for iam...
- iam in .terraform/modules/iam

Initializing provider plugins...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

```