### PR TITLE
Improve Team Token Validation (cloud block/remote state)

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -61,6 +61,7 @@ public class RemoteTfeController {
         return ResponseEntity.of(Optional.ofNullable(remoteTfeService.getOrgInformation(organizationName, (JwtAuthenticationToken) principal)));
     }
 
+    @Transactional
     @GetMapping(produces = "application/vnd.api+json", path = "organizations/{organizationName}/workspaces/{workspaceName}")
     public ResponseEntity<WorkspaceData> getWorkspace(@PathVariable("organizationName") String organizationName, @PathVariable("workspaceName") String workspaceName, Principal principal) {
         log.info("Searching: {} {}", organizationName, workspaceName);
@@ -94,6 +95,7 @@ public class RemoteTfeController {
     }
 
 
+    @Transactional
     @PostMapping(produces = "application/vnd.api+json", path = "organizations/{organizationName}/workspaces")
     public ResponseEntity<WorkspaceData> createWorkspace(@PathVariable("organizationName") String organizationName, @RequestBody WorkspaceData workspaceData, Principal principal) {
         log.info("Create {}", workspaceData.toString());

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -108,7 +108,6 @@ public class RemoteTfeService {
             userGroups.forEach(userTeam->{
                 if(orgTeam.getName().equals(userTeam)){
                     userIsMemberOrg.set(true);
-                    log.info("User {} is member of {}", currentUser.getTokenAttributes().get("email"), orgTeam.getName());
                 }
             });
         });
@@ -122,7 +121,6 @@ public class RemoteTfeService {
             userGroups.forEach(userTeam->{
                 if(orgTeam.getName().equals(userTeam) && orgTeam.isManageWorkspace()){
                     userWithManageWorkspace.set(true);
-                    log.info("User {} has manage workspace in {}", currentUser.getTokenAttributes().get("email"), orgTeam.getName());
                 }
             });
         });


### PR DESCRIPTION
Using a team token inside an organization without the team read access will return the following error:

![image](https://github.com/AzBuilder/terrakube/assets/4461895/5e9d0f51-32e5-48f2-b781-22f6acf2b889)

Using a team token inside an organization where the team is present but there is no "[manage worspace](https://docs.terrakube.io/user-guide/organizations/team-management)" permission, will return.
![image](https://github.com/AzBuilder/terrakube/assets/4461895/dd5ae110-5822-4167-8aa6-69ea17f47371)

