### PR TITLE
 Delete module data from gcp storage backend

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/storage/gcp/GcpStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/gcp/GcpStorageTypeServiceImpl.java
@@ -1,5 +1,6 @@
 package org.terrakube.api.plugin.storage.gcp;
 
+import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -197,6 +198,15 @@ public class GcpStorageTypeServiceImpl implements StorageTypeService {
 
     @Override
     public void deleteModuleStorage(String organizationName, String moduleName, String providerName) {
-        log.warn("Delete Module Storage not supported (Gcp)");
+        Page<Blob> blobs =
+                storage.list(
+                        bucketName,
+                        Storage.BlobListOption.prefix(String.format("registry/%s/%s/%s", organizationName, moduleName, providerName)),
+                        Storage.BlobListOption.currentDirectory());
+
+        for (Blob blob : blobs.iterateAll()) {
+            log.warn("Deleting blob: {}", blob.getName());
+            blob.delete(Blob.BlobSourceOption.generationMatch());
+        }
     }
 }


### PR DESCRIPTION
Delete module data from the GCP bucket when deleting a module from the UI.

Before Delete
![image](https://github.com/AzBuilder/terrakube/assets/4461895/aa79b527-92c9-4183-95b7-14558f3e8242)

After Delete:
![image](https://github.com/AzBuilder/terrakube/assets/4461895/60b8dee2-9eb2-4794-964f-7e73825e488e)

Logs:
![image](https://github.com/AzBuilder/terrakube/assets/4461895/9bf19dde-ec44-47ee-afd0-5ebf0f21b301)

Fix #523 