### PR TITLE
Delete storage backend data when deleting a workspace

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/module/DeleteStorageCacheJob.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/module/DeleteStorageCacheJob.java
@@ -17,7 +17,7 @@ public class DeleteStorageCacheJob implements Job {
 
     @Override
     public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
-        log.info("Deleting module storage backened data....");
+        log.info("Deleting module storage backend data....");
         storageTypeService.deleteModuleStorage(
                 jobExecutionContext.getJobDetail().getJobDataMap().getString("moduleOrganization"),
                 jobExecutionContext.getJobDetail().getJobDataMap().getString("moduleName"),

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/workspace/DeleteStorageBackendJob.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/workspace/DeleteStorageBackendJob.java
@@ -1,0 +1,29 @@
+package org.terrakube.api.plugin.scheduler.workspace;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.stereotype.Component;
+import org.terrakube.api.plugin.storage.StorageTypeService;
+
+import java.util.List;
+
+@Slf4j
+@AllArgsConstructor
+@Component
+public class DeleteStorageBackendJob implements Job {
+
+    StorageTypeService storageTypeService;
+
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+        String workspaceId = jobExecutionContext.getJobDetail().getJobDataMap().getString("workspaceId");
+        String organizationId = jobExecutionContext.getJobDetail().getJobDataMap().getString("organizationId");
+        List<Integer> jobList = (List<Integer>) jobExecutionContext.getJobDetail().getJobDataMap().get("jobList");
+
+        storageTypeService.deleteWorkspaceOutputData(organizationId, jobList);
+        storageTypeService.deleteWorkspaceStateData(organizationId, workspaceId);
+    }
+}

--- a/api/src/main/java/org/terrakube/api/plugin/softdelete/SoftDeleteService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/softdelete/SoftDeleteService.java
@@ -2,27 +2,36 @@ package org.terrakube.api.plugin.softdelete;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.quartz.SchedulerException;
+import org.quartz.*;
 import org.springframework.stereotype.Service;
 import org.terrakube.api.plugin.scheduler.ScheduleJobService;
+import org.terrakube.api.plugin.scheduler.module.DeleteStorageCacheJob;
 import org.terrakube.api.repository.ScheduleRepository;
 import org.terrakube.api.repository.WorkspaceRepository;
 import org.terrakube.api.rs.Organization;
+import org.terrakube.api.rs.job.Job;
 import org.terrakube.api.rs.workspace.Workspace;
 import org.terrakube.api.rs.workspace.schedule.Schedule;
 
 import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @AllArgsConstructor
 @Slf4j
 @Service
 public class SoftDeleteService {
 
+    private static final String PREFIX_JOB_MODULE_DELETE_STORAGE="TerrakubeV2_WorkspaceDeleteStorage";
+
     ScheduleJobService scheduleJobService;
 
     ScheduleRepository scheduleRepository;
 
     WorkspaceRepository workspaceRepository;
+
+    Scheduler scheduler;
 
     public void disableWorkspaceSchedules(Workspace workspace){
         for(Schedule schedule: workspace.getSchedule()){
@@ -33,6 +42,44 @@ public class SoftDeleteService {
             } catch (ParseException | SchedulerException e) {
                 log.error(e.getMessage());
             }
+        }
+
+        deleteWorkspaceStorage(workspace);
+    }
+
+    public void deleteWorkspaceStorage(Workspace workspace){
+        List<Job> jobList = workspace.getJob();
+        List<Integer> jobIdList = new ArrayList();
+        jobList.forEach(job -> jobIdList.add(job.getId()));
+        String workspaceId = workspace.getId().toString();
+        String organizationId = workspace.getOrganization().getId().toString();
+
+        try {
+            log.info("Setup job to delete storage for organization {} workspace {} jobs {}", organizationId, workspaceId, jobIdList);
+            JobDataMap jobDataMap = new JobDataMap();
+            jobDataMap.put("organizationId", organizationId);
+            jobDataMap.put("workspaceId", workspaceId);
+            jobDataMap.put("jobList", jobIdList);
+
+            JobDetail jobDetail = JobBuilder.newJob().ofType(DeleteStorageCacheJob.class)
+                    .storeDurably()
+                    .setJobData(jobDataMap)
+                    .withIdentity(PREFIX_JOB_MODULE_DELETE_STORAGE + "_" + UUID.randomUUID())
+                    .withDescription("WorkspaceDeleteStorage")
+                    .build();
+
+            Trigger trigger = TriggerBuilder.newTrigger()
+                    .startNow()
+                    .forJob(jobDetail)
+                    .withIdentity(PREFIX_JOB_MODULE_DELETE_STORAGE + "_" + UUID.randomUUID())
+                    .withDescription("WorkspaceDeleteStorageV1")
+                    .startNow()
+                    .build();
+
+            log.info("Creating schedule to delete workspace data: {}", jobDetail.getKey());
+            scheduler.scheduleJob(jobDetail, trigger);
+        } catch (SchedulerException e) {
+            log.error(e.getMessage());
         }
     }
 

--- a/api/src/main/java/org/terrakube/api/plugin/softdelete/SoftDeleteService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/softdelete/SoftDeleteService.java
@@ -6,6 +6,7 @@ import org.quartz.*;
 import org.springframework.stereotype.Service;
 import org.terrakube.api.plugin.scheduler.ScheduleJobService;
 import org.terrakube.api.plugin.scheduler.module.DeleteStorageCacheJob;
+import org.terrakube.api.plugin.scheduler.workspace.DeleteStorageBackendJob;
 import org.terrakube.api.repository.ScheduleRepository;
 import org.terrakube.api.repository.WorkspaceRepository;
 import org.terrakube.api.rs.Organization;
@@ -61,7 +62,7 @@ public class SoftDeleteService {
             jobDataMap.put("workspaceId", workspaceId);
             jobDataMap.put("jobList", jobIdList);
 
-            JobDetail jobDetail = JobBuilder.newJob().ofType(DeleteStorageCacheJob.class)
+            JobDetail jobDetail = JobBuilder.newJob().ofType(DeleteStorageBackendJob.class)
                     .storeDurably()
                     .setJobData(jobDataMap)
                     .withIdentity(PREFIX_JOB_MODULE_DELETE_STORAGE + "_" + UUID.randomUUID())

--- a/api/src/main/java/org/terrakube/api/plugin/storage/StorageTypeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/StorageTypeService.java
@@ -1,6 +1,7 @@
 package org.terrakube.api.plugin.storage;
 
 import java.io.InputStream;
+import java.util.List;
 
 public interface StorageTypeService {
 
@@ -25,4 +26,8 @@ public interface StorageTypeService {
     byte[] getContentFile(String contentId);
 
     void deleteModuleStorage(String organizationName, String moduleName, String providerName);
+
+    void deleteWorkspaceOutputData(String organizationId, List<Integer> jobList);
+
+    void deleteWorkspaceStateData(String organizationId, String workspaceId);
 }

--- a/api/src/main/java/org/terrakube/api/plugin/storage/aws/AwsStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/aws/AwsStorageTypeServiceImpl.java
@@ -169,10 +169,24 @@ public class AwsStorageTypeServiceImpl implements StorageTypeService {
     @Override
     public void deleteModuleStorage(String organizationName, String moduleName, String providerName) {
         String registryPath = String.format("registry/%s/%s/%s/", organizationName, moduleName, providerName);
-        deleteDirectory(registryPath);
+        deleteFolderFromBucket(registryPath);
     }
 
-    private void deleteDirectory(String prefix) {
+    @Override
+    public void deleteWorkspaceOutputData(String organizationId, List<Integer> jobList) {
+        for (Integer jobId: jobList){
+            String workspaceOutputFolder = String.format("tfoutput/%s/%s/", organizationId, jobId);
+            deleteFolderFromBucket(workspaceOutputFolder);
+        }
+    }
+
+    @Override
+    public void deleteWorkspaceStateData(String organizationId, String workspaceId) {
+        String workspaceStateFolder = String.format("tfstate/%s/%s/", organizationId, workspaceId);
+        deleteFolderFromBucket(workspaceStateFolder);
+    }
+
+    private void deleteFolderFromBucket(String prefix) {
         ObjectListing objectList = s3client.listObjects(bucketName, prefix);
         List<S3ObjectSummary> objectSummeryList = objectList.getObjectSummaries();
         String[] keysList = new String[objectSummeryList.size()];

--- a/api/src/main/java/org/terrakube/api/plugin/storage/aws/AwsStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/aws/AwsStorageTypeServiceImpl.java
@@ -43,7 +43,7 @@ public class AwsStorageTypeServiceImpl implements StorageTypeService {
             S3Object s3object = s3client.getObject(bucketName, String.format(BUCKET_LOCATION_OUTPUT, organizationId, jobId, stepId));
             S3ObjectInputStream inputStream = s3object.getObjectContent();
             data = inputStream.getDelegateStream().readAllBytes();
-        } catch (IOException e) {
+        } catch (Exception e) {
             log.error(S3_ERROR_LOG, e.getMessage());
             data = new byte[0];
         }
@@ -58,7 +58,7 @@ public class AwsStorageTypeServiceImpl implements StorageTypeService {
             S3Object s3object = s3client.getObject(bucketName, String.format(BUCKET_STATE_LOCATION, organizationId, workspaceId, jobId, stepId));
             S3ObjectInputStream inputStream = s3object.getObjectContent();
             data = inputStream.getDelegateStream().readAllBytes();
-        } catch (IOException e) {
+        } catch (Exception e) {
             log.error(S3_ERROR_LOG, e.getMessage());
             data = new byte[0];
         }
@@ -73,7 +73,7 @@ public class AwsStorageTypeServiceImpl implements StorageTypeService {
             S3Object s3object = s3client.getObject(bucketName, String.format(BUCKET_STATE_JSON, organizationId, workspaceId, stateFileName));
             S3ObjectInputStream inputStream = s3object.getObjectContent();
             data = inputStream.getDelegateStream().readAllBytes();
-        } catch (IOException e) {
+        } catch (Exception e) {
             log.error(S3_ERROR_LOG, e.getMessage());
             data = new byte[0];
         }
@@ -95,7 +95,7 @@ public class AwsStorageTypeServiceImpl implements StorageTypeService {
             S3Object s3object = s3client.getObject(bucketName, String.format("tfstate/%s/%s/terraform.tfstate", organizationId, workspaceId));
             S3ObjectInputStream inputStream = s3object.getObjectContent();
             data = inputStream.getDelegateStream().readAllBytes();
-        } catch (IOException e) {
+        } catch (Exception e) {
             log.error(S3_ERROR_LOG, e.getMessage());
             data = new byte[0];
         }

--- a/api/src/main/java/org/terrakube/api/plugin/storage/azure/AzureStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/azure/AzureStorageTypeServiceImpl.java
@@ -36,21 +36,40 @@ public class AzureStorageTypeServiceImpl implements StorageTypeService {
     public byte[] getStepOutput(String organizationId, String jobId, String stepId) {
         BlobContainerClient containerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME_OUTPUT);
         log.info("Searching: /tfoutput/{}/{}/{}.tfoutput", organizationId, jobId, stepId);
-        return containerClient.getBlobClient(String.format("%s/%s/%s.tfoutput", organizationId, jobId, stepId)).downloadContent().toBytes();
+        byte[] response = new byte[0];
+        try {
+            response = containerClient.getBlobClient(String.format("%s/%s/%s.tfoutput", organizationId, jobId, stepId)).downloadContent().toBytes();
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        return response;
     }
 
     @Override
     public byte[] getTerraformPlan(String organizationId, String workspaceId, String jobId, String stepId) {
         BlobContainerClient containerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME_STATE);
         log.info("Searching: /tfstate/{}/{}/{}/{}/terraformLibrary.tfPlan", organizationId, workspaceId, jobId, stepId);
-        return containerClient.getBlobClient(String.format("%s/%s/%s/%s/terraformLibrary.tfPlan", organizationId, workspaceId, jobId, stepId)).downloadContent().toBytes();
+        byte[] response = new byte[0];
+        try {
+            response = containerClient.getBlobClient(String.format("%s/%s/%s/%s/terraformLibrary.tfPlan", organizationId, workspaceId, jobId, stepId)).downloadContent().toBytes();
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+
+        return response;
     }
 
     @Override
     public byte[] getTerraformStateJson(String organizationId, String workspaceId, String stateFileName) {
         BlobContainerClient containerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME_STATE);
         log.info("Searching: /tfstate/{}/{}/state/{}.json", organizationId, workspaceId, stateFileName);
-        return containerClient.getBlobClient(String.format("%s/%s/state/%s.json", organizationId, workspaceId, stateFileName)).downloadContent().toBytes();
+        byte[] response = new byte[0];
+        try {
+            response = containerClient.getBlobClient(String.format("%s/%s/state/%s.json", organizationId, workspaceId, stateFileName)).downloadContent().toBytes();
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        return response;
     }
 
     @Override
@@ -69,7 +88,13 @@ public class AzureStorageTypeServiceImpl implements StorageTypeService {
     public byte[] getCurrentTerraformState(String organizationId, String workspaceId) {
         BlobContainerClient containerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME_STATE);
         log.info("Searching: /{}/{}/terraform.tfstate", organizationId, workspaceId);
-        return containerClient.getBlobClient(String.format("%s/%s/terraform.tfstate", organizationId, workspaceId)).downloadContent().toBytes();
+        byte[] response = new byte[0];
+        try {
+            response = containerClient.getBlobClient(String.format("%s/%s/terraform.tfstate", organizationId, workspaceId)).downloadContent().toBytes();
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        return response;
     }
 
     @Override
@@ -154,9 +179,9 @@ public class AzureStorageTypeServiceImpl implements StorageTypeService {
 
     @Override
     public void deleteWorkspaceOutputData(String organizationId, List<Integer> jobList) {
-        for(Integer jobId: jobList){
+        for (Integer jobId : jobList) {
             String workspaceOutputFolder = String.format("%s/%s", organizationId, jobId);
-            deleteFolderFromContainer(CONTAINER_NAME_OUTPUT,workspaceOutputFolder);
+            deleteFolderFromContainer(CONTAINER_NAME_OUTPUT, workspaceOutputFolder);
         }
     }
 
@@ -166,7 +191,7 @@ public class AzureStorageTypeServiceImpl implements StorageTypeService {
         deleteFolderFromContainer(CONTAINER_NAME_STATE, moduleFolderPath);
     }
 
-    private void deleteFolderFromContainer(String containerName, String folderPath){
+    private void deleteFolderFromContainer(String containerName, String folderPath) {
         BlobContainerClient containerClient = blobServiceClient.getBlobContainerClient(containerName);
         ListBlobsOptions options = new ListBlobsOptions().setPrefix(folderPath)
                 .setDetails(new BlobListDetails().setRetrieveDeletedBlobs(false).setRetrieveSnapshots(false));

--- a/api/src/main/java/org/terrakube/api/plugin/storage/gcp/GcpStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/gcp/GcpStorageTypeServiceImpl.java
@@ -37,31 +37,49 @@ public class GcpStorageTypeServiceImpl implements StorageTypeService {
     @Override
     public byte[] getStepOutput(String organizationId, String jobId, String stepId) {
         log.info("getStepOutput {}", String.format(GCP_LOCATION_OUTPUT, organizationId, jobId, stepId));
-        return storage.get(
-                        BlobId.of(
-                                bucketName,
-                                String.format(GCP_LOCATION_OUTPUT, organizationId, jobId, stepId)))
-                .getContent();
+        byte[] response = new byte[0];
+        try {
+            response = storage.get(
+                            BlobId.of(
+                                    bucketName,
+                                    String.format(GCP_LOCATION_OUTPUT, organizationId, jobId, stepId)))
+                    .getContent();
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        return response;
     }
 
     @Override
     public byte[] getTerraformPlan(String organizationId, String workspaceId, String jobId, String stepId) {
         log.info("getTerraformPlan {}", String.format(GCP_STATE_LOCATION, organizationId, workspaceId, jobId, stepId));
-        return storage.get(
-                        BlobId.of(
-                                bucketName,
-                                String.format(GCP_STATE_LOCATION, organizationId, workspaceId, jobId, stepId)))
-                .getContent();
+        byte[] response = new byte[0];
+        try {
+            response = storage.get(
+                            BlobId.of(
+                                    bucketName,
+                                    String.format(GCP_STATE_LOCATION, organizationId, workspaceId, jobId, stepId)))
+                    .getContent();
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        return response;
     }
 
     @Override
     public byte[] getTerraformStateJson(String organizationId, String workspaceId, String stateFileName) {
         log.info("getTerraformStateJson {}", String.format(GCP_STATE_JSON, organizationId, workspaceId, stateFileName));
-        return storage.get(
-                        BlobId.of(
-                                bucketName,
-                                String.format(GCP_STATE_JSON, organizationId, workspaceId, stateFileName)))
-                .getContent();
+        byte[] response = new byte[0];
+        try {
+            response = storage.get(
+                            BlobId.of(
+                                    bucketName,
+                                    String.format(GCP_STATE_JSON, organizationId, workspaceId, stateFileName)))
+                    .getContent();
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        return response;
     }
 
     @Override
@@ -86,11 +104,17 @@ public class GcpStorageTypeServiceImpl implements StorageTypeService {
     @Override
     public byte[] getCurrentTerraformState(String organizationId, String workspaceId) {
         log.info("getTerraformStateJson {}", String.format(GCP_CURRENT_STATE, organizationId, workspaceId));
-        return storage.get(
+        byte[] response = new byte[0];
+        try {
+            response =  storage.get(
                         BlobId.of(
                                 bucketName,
                                 String.format(GCP_CURRENT_STATE, organizationId, workspaceId)))
                 .getContent();
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        return response;
     }
 
     @Override

--- a/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
@@ -190,9 +190,13 @@ public class LocalStorageTypeServiceImpl implements StorageTypeService {
     @Override
     public void deleteWorkspaceStateData(String organizationId, String workspaceId) {
         try {
-            String registryPath = String.format("%s/.terraform-spring-boot/local/state/%s/%s", FileUtils.getUserDirectoryPath(), organizationId, workspaceId);
-            log.warn("Delete workspace state folder: {}", registryPath);
-            FileUtils.cleanDirectory(new File(registryPath));
+            String statePath = String.format("%s/.terraform-spring-boot/local/state/%s/%s", FileUtils.getUserDirectoryPath(), organizationId, workspaceId);
+            log.warn("Delete workspace state folder: {}", statePath);
+            FileUtils.cleanDirectory(new File(statePath));
+
+            statePath = String.format("%s/.terraform-spring-boot/local/backend/%s/%s/", FileUtils.getUserDirectoryPath(), organizationId, workspaceId);
+            log.warn("Delete workspace state folder: {}", statePath);
+            FileUtils.cleanDirectory(new File(statePath));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -167,6 +168,30 @@ public class LocalStorageTypeServiceImpl implements StorageTypeService {
         try {
             String registryPath = String.format("%s/.terraform-spring-boot/local/modules/%s/%s/%s", FileUtils.getUserDirectoryPath(), organizationName, moduleName, providerName);
             log.warn("Delete module folder: {}", registryPath);
+            FileUtils.cleanDirectory(new File(registryPath));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void deleteWorkspaceOutputData(String organizationId, List<Integer> jobList) {
+        try {
+            for (Integer jobId : jobList) {
+                String workspaceOutputFolder = String.format("%s/.terraform-spring-boot/local/output/%s/%s", FileUtils.getUserDirectoryPath(), organizationId, jobId);
+                log.warn("Delete workspace output folder: {}", workspaceOutputFolder);
+                FileUtils.cleanDirectory(new File(workspaceOutputFolder));
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void deleteWorkspaceStateData(String organizationId, String workspaceId) {
+        try {
+            String registryPath = String.format("%s/.terraform-spring-boot/local/state/%s/%s", FileUtils.getUserDirectoryPath(), organizationId, workspaceId);
+            log.warn("Delete workspace state folder: {}", registryPath);
             FileUtils.cleanDirectory(new File(registryPath));
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
@@ -170,7 +170,7 @@ public class LocalStorageTypeServiceImpl implements StorageTypeService {
             log.warn("Delete module folder: {}", registryPath);
             FileUtils.cleanDirectory(new File(registryPath));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            log.error(e.getMessage());
         }
     }
 
@@ -183,7 +183,7 @@ public class LocalStorageTypeServiceImpl implements StorageTypeService {
                 FileUtils.cleanDirectory(new File(workspaceOutputFolder));
             }
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            log.error(e.getMessage());
         }
     }
 
@@ -198,7 +198,7 @@ public class LocalStorageTypeServiceImpl implements StorageTypeService {
             log.warn("Delete workspace state folder: {}", statePath);
             FileUtils.cleanDirectory(new File(statePath));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            log.error(e.getMessage());
         }
     }
 }

--- a/api/src/main/java/org/terrakube/api/rs/hooks/module/ModuleManageHook.java
+++ b/api/src/main/java/org/terrakube/api/rs/hooks/module/ModuleManageHook.java
@@ -48,7 +48,7 @@ public class ModuleManageHook implements LifeCycleHook<Module> {
                             .startNow()
                             .build();
 
-                    log.info("Create Schedule Module Refresh: {}", jobDetail.getKey());
+                    log.info("Create Schedule to delete module cache form storage: {}", jobDetail.getKey());
                     scheduler.scheduleJob(jobDetail, trigger);
                 } catch (SchedulerException e) {
                     log.error(e.getMessage());


### PR DESCRIPTION
This will delete all workspace data from the backend storage when a workspace is deleted (outputs, terraform state, terraform state json, etc)

Fix #522 