### PR TITLE
Fix remote execution using data.terraform_remote_state

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -101,7 +101,13 @@ public class RemoteTfeService {
         this.teamTokenService = teamTokenService;
     }
 
+    private boolean validateTerrakubeUser(JwtAuthenticationToken currentUser){
+        return currentUser.getTokenAttributes().get("iss").equals("TerrakubeInternal");
+    }
+
     private boolean validateUserIsMemberOrg(Organization organization, JwtAuthenticationToken currentUser){
+        if(validateTerrakubeUser(currentUser))
+            return true;
         List<String> userGroups = teamTokenService.getCurrentGroups(currentUser);
         AtomicBoolean userIsMemberOrg = new AtomicBoolean(false);
         organization.getTeam().forEach(orgTeam ->{
@@ -115,6 +121,8 @@ public class RemoteTfeService {
     }
 
     private boolean validateUserManageWorkspace(Organization organization, JwtAuthenticationToken currentUser){
+        if(validateTerrakubeUser(currentUser))
+            return true;
         List<String> userGroups = teamTokenService.getCurrentGroups(currentUser);
         AtomicBoolean userWithManageWorkspace = new AtomicBoolean(false);
         organization.getTeam().forEach(orgTeam ->{


### PR DESCRIPTION
Fix internal token validation when using remote execution using data.terraform_remote_state

Workspace 1 (name=shared1):

```terraform
terraform {
  cloud {
    organization = "simple"
    hostname = "8080-azbuilder-terrakube-uzxpj6u2gpe.ws-us105.gitpod.io"

    workspaces {
      tags = ["shared1", "example"]
    }
  }
}

resource "null_resource" "previous" {}

resource "time_sleep" "wait_30_seconds" {
  depends_on = [null_resource.previous]

  create_duration = "5s"
}

resource "null_resource" "next" {
  depends_on = [time_sleep.wait_30_seconds]
}

output "creation_time" {
    value = time_sleep.wait_30_seconds.create_duration
}
```

Workspace 2 (name=shared2)
```terraform
terraform {
  cloud {
    organization = "simple"
    hostname = "8080-azbuilder-terrakube-uzxpj6u2gpe.ws-us105.gitpod.io"

    workspaces {
      tags = ["shared2", "example"]
    }
  }
}


data "terraform_remote_state" "remote_creation_time" {
  backend = "remote"
  config = {
    organization = "simple"
    hostname = "8080-azbuilder-terrakube-uzxpj6u2gpe.ws-us105.gitpod.io"
    workspaces = {
      name = "shared1"
    }
  }
}

resource "null_resource" "previous" {}

resource "time_sleep" "wait_30_seconds" {
  depends_on = [null_resource.previous]

  create_duration = data.terraform_remote_state.remote_creation_time.outputs.creation_time
}

resource "null_resource" "next" {
  depends_on = [time_sleep.wait_30_seconds]
}
```

Running remote execution from the CLI:
![image](https://github.com/AzBuilder/terrakube/assets/4461895/6f9edfda-6e96-448f-804f-5b85f0becbf8)

Running remote execution from the UI.
![image](https://github.com/AzBuilder/terrakube/assets/4461895/d08fd6ee-0885-4c47-be17-468375317d0e)



Fix #530 