### PR TITLE
Delete module data from storage backend (Minio/S3/Local)

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/module/DeleteStorageCacheJob.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/module/DeleteStorageCacheJob.java
@@ -1,0 +1,22 @@
+package org.terrakube.api.plugin.scheduler.module;
+
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.terrakube.api.plugin.storage.StorageTypeService;
+
+@Slf4j
+public class DeleteStorageCacheJob implements Job {
+
+    StorageTypeService storageTypeService;
+
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+        log.info("Deleting module storage backened data....");
+        storageTypeService.deleteModuleStorage(
+                jobExecutionContext.getJobDetail().getJobDataMap().getString("moduleOrganization"),
+                jobExecutionContext.getJobDetail().getJobDataMap().getString("moduleName"),
+                jobExecutionContext.getJobDetail().getJobDataMap().getString("moduleProvider"));
+    }
+}

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/module/DeleteStorageCacheJob.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/module/DeleteStorageCacheJob.java
@@ -1,12 +1,16 @@
 package org.terrakube.api.plugin.scheduler.module;
 
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
+import org.springframework.stereotype.Component;
 import org.terrakube.api.plugin.storage.StorageTypeService;
 
 @Slf4j
+@AllArgsConstructor
+@Component
 public class DeleteStorageCacheJob implements Job {
 
     StorageTypeService storageTypeService;

--- a/api/src/main/java/org/terrakube/api/plugin/storage/StorageTypeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/StorageTypeService.java
@@ -23,4 +23,6 @@ public interface StorageTypeService {
     void createContentFile(String contentId, InputStream inputStream);
 
     byte[] getContentFile(String contentId);
+
+    void deleteModuleStorage(String organizationName, String moduleName, String providerName);
 }

--- a/api/src/main/java/org/terrakube/api/plugin/storage/azure/AzureStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/azure/AzureStorageTypeServiceImpl.java
@@ -141,4 +141,9 @@ public class AzureStorageTypeServiceImpl implements StorageTypeService {
             return "".getBytes(StandardCharsets.UTF_8);
         }
     }
+
+    @Override
+    public void deleteModuleStorage(String organizationName, String moduleName, String providerName) {
+        log.warn("Delete Module Storage not supported (Azure)");
+    }
 }

--- a/api/src/main/java/org/terrakube/api/plugin/storage/gcp/GcpStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/gcp/GcpStorageTypeServiceImpl.java
@@ -194,4 +194,9 @@ public class GcpStorageTypeServiceImpl implements StorageTypeService {
         else
             return "".getBytes(Charset.defaultCharset());
     }
+
+    @Override
+    public void deleteModuleStorage(String organizationName, String moduleName, String providerName) {
+        log.warn("Delete Module Storage not supported (Gcp)");
+    }
 }

--- a/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
@@ -161,4 +161,15 @@ public class LocalStorageTypeServiceImpl implements StorageTypeService {
             return NO_DATA_FOUND.getBytes(StandardCharsets.UTF_8);
         }
     }
+
+    @Override
+    public void deleteModuleStorage(String organizationName, String moduleName, String providerName) {
+        try {
+            String registryPath = String.format("%s/.terraform-spring-boot/local/modules/%s/%s/%s", FileUtils.getUserDirectoryPath(), organizationName, moduleName, providerName);
+            log.warn("Delete module folder: {}", registryPath);
+            FileUtils.cleanDirectory(new File(registryPath));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/api/src/main/java/org/terrakube/api/rs/hooks/module/ModuleManageHook.java
+++ b/api/src/main/java/org/terrakube/api/rs/hooks/module/ModuleManageHook.java
@@ -1,0 +1,62 @@
+package org.terrakube.api.rs.hooks.module;
+
+import com.yahoo.elide.annotation.LifeCycleHookBinding;
+import com.yahoo.elide.core.lifecycle.LifeCycleHook;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.*;
+import org.terrakube.api.plugin.scheduler.module.DeleteStorageCacheJob;
+import org.terrakube.api.rs.module.Module;
+
+import java.util.Optional;
+import java.util.UUID;
+
+
+@AllArgsConstructor
+@Slf4j
+public class ModuleManageHook implements LifeCycleHook<Module> {
+
+    private static final String PREFIX_JOB_MODULE_DELETE_STORAGE = "TerrakubeV2_ModuleDeleteStorage";
+
+    Scheduler scheduler;
+    @Override
+    public void execute(LifeCycleHookBinding.Operation operation, LifeCycleHookBinding.TransactionPhase transactionPhase, Module module, RequestScope requestScope, Optional<ChangeSpec> optional) {
+
+        switch (operation) {
+            case DELETE:
+                try {
+                    log.warn("ModuleManageHook Delete Storage for {}/{}/{}", module.getOrganization().getName(), module.getName(), module.getProvider());
+                    JobDataMap jobDataMap = new JobDataMap();
+                    jobDataMap.put("moduleOrganization", module.getOrganization().getName());
+                    jobDataMap.put("moduleName", module.getName());
+                    jobDataMap.put("moduleProvider", module.getProvider());
+
+                    JobDetail jobDetail = JobBuilder.newJob().ofType(DeleteStorageCacheJob.class)
+                            .storeDurably()
+                            .setJobData(jobDataMap)
+                            .withIdentity(PREFIX_JOB_MODULE_DELETE_STORAGE + "_" + UUID.randomUUID())
+                            .withDescription("ModuleDeleteStorage")
+                            .build();
+
+                    Trigger trigger = TriggerBuilder.newTrigger()
+                            .startNow()
+                            .forJob(jobDetail)
+                            .withIdentity(PREFIX_JOB_MODULE_DELETE_STORAGE + "_" + UUID.randomUUID())
+                            .withDescription("ModuleDeleteStorageV1")
+                            .startNow()
+                            .build();
+
+                    log.info("Create Schedule Module Refresh: {}", jobDetail.getKey());
+                    scheduler.scheduleJob(jobDetail, trigger);
+                } catch (SchedulerException e) {
+                    log.error(e.getMessage());
+                }
+                break;
+            default:
+                log.warn("Hook not supported in module");
+                break;
+        }
+    }
+}

--- a/api/src/main/java/org/terrakube/api/rs/module/Module.java
+++ b/api/src/main/java/org/terrakube/api/rs/module/Module.java
@@ -7,6 +7,8 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.terrakube.api.plugin.security.audit.GenericAuditFields;
 import org.terrakube.api.rs.Organization;
+import org.terrakube.api.rs.hooks.module.ModuleManageHook;
+import org.terrakube.api.rs.hooks.workspace.WorkspaceManageHook;
 import org.terrakube.api.rs.ssh.Ssh;
 import org.terrakube.api.rs.vcs.Vcs;
 import org.hibernate.annotations.Type;
@@ -18,6 +20,7 @@ import java.util.*;
 @CreatePermission(expression = "team manage module")
 @UpdatePermission(expression = "team manage module OR user is a super service")
 @DeletePermission(expression = "team manage module")
+@LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.DELETE, phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT, hook = ModuleManageHook.class)
 @Slf4j
 @Include(rootLevel = false)
 @Getter


### PR DESCRIPTION
Adding the logic to delete the module data from the storage backend when deleting a module from the UI.

Files before deleting the modules from the UI:

![image](https://github.com/AzBuilder/terrakube/assets/4461895/eebe6989-cc96-48e4-96c6-08908cb26f88)

Files after delete the modules:
![image](https://github.com/AzBuilder/terrakube/assets/4461895/3094875d-6a6d-426e-ba1c-c399574930ad)

Adding information in the logs:

S3/MINIO
![image](https://github.com/AzBuilder/terrakube/assets/4461895/68f75a09-fa96-43fd-a573-e47b3998aa0d)

Local
![image](https://github.com/AzBuilder/terrakube/assets/4461895/90c0346b-459a-48f6-9497-e6c37c170a29)


This PR will add support for MINIO, S3 and Local storage backend.

Azure and GCP storage backend will be added later.