### PR TITLE
Keep repository structure when cloning a GIT workspace

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -50,7 +50,7 @@
                 <image>
                     <builder>paketobuildpacks/builder-jammy-base</builder>
                     <buildpacks>
-                        <buildpack>gcr.io/paketo-buildpacks/java</buildpack>
+                        <buildpack>gcr.io/paketo-buildpacks/java:10.1.0</buildpack>
                         <buildpack>gcr.io/paketo-buildpacks/opentelemetry</buildpack>
                     </buildpacks>
                     <bindings>

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -101,7 +101,13 @@ public class RemoteTfeService {
         this.teamTokenService = teamTokenService;
     }
 
+    private boolean validateTerrakubeUser(JwtAuthenticationToken currentUser){
+        return currentUser.getTokenAttributes().get("iss").equals("TerrakubeInternal");
+    }
+
     private boolean validateUserIsMemberOrg(Organization organization, JwtAuthenticationToken currentUser){
+        if(validateTerrakubeUser(currentUser))
+            return true;
         List<String> userGroups = teamTokenService.getCurrentGroups(currentUser);
         AtomicBoolean userIsMemberOrg = new AtomicBoolean(false);
         organization.getTeam().forEach(orgTeam ->{
@@ -115,6 +121,8 @@ public class RemoteTfeService {
     }
 
     private boolean validateUserManageWorkspace(Organization organization, JwtAuthenticationToken currentUser){
+        if(validateTerrakubeUser(currentUser))
+            return true;
         List<String> userGroups = teamTokenService.getCurrentGroups(currentUser);
         AtomicBoolean userWithManageWorkspace = new AtomicBoolean(false);
         organization.getTeam().forEach(orgTeam ->{

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -202,7 +202,7 @@
 					<image>
 					    <builder>paketobuildpacks/builder-jammy-base</builder>
                     	<buildpacks>
-                        	<buildpack>gcr.io/paketo-buildpacks/java</buildpack>
+                        	<buildpack>gcr.io/paketo-buildpacks/java:10.1.0</buildpack>
                         	<buildpack>gcr.io/paketo-buildpacks/opentelemetry</buildpack>
                     	</buildpacks>
                     	<bindings>

--- a/executor/src/main/java/org/terrakube/executor/service/scripts/CommandExecution.java
+++ b/executor/src/main/java/org/terrakube/executor/service/scripts/CommandExecution.java
@@ -6,5 +6,5 @@ import java.io.File;
 import java.util.function.Consumer;
 
 public interface CommandExecution {
-    boolean execute(TerraformJob terraformJob, String command, File workingDirectory, Consumer<String> output);
+    boolean execute(TerraformJob terraformJob, String command, File terraformWorkingDir, Consumer<String> output);
 }

--- a/executor/src/main/java/org/terrakube/executor/service/scripts/bash/BashEngine.java
+++ b/executor/src/main/java/org/terrakube/executor/service/scripts/bash/BashEngine.java
@@ -33,11 +33,11 @@ public class BashEngine implements CommandExecution {
     private final ExecutorService executor = Executors.newWorkStealingPool();
 
     @Override
-    public boolean execute(TerraformJob terraformJob, String script, File workingDirectory, Consumer<String> output) {
+    public boolean execute(TerraformJob terraformJob, String script, File terraformWorkingDir, Consumer<String> output) {
         boolean executeSuccess = true;
         File bashScript = new File(
                 FilenameUtils.separatorsToSystem(
-                        workingDirectory.getAbsolutePath().concat(USER_BASH_SCRIPT)
+                        terraformWorkingDir.getAbsolutePath().concat(USER_BASH_SCRIPT)
                 )
         );
 
@@ -45,7 +45,7 @@ public class BashEngine implements CommandExecution {
             log.info("ScriptPath: {}", bashScript.toURI().toURL());
             FileUtils.writeStringToFile(bashScript, script, Charset.defaultCharset());
 
-            ProcessLauncher processLauncher = setupBashProcess(terraformJob, workingDirectory, bashScript, output, output);
+            ProcessLauncher processLauncher = setupBashProcess(terraformJob, terraformWorkingDir, bashScript, output, output);
             Integer exitCode = processLauncher.launch().get();
             log.info("Exit code {}", exitCode);
             if(exitCode != 0) {

--- a/executor/src/main/java/org/terrakube/executor/service/scripts/groovy/GroovyEngine.java
+++ b/executor/src/main/java/org/terrakube/executor/service/scripts/groovy/GroovyEngine.java
@@ -41,15 +41,15 @@ public class GroovyEngine implements CommandExecution {
     }
 
     @Override
-    public boolean execute(TerraformJob terraformJob, String scriptContent, File workingDirectory, Consumer<String> output) {
+    public boolean execute(TerraformJob terraformJob, String scriptContent, File terraformWorkingDir, Consumer<String> output) {
         boolean executeSuccess = true;
-        File groovyScript = new File(workingDirectory.getAbsolutePath() + USER_GROOVY_SCRIPT);
+        File groovyScript = new File(terraformWorkingDir.getAbsolutePath() + USER_GROOVY_SCRIPT);
 
         try {
             log.info("ScriptPath: {}", groovyScript.toURI().toURL());
             FileUtils.writeStringToFile(groovyScript, scriptContent, Charset.defaultCharset());
 
-            List<URL> groovyClasses = getGroovyExtensions(workingDirectory);
+            List<URL> groovyClasses = getGroovyExtensions(terraformWorkingDir);
             groovyClasses.add(groovyScript.toURI().toURL());
 
             log.info("Execute Groovy scriptContent: \n {}", scriptContent);
@@ -58,7 +58,7 @@ public class GroovyEngine implements CommandExecution {
                     this.getClass().getClassLoader()
             );
 
-            Binding sharedData = setupBindings(terraformJob, workingDirectory);
+            Binding sharedData = setupBindings(terraformJob, terraformWorkingDir);
             sharedData.setProperty("terrakubeOutput", new ByteArrayOutputStream());
 
             engine.run(groovyScript.getName(), sharedData);

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -62,8 +62,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         try {
             if (!terraformJob.getBranch().equals("remote-content")) {
                 terraformWorkingDir = new File(workingDirectory.getCanonicalPath() + terraformJob.getFolder());
-            } else
-                terraformWorkingDir = workingDirectory;
+            }
         } catch (IOException e) {
             log.error(e.getMessage());
         }

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -58,7 +58,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
     }
 
     private File getTerraformWorkingDir(TerraformJob terraformJob, File workingDirectory) throws IOException {
-        File terraformWorkingDir = null;
+        File terraformWorkingDir = workingDirectory;
         try {
             if (!terraformJob.getBranch().equals("remote-content")) {
                 terraformWorkingDir = new File(workingDirectory.getCanonicalPath() + terraformJob.getFolder());
@@ -67,7 +67,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         } catch (IOException e) {
             log.error(e.getMessage());
         }
-        log.info("Terraform Working Directory: {}",terraformWorkingDir.getCanonicalPath());
+        log.info("Terraform Working Directory: {}", terraformWorkingDir.getCanonicalPath());
         return terraformWorkingDir;
     }
 

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -56,7 +56,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
             if (!terraformJob.getBranch().equals("remote-content")) {
                 downloadWorkspace(workspaceCloneFolder, terraformJob);
             } else {
-                downloadWorkspaceTarGz(workspaceCloneFolder.getParentFile(), terraformJob.getSource());
+                downloadWorkspaceTarGz(workspaceCloneFolder, terraformJob.getSource());
             }
             if (enableRegistrySecurity)
                 workspaceSecurity.addTerraformCredentials(workspaceCloneFolder);

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -37,7 +37,7 @@ import java.util.*;
 @Service
 public class SetupWorkspaceImpl implements SetupWorkspace {
 
-    private static final String EXECUTOR_DIRECTORY = "%s/.terraform-spring-boot/executor/%s/%s/.originRepository";
+    private static final String EXECUTOR_DIRECTORY = "%s/.terraform-spring-boot/executor/%s/%s";
     public static final String SSH_DIRECTORY = "%s/.terraform-spring-boot/executor/%s/%s/.ssh/%s";
 
     WorkspaceSecurity workspaceSecurity;
@@ -75,7 +75,6 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
         FileUtils.forceMkdir(executorFolder);
         FileUtils.cleanDirectory(executorFolder);
         log.info("Workspace git clone directory: {}", executorFolder.getPath());
-        log.info("Workspace working directory: {}", executorFolder.getParentFile().getPath());
         return executorFolder;
     }
 
@@ -101,20 +100,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
 
             getCommitId(gitCloneFolder);
 
-            log.info("Copy files from folder {} to {}", gitCloneFolder.getPath() + terraformJob.getFolder(), gitCloneFolder.getParentFile().getPath());
-            File finalWorkspaceFolder = new File(gitCloneFolder.getPath() + terraformJob.getFolder());
-            if (finalWorkspaceFolder.exists())
-                for (File srcFile : finalWorkspaceFolder.listFiles()) {
-                    log.info("Copy {} to {}", srcFile.getName(), gitCloneFolder.getParentFile().getPath());
-                    if (srcFile.isDirectory()) {
-                        FileUtils.copyDirectoryToDirectory(srcFile, gitCloneFolder.getParentFile());
-                    } else {
-                        FileUtils.copyFileToDirectory(srcFile, gitCloneFolder.getParentFile());
-                    }
-                }
-            else {
-                log.error("Folder {} does not exists in the repository", terraformJob.getFolder());
-            }
+            log.info("Git clone: {} Branch: {} Folder {}", terraformJob.getSource(), terraformJob.getBranch(), gitCloneFolder.getPath());
 
         } catch (GitAPIException ex) {
             log.error(ex.getMessage());
@@ -150,7 +136,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
                     log.debug("Creating folder: {}", f.getCanonicalPath());
                     String canonicalDestinationPath = f.getCanonicalPath();
 
-                    if( !canonicalDestinationPath.startsWith(destinationFilePath)){
+                    if (!canonicalDestinationPath.startsWith(destinationFilePath)) {
                         throw new IOException("Entry is outside of the target directory");
                     }
 
@@ -164,13 +150,13 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
                     File f = new File(String.format("%s/%s", destinationFilePath, entry.getName()));
                     String canonicalDestinationPath = f.getCanonicalPath();
 
-                    if( !canonicalDestinationPath.startsWith(destinationFilePath)){
+                    if (!canonicalDestinationPath.startsWith(destinationFilePath)) {
                         throw new IOException("Entry is outside of the target directory");
                     }
                     if (!f.exists()) {
                         f.getParentFile().mkdirs();
-                        if(f.createNewFile()){
-                            log.debug("File created: {}",f.getCanonicalPath());
+                        if (f.createNewFile()) {
+                            log.debug("File created: {}", f.getCanonicalPath());
                         }
                     }
                     FileOutputStream fos = new FileOutputStream(f.getCanonicalPath(), false);
@@ -244,7 +230,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
             log.info("Creating new SSH folder for organization {} wordkspace {}", organizationId, workspaceId);
             FileUtils.forceMkdirParent(sshFile);
             FileUtils.writeStringToFile(sshFile, privateKey + "\n", Charset.defaultCharset());
-            
+
             Set<PosixFilePermission> perms = new HashSet<>();
             perms.add(PosixFilePermission.OWNER_READ);
             perms.add(PosixFilePermission.OWNER_WRITE);

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -184,7 +184,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
                     next();
             String latestCommitHash = latestCommit.getName();
             log.info("Commit Id: {}", latestCommitHash);
-            String commitInfoFile = String.format("%s/commitHash.info", gitCloneFolder.getParentFile().getPath());
+            String commitInfoFile = String.format("%s/commitHash.info", gitCloneFolder.getCanonicalPath());
             log.info("Writing commit id to {}", commitInfoFile);
             FileUtils.writeStringToFile(new File(commitInfoFile), latestCommitHash, Charset.defaultCharset());
 

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -59,7 +59,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
                 downloadWorkspaceTarGz(workspaceCloneFolder, terraformJob.getSource());
             }
             if (enableRegistrySecurity)
-                workspaceSecurity.addTerraformCredentials(workspaceCloneFolder);
+                workspaceSecurity.addTerraformCredentials();
         } catch (IOException e) {
             log.error(e.getMessage());
         }

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -63,7 +63,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
         } catch (IOException e) {
             log.error(e.getMessage());
         }
-        return workspaceCloneFolder != null ? workspaceCloneFolder.getParentFile() : new File("/tmp/" + UUID.randomUUID());
+        return workspaceCloneFolder != null ? workspaceCloneFolder : new File("/tmp/" + UUID.randomUUID());
     }
 
     private File setupWorkspaceDirectory(String organizationId, String workspaceId) throws IOException {

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/security/WorkspaceSecurity.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/security/WorkspaceSecurity.java
@@ -4,7 +4,7 @@ import java.io.File;
 
 public interface WorkspaceSecurity {
 
-    void addTerraformCredentials(File workingDirectory);
+    void addTerraformCredentials();
 
     String generateAccessToken();
 

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/security/WorkspaceSecurityImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/security/WorkspaceSecurityImpl.java
@@ -87,7 +87,7 @@ public class WorkspaceSecurityImpl implements WorkspaceSecurity {
     }
 
     @Override
-    public void addTerraformCredentials(File workingDirectory) {
+    public void addTerraformCredentials() {
 
         String token = generateAccessToken();
         String credentialFileContent = String.format(CREDENTIALS_CONTENT, registryDomain, token);

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>2.16.0-beta.1</revision>
+        <revision>2.17.0</revision>
         <sonar.organization>azbuilder</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.project.key>AzBuilder_azb-server</sonar.project.key>

--- a/registry/pom.xml
+++ b/registry/pom.xml
@@ -39,7 +39,7 @@
                 <image>
 				    <builder>paketobuildpacks/builder-jammy-base</builder>
                     <buildpacks>
-                        <buildpack>gcr.io/paketo-buildpacks/java</buildpack>
+                        <buildpack>gcr.io/paketo-buildpacks/java:10.1.0</buildpack>
                         <buildpack>gcr.io/paketo-buildpacks/opentelemetry</buildpack>
                     </buildpacks>
                     <bindings>


### PR DESCRIPTION
This will keep all the git repository structure instead of just copy the folders form the "path" parameter from the workspace definition, this will allow to use modules that are inside the same repository.

Fix #431 