### PR TITLE
Improving workspace details view

### DIFF
--- a/ui/src/domain/Jobs/Create.jsx
+++ b/ui/src/domain/Jobs/Create.jsx
@@ -6,7 +6,7 @@ import {
   WORKSPACE_ARCHIVE,
 } from "../../config/actionTypes";
 import axiosInstance from "../../config/axiosConfig";
-import { InfoCircleTwoTone } from "@ant-design/icons";
+import { InfoCircleTwoTone,PlusOutlined } from "@ant-design/icons";
 
 const validateMessages = { required: "${label} is required!" };
 
@@ -81,8 +81,9 @@ export const CreateJob = ({ changeJob }) => {
         onClick={() => {
           setVisible(true);
         }}
+        icon={<PlusOutlined />}
       >
-        Start new job
+        New job
       </Button>
 
       <Modal

--- a/ui/src/domain/Workspaces/Create.jsx
+++ b/ui/src/domain/Workspaces/Create.jsx
@@ -173,6 +173,7 @@ export const CreateWorkspace = () => {
           name: values.name,
           terraformVersion: values.terraformVersion,
           branch: values.branch,
+          executionMode: "remote",
         },
       },
     };
@@ -187,6 +188,7 @@ export const CreateWorkspace = () => {
             name: values.name,
             terraformVersion: values.terraformVersion,
             branch: values.branch,
+            executionMode: "remote",
           },
           relationships: {
             vcs: {
@@ -209,6 +211,7 @@ export const CreateWorkspace = () => {
             name: values.name,
             terraformVersion: values.terraformVersion,
             branch: values.branch,
+            executionMode: "remote"
           },
           relationships: {
             ssh: {

--- a/ui/src/domain/Workspaces/Workspaces.css
+++ b/ui/src/domain/Workspaces/Workspaces.css
@@ -108,3 +108,14 @@
   color: #000;
   padding: 0.2em 0.4em; 
 }
+
+.workspace-details{
+  color:rgb(82, 87, 97);
+  font-size: 14px;
+}
+
+.workspace-button{
+  text-decoration: underline;
+  color:"black";
+  font-weight: 400;
+}


### PR DESCRIPTION
addresses #524 

Adding workspace details to easily check the information (resources count, lock/unlock workspace, terraform version,id, repo url)

<img width="1434" alt="image" src="https://github.com/AzBuilder/terrakube/assets/27365102/e9a7e53d-0681-4e0f-b49f-a1596a53d853">

Adding resources list based in the latest state
<img width="1434" alt="image" src="https://github.com/AzBuilder/terrakube/assets/27365102/e1ea6e1c-6503-4273-9bd8-8ab8043ecd81">


Adding outputs list based in the latest state

<img width="1434" alt="image" src="https://github.com/AzBuilder/terrakube/assets/27365102/60d2d2b8-e6d5-4900-8a57-2512f4ed5d02">




