### PR TITLE
fix hard-coded hostname in configuration details

### DIFF
--- a/ui/src/domain/Modules/Details.jsx
+++ b/ui/src/domain/Modules/Details.jsx
@@ -543,7 +543,8 @@ export const ModuleDetails = ({ setOrganizationName, organizationName }) => {
                       configure credentials in .terraformrc or <br />{" "}
                       terraform.rc to access this module:
                       <pre className="moduleCredentials">
-                        credentials "app.terrakube.io" {"{"} <br />
+                        credentials "
+                        {new URL(window._env_.REACT_APP_REGISTRY_URI).hostname" {"{"} <br />
                         &nbsp;&nbsp;# valid user API token:
                         <br />
                         &nbsp;&nbsp;token = "xxxxxx.yyyyyy.zzzzzzzzzzzzz"

--- a/ui/src/domain/Modules/Details.jsx
+++ b/ui/src/domain/Modules/Details.jsx
@@ -544,7 +544,7 @@ export const ModuleDetails = ({ setOrganizationName, organizationName }) => {
                       terraform.rc to access this module:
                       <pre className="moduleCredentials">
                         credentials "
-                        {new URL(window._env_.REACT_APP_REGISTRY_URI).hostname" {"{"} <br />
+                        {new URL(window._env_.REACT_APP_REGISTRY_URI).hostname}" {"{"} <br />
                         &nbsp;&nbsp;# valid user API token:
                         <br />
                         &nbsp;&nbsp;token = "xxxxxx.yyyyyy.zzzzzzzzzzzzz"


### PR DESCRIPTION
In the 'configuration details' help box on a registry module, there is a hard-coded value of 'app.terrakube.io' for the registry hostname.
This change sets the hostname to the value defined in Terrakube for the Registry URL.