### PR TITLE
Remove deprecated WebSecurityConfigurerAdapter

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
@@ -36,7 +36,6 @@ public class DexWebSecurityAdapter {
                         .antMatchers(HttpMethod.PUT, "/remote/tfe/v2/configuration-versions/*").permitAll()
                         .antMatchers("/remote/tfe/v2/plans/*/logs").permitAll()
                         .antMatchers("/remote/tfe/v2/applies/*/logs").permitAll()
-                        .antMatchers(HttpMethod.POST, "/remote/tfe/v2/workspaces/{workspaceId}/state-versions").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2ResourceServer(oauth2 -> {

--- a/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
@@ -32,7 +32,6 @@ public class DexWebSecurityAdapter {
                         .antMatchers("/callback/v1/**").permitAll()
                         .antMatchers("/.well-known/terraform.json").permitAll()
                         .antMatchers("/remote/tfe/v2/ping").permitAll()
-                        .antMatchers("/remote/tfe/v2/configuration-versions/*/terraformContent.tar.gz").permitAll()
                         .antMatchers(HttpMethod.PUT, "/remote/tfe/v2/configuration-versions/*").permitAll()
                         .antMatchers("/remote/tfe/v2/plans/*/logs").permitAll()
                         .antMatchers("/remote/tfe/v2/applies/*/logs").permitAll()

--- a/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
@@ -26,12 +26,17 @@ public class DexWebSecurityAdapter {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, @Value("${org.terrakube.token.issuer-uri}") String issuerUri, @Value("${org.terrakube.token.pat}") String patJwtSecret, @Value("${org.terrakube.token.internal}") String internalJwtSecret) throws Exception {
-        http.cors().and().authorizeRequests(authz -> authz
+        http.csrf().disable().cors().and().authorizeRequests(authz -> authz
                         .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .antMatchers("/actuator/**").permitAll()
                         .antMatchers("/callback/v1/**").permitAll()
-                        .antMatchers("configuration-versions/*/terraformContent.tar.gz").permitAll()
-                        .antMatchers("/doc").permitAll()
+                        .antMatchers("/.well-known/terraform.json").permitAll()
+                        .antMatchers("/remote/tfe/v2/ping").permitAll()
+                        .antMatchers("/remote/tfe/v2/configuration-versions/*/terraformContent.tar.gz").permitAll()
+                        .antMatchers(HttpMethod.PUT, "/remote/tfe/v2/configuration-versions/*").permitAll()
+                        .antMatchers("/remote/tfe/v2/plans/*/logs").permitAll()
+                        .antMatchers("/remote/tfe/v2/applies/*/logs").permitAll()
+                        .antMatchers(HttpMethod.POST, "/remote/tfe/v2/workspaces/{workspaceId}/state-versions").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2ResourceServer(oauth2 -> {

--- a/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
@@ -26,7 +26,7 @@ public class DexWebSecurityAdapter {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, @Value("${org.terrakube.token.issuer-uri}") String issuerUri, @Value("${org.terrakube.token.pat}") String patJwtSecret, @Value("${org.terrakube.token.internal}") String internalJwtSecret) throws Exception {
-        http.csrf().ignoringAntMatchers("/remote/tfe/v2/configuration-versions/*").and().cors().and().authorizeRequests(authz -> authz
+        http.cors().and().authorizeRequests(authz -> authz
                         .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .antMatchers("/actuator/**").permitAll()
                         .antMatchers("/callback/v1/**").permitAll()

--- a/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
@@ -26,7 +26,7 @@ public class DexWebSecurityAdapter {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, @Value("${org.terrakube.token.issuer-uri}") String issuerUri, @Value("${org.terrakube.token.pat}") String patJwtSecret, @Value("${org.terrakube.token.internal}") String internalJwtSecret) throws Exception {
-        http.csrf().disable().cors().and().authorizeRequests(authz -> authz
+        http.csrf().ignoringAntMatchers("/remote/tfe/v2/configuration-versions/*").and().cors().and().authorizeRequests(authz -> authz
                         .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .antMatchers("/actuator/**").permitAll()
                         .antMatchers("/callback/v1/**").permitAll()

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -123,10 +123,18 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
 
     private void downloadWorkspaceTarGz(File tarGzFolder, String source) throws IOException {
         File terraformTarGz = new File(tarGzFolder.getPath() + "/terraformContent.tar.gz");
-        URL url = new URL(source);
-        URLConnection urlConnection = url.openConnection();
-        urlConnection.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(1));
-        IOUtils.copy(urlConnection.getInputStream(), new FileOutputStream(terraformTarGz));
+        OutputStream stream = null;
+        try {
+            URL url = new URL(source);
+            URLConnection urlConnection = url.openConnection();
+            urlConnection.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(1));
+            IOUtils.copy(urlConnection.getInputStream(), new FileOutputStream(terraformTarGz));
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        } finally {
+            stream.close();
+        }
+
         extractTarGZ(new FileInputStream(terraformTarGz), tarGzFolder.getPath());
     }
 

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -128,7 +128,8 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
             URL url = new URL(source);
             URLConnection urlConnection = url.openConnection();
             urlConnection.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(1));
-            IOUtils.copy(urlConnection.getInputStream(), new FileOutputStream(terraformTarGz));
+            stream = new FileOutputStream(terraformTarGz);
+            IOUtils.copy(urlConnection.getInputStream(), stream);
         } catch (Exception e) {
             log.error(e.getMessage());
         } finally {

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -5,6 +5,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -24,6 +25,7 @@ import org.terrakube.executor.service.workspace.security.WorkspaceSecurity;
 import java.io.*;
 import java.net.InetSocketAddress;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -121,7 +123,10 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
 
     private void downloadWorkspaceTarGz(File tarGzFolder, String source) throws IOException {
         File terraformTarGz = new File(tarGzFolder.getPath() + "/terraformContent.tar.gz");
-        FileUtils.copyURLToFile(new URL(source), terraformTarGz, 10000, 10000);
+        URL url = new URL(source);
+        URLConnection urlConnection = url.openConnection();
+        urlConnection.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(1));
+        IOUtils.copy(urlConnection.getInputStream(), new FileOutputStream(terraformTarGz));
         extractTarGZ(new FileInputStream(terraformTarGz), tarGzFolder.getPath());
     }
 

--- a/registry/src/main/java/org/terrakube/registry/configuration/authentication/dex/DexWebSecurityAdapter.java
+++ b/registry/src/main/java/org/terrakube/registry/configuration/authentication/dex/DexWebSecurityAdapter.java
@@ -2,6 +2,7 @@ package org.terrakube.registry.configuration.authentication.dex;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -20,6 +21,7 @@ import java.util.List;
 
 @Slf4j
 @Configuration
+@ConditionalOnProperty(prefix = "org.terrakube.registry.authentication", name = "type", havingValue = "DEX")
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true, jsr250Enabled = true)
 public class DexWebSecurityAdapter {

--- a/registry/src/main/java/org/terrakube/registry/configuration/authentication/dex/DexWebSecurityAdapter.java
+++ b/registry/src/main/java/org/terrakube/registry/configuration/authentication/dex/DexWebSecurityAdapter.java
@@ -2,14 +2,14 @@ package org.terrakube.registry.configuration.authentication.dex;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManagerResolver;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -21,23 +21,11 @@ import java.util.List;
 @Slf4j
 @Configuration
 @EnableWebSecurity
-@ConditionalOnProperty(prefix = "org.terrakube.registry.authentication", name = "type", havingValue = "DEX")
-public class DexWebSecurityAdapter extends WebSecurityConfigurerAdapter {
+@EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true, jsr250Enabled = true)
+public class DexWebSecurityAdapter {
 
-    @Value("${org.terrakube.ui.fqdn:http://localhost:3000}")
-    private String uiDomain;
-
-    @Value("${org.terrakube.token.issuer-uri}")
-    private String issuerUri;
-
-    @Value("${org.terrakube.token.pat}")
-    private String patJwtSecret;
-
-    @Value("${org.terrakube.token.internal}")
-    private String internalJwtSecret;
-
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, @Value("${org.terrakube.token.issuer-uri}") String issuerUri, @Value("${org.terrakube.token.pat}") String patJwtSecret, @Value("${org.terrakube.token.internal}") String internalJwtSecret) throws Exception {
         http.cors().and().authorizeRequests(authz -> authz
                         .antMatchers("/.well-known/**").permitAll()
                         .antMatchers("/actuator/**").permitAll()
@@ -48,16 +36,18 @@ public class DexWebSecurityAdapter extends WebSecurityConfigurerAdapter {
                 .oauth2ResourceServer(oauth2 -> {
                     AuthenticationManagerResolver<HttpServletRequest> authenticationManagerResolver = RegistryAuthenticationManagerResolver
                             .builder()
-                            .issuerUri(this.issuerUri)
-                            .patSecret(this.patJwtSecret)
-                            .internalSecret(this.internalJwtSecret)
+                            .issuerUri(issuerUri)
+                            .patSecret(patJwtSecret)
+                            .internalSecret(internalJwtSecret)
                             .build();
                     oauth2.authenticationManagerResolver(authenticationManagerResolver);
                 });
+
+        return http.build();
     }
 
     @Bean
-    CorsConfigurationSource corsConfigurationSource() {
+    CorsConfigurationSource corsConfigurationSource(@Value("${org.terrakube.ui.fqdn:http://localhost:3000}") String uiDomain) {
         log.info("CORS for UI Domain {}", uiDomain);
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(List.of(uiDomain.split(",")));

--- a/registry/src/main/java/org/terrakube/registry/configuration/authentication/dex/DexWebSecurityAdapter.java
+++ b/registry/src/main/java/org/terrakube/registry/configuration/authentication/dex/DexWebSecurityAdapter.java
@@ -26,7 +26,7 @@ public class DexWebSecurityAdapter {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, @Value("${org.terrakube.token.issuer-uri}") String issuerUri, @Value("${org.terrakube.token.pat}") String patJwtSecret, @Value("${org.terrakube.token.internal}") String internalJwtSecret) throws Exception {
-        http.cors().and().authorizeRequests(authz -> authz
+        http.csrf().disable().cors().and().authorizeRequests(authz -> authz
                         .antMatchers("/.well-known/**").permitAll()
                         .antMatchers("/actuator/**").permitAll()
                         .antMatchers("/terraform/modules/v1/download/**").permitAll()

--- a/registry/src/main/java/org/terrakube/registry/configuration/authentication/dex/DexWebSecurityAdapter.java
+++ b/registry/src/main/java/org/terrakube/registry/configuration/authentication/dex/DexWebSecurityAdapter.java
@@ -28,7 +28,7 @@ public class DexWebSecurityAdapter {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, @Value("${org.terrakube.token.issuer-uri}") String issuerUri, @Value("${org.terrakube.token.pat}") String patJwtSecret, @Value("${org.terrakube.token.internal}") String internalJwtSecret) throws Exception {
-        http.csrf().disable().cors().and().authorizeRequests(authz -> authz
+        http.cors().and().authorizeRequests(authz -> authz
                         .antMatchers("/.well-known/**").permitAll()
                         .antMatchers("/actuator/**").permitAll()
                         .antMatchers("/terraform/modules/v1/download/**").permitAll()

--- a/ui/src/domain/Jobs/Details.jsx
+++ b/ui/src/domain/Jobs/Details.jsx
@@ -214,7 +214,7 @@ export const DetailsJob = ({ jobId }) => {
   const loadContext = () => {
     const api = new URL(window._env_.REACT_APP_TERRAKUBE_API_URL);
 
-    axiosClient
+    axiosInstance
       .get(`${api.protocol}//${api.host}/context/v1/${jobId}`)
       .then((response) => {
         console.log("terrakube");

--- a/ui/src/domain/Workspaces/Create.jsx
+++ b/ui/src/domain/Workspaces/Create.jsx
@@ -54,7 +54,7 @@ export const CreateWorkspace = () => {
   useEffect(() => {
     setOrganizationName(localStorage.getItem(ORGANIZATION_NAME));
     setLoading(true);
-    axiosClient.get(terraformVersionsApi).then((resp) => {
+    axiosInstance.get(terraformVersionsApi).then((resp) => {
       console.log(resp);
       const tfVersions = [];
       for (const version in resp.data.versions) {

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -111,7 +111,7 @@ export const WorkspaceDetails = (props) => {
   useEffect(() => {
     setLoading(true);
     loadWorkspace();
-    axiosClient.get(terraformVersionsApi).then((resp) => {
+    axiosInstance.get(terraformVersionsApi).then((resp) => {
       const tfVersions = [];
       for (const version in resp.data.versions) {
         if (!version.includes("-")) tfVersions.push(version);


### PR DESCRIPTION
Refactor code to remove deprecated WebSecurityConfigurerAdapter to use the new way using @Bean SecurityFilterChain

Tested with terraform 1.5.7

Reference: 
https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter
https://www.baeldung.com/spring-deprecated-websecurityconfigureradapter