### PR TITLE
Support to handle minutes and hours in team token

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -50,7 +50,7 @@
                 <image>
                     <builder>paketobuildpacks/builder-jammy-base</builder>
                     <buildpacks>
-                        <buildpack>gcr.io/paketo-buildpacks/java:10.1.0</buildpack>
+                        <buildpack>gcr.io/paketo-buildpacks/java</buildpack>
                         <buildpack>gcr.io/paketo-buildpacks/opentelemetry</buildpack>
                     </buildpacks>
                     <bindings>

--- a/api/src/main/java/org/terrakube/api/plugin/token/team/TeamTokenController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/team/TeamTokenController.java
@@ -26,7 +26,12 @@ public class TeamTokenController {
     @PostMapping
     public ResponseEntity<TeamToken> createToken(@RequestBody GroupTokenRequest groupTokenRequest,  Principal principal) {
         TeamToken teamToken = new TeamToken();
-        teamToken.setToken(teamTokenService.createTeamToken(groupTokenRequest.getGroup(), groupTokenRequest.getDays(), groupTokenRequest.getDescription(), ((JwtAuthenticationToken) principal)));
+        teamToken.setToken(teamTokenService.createTeamToken(
+                groupTokenRequest.getGroup(),
+                groupTokenRequest.getDays(),
+                groupTokenRequest.getHours(),
+                groupTokenRequest.getMinutes(),
+                groupTokenRequest.getDescription(), ((JwtAuthenticationToken) principal)));
         return new ResponseEntity<>(teamToken, HttpStatus.CREATED);
     }
 
@@ -63,7 +68,9 @@ public class TeamTokenController {
     private static class GroupTokenRequest{
         private String group;
         private String description;
-        private int days;
+        private int days = 0;
+        private int minutes = 0;
+        private int hours = 0;
     }
 
 }

--- a/api/src/main/java/org/terrakube/api/plugin/token/team/TeamTokenService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/team/TeamTokenService.java
@@ -53,6 +53,8 @@ public class TeamTokenService {
 
         Date expiration = Date.from(Instant.now().plus(days, ChronoUnit.DAYS).plus(hours, ChronoUnit.HOURS).plus(minutes, ChronoUnit.MINUTES));
 
+        log.info("Team token will expire: {}", expiration);
+
         String jws = Jwts.builder()
                 .setIssuer(ISSUER)
                 .setSubject(String.format("%s (Team Token)", groupName))

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -202,7 +202,7 @@
 					<image>
 					    <builder>paketobuildpacks/builder-jammy-base</builder>
                     	<buildpacks>
-                        	<buildpack>gcr.io/paketo-buildpacks/java:10.1.0</buildpack>
+                        	<buildpack>gcr.io/paketo-buildpacks/java</buildpack>
                         	<buildpack>gcr.io/paketo-buildpacks/opentelemetry</buildpack>
                     	</buildpacks>
                     	<bindings>

--- a/registry/pom.xml
+++ b/registry/pom.xml
@@ -39,7 +39,7 @@
                 <image>
 				    <builder>paketobuildpacks/builder-jammy-base</builder>
                     <buildpacks>
-                        <buildpack>gcr.io/paketo-buildpacks/java:10.1.0</buildpack>
+                        <buildpack>gcr.io/paketo-buildpacks/java</buildpack>
                         <buildpack>gcr.io/paketo-buildpacks/opentelemetry</buildpack>
                     </buildpacks>
                     <bindings>

--- a/thunder-tests/thunderclient.json
+++ b/thunder-tests/thunderclient.json
@@ -2651,7 +2651,7 @@
     "method": "POST",
     "sortNum": 730000,
     "created": "2023-09-14T23:33:33.132Z",
-    "modified": "2023-09-14T23:38:39.297Z",
+    "modified": "2023-10-16T16:33:41.029Z",
     "headers": [
       {
         "name": "Content-Type",
@@ -2661,7 +2661,7 @@
     "params": [],
     "body": {
       "type": "json",
-      "raw": "{\n  \"days\": \"1\",\n  \"group\": \"TERRAKUBE_ADMIN\",\n  \"description\": \"Sample PAT\"\n}",
+      "raw": "{\n  \"days\": \"0\",\n  \"hours\": \"6\",\n  \"minutes\": \"00\",\n  \"group\": \"TERRAKUBE_ADMIN\",\n  \"description\": \"Sample PAT\"\n}",
       "form": []
     },
     "auth": {


### PR DESCRIPTION
Add support to handle minutes and hours when generating a team token.

Example:
```
POST {{terrakubeApi}}/access-token/v1/teams
Authorization: Bearer (PERSONAL ACCESS TOKEN)
Request Body:
{
  "days": "1",
  "hours": "6",
  "minutes": "30",
  "group": "TERRAKUBE_ADMIN",
  "description": "Sample PAT"
}
```

Fix #535 