### PR TITLE
Experimental Alpaquita Linux Support 

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build Terrakube Backend
 
 on:
   push:
@@ -8,19 +8,17 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  build:
-
+  build-jammy:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '17'
-        distribution: 'adopt'
+        distribution: 'liberica'
     - name: Cache SonarCloud packages
       uses: actions/cache@v1
       with:
@@ -39,4 +37,27 @@ jobs:
         USER_NAME: ${{ secrets.USER_NAME }}
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}  # Needed to get PR information, if any
+        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+
+  build-alpaquita:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'liberica'
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build with Alpaquita Linux
+        run: mvn clean install -Dspring-boot.build-image.skip=false -Dmaven.test.skip=true -Dbuildpack.builder=gcr.io/bellsoft/buildpacks.builder:glibc
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -57,7 +57,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Alpaquita Linux
-        run: mvn clean install -Dspring-boot.build-image.skip=false -Dmaven.test.skip=true -Dbuildpack.builder=gcr.io/bellsoft/buildpacks.builder:glibc
+        run: mvn clean install -Dspring-boot.build-image.skip=false -Dmaven.test.skip=true -Dbuildpack.builder=bellsoft/buildpacks.builder:glibc
 
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/pull_request_ui.yml
+++ b/.github/workflows/pull_request_ui.yml
@@ -1,4 +1,4 @@
-name: Build UI
+name: Build Terrakube UI
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,25 @@
-name: Push Docker Images
+name: Release Terrakube
 
 on: 
   release:
     types: [created]
 
 jobs:
-  build:
-
+  build-jammy:
     runs-on: ubuntu-latest
     env:
        VERSION: ${{ github.event.release.tag_name }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '17'
-        distribution: 'adopt'
+        distribution: 'liberica'
     - name: Update POM Version
       run: mvn versions:set-property -Dproperty=revision -DnewVersion=$VERSION -DgenerateBackupPoms=false
     - name: Build Image with Maven
-      run: mvn -pl "api,registry,executor" spring-boot:build-image -B  --file pom.xml
+      run: mvn -pl "api,registry,executor" spring-boot:build-image -B  --file pom.xml -Dmaven.test.skip=true
       env:
         USER_NAME: ${{ secrets.USER_NAME }}
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
@@ -105,3 +104,42 @@ jobs:
 
     - name: Docker Push UI Latest
       run: docker push azbuilder/terrakube-ui:latest
+
+  build-alpaquita:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.release.tag_name }}-alpaquita
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'liberica'
+      - name: Update POM Version
+        run: mvn versions:set-property -Dproperty=revision -DnewVersion=$VERSION -DgenerateBackupPoms=false
+      - name: Build Image with Maven
+        run: mvn -pl "api,registry" spring-boot:build-image -B --file pom.xml -Dmaven.test.skip=true -Dbuildpack.builder=bellsoft/buildpacks.builder:glibc
+        env:
+          USER_NAME: ${{ secrets.USER_NAME }}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+
+      - name: docker login
+        env:
+          DOCKER_USER: ${{secrets.DOCKER_USER}}
+          DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+        run: |
+          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+
+      - name: Docker tag API Image
+        run: docker tag $(docker images api-server -q) azbuilder/api-server:$VERSION
+
+      - name: Docker Push API latest
+        run: docker push azbuilder/api-server:$VERSION
+
+      - name: Docker tag Registry Image
+        run: docker tag $(docker images open-registry -q) azbuilder/open-registry:$VERSION
+
+      - name: Docker Push Registry
+        run: docker push azbuilder/open-registry:$VERSION
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Update POM Version
         run: mvn versions:set-property -Dproperty=revision -DnewVersion=$VERSION -DgenerateBackupPoms=false
       - name: Build Image with Maven
-        run: mvn -pl "api,registry" spring-boot:build-image -B --file pom.xml -Dmaven.test.skip=true -Dbuildpack.builder=bellsoft/buildpacks.builder:glibc
+        run: mvn -pl "api,registry, executor" spring-boot:build-image -B --file pom.xml -Dmaven.test.skip=true -Dbuildpack.builder=bellsoft/buildpacks.builder:glibc
         env:
           USER_NAME: ${{ secrets.USER_NAME }}
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
@@ -131,15 +131,21 @@ jobs:
         run: |
           docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
 
-      - name: Docker tag API Image
+      - name: Docker tag API Alpaquita
         run: docker tag $(docker images api-server -q) azbuilder/api-server:$VERSION
 
-      - name: Docker Push API latest
+      - name: Docker Push API Alpaquita
         run: docker push azbuilder/api-server:$VERSION
 
-      - name: Docker tag Registry Image
+      - name: Docker tag Registry Alpaquita
         run: docker tag $(docker images open-registry -q) azbuilder/open-registry:$VERSION
 
-      - name: Docker Push Registry
+      - name: Docker Push Registry Alpaquita
         run: docker push azbuilder/open-registry:$VERSION
+
+      - name: Docker tag EXECUTOR Alpaquita
+        run: docker tag $(docker images executor -q) azbuilder/executor:$VERSION
+
+      - name: Docker Push EXECUTOR Alpaquita
+        run: docker push azbuilder/executor:$VERSION
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -40,6 +40,10 @@
         <commons-lang3.version>3.13.0</commons-lang3.version>
         <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}
         </sonar.coverage.jacoco.xmlReportPaths>
+        <!--BUILDPACK DATA-->
+        <buildpack.builder>paketobuildpacks/builder-jammy-base</buildpack.builder>
+        <buildpack.java>gcr.io/paketo-buildpacks/java</buildpack.java>
+        <buildpack.telemetry>gcr.io/paketo-buildpacks/opentelemetry</buildpack.telemetry>
     </properties>
     <build>
         <plugins>
@@ -48,10 +52,10 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                 <image>
-                    <builder>paketobuildpacks/builder-jammy-base</builder>
+                    <builder>${buildpack.builder}</builder>
                     <buildpacks>
-                        <buildpack>gcr.io/paketo-buildpacks/java</buildpack>
-                        <buildpack>gcr.io/paketo-buildpacks/opentelemetry</buildpack>
+                        <buildpack>${buildpack.java}</buildpack>
+                        <buildpack>${buildpack.telemetry}</buildpack>
                     </buildpacks>
                     <bindings>
                         <binding>${basedir}/../bindings/ca-certificates:/platform/bindings/ca-certificates</binding>

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -35,6 +35,10 @@
 		<jedis.version>3.9.0</jedis.version>
 		<sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}
 		</sonar.coverage.jacoco.xmlReportPaths>
+		<!--BUILDPACK DATA-->
+		<buildpack.builder>paketobuildpacks/builder-jammy-base</buildpack.builder>
+		<buildpack.java>gcr.io/paketo-buildpacks/java</buildpack.java>
+		<buildpack.telemetry>gcr.io/paketo-buildpacks/opentelemetry</buildpack.telemetry>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -200,10 +204,10 @@
 						</exclude>
 					</excludes>
 					<image>
-					    <builder>paketobuildpacks/builder-jammy-base</builder>
+					    <builder>${buildpack.builder}</builder>
                     	<buildpacks>
-                        	<buildpack>gcr.io/paketo-buildpacks/java</buildpack>
-                        	<buildpack>gcr.io/paketo-buildpacks/opentelemetry</buildpack>
+                        	<buildpack>${buildpack.java}</buildpack>
+                        	<buildpack>${buildpack.telemetry}</buildpack>
                     	</buildpacks>
                     	<bindings>
                         	<binding>${basedir}/../bindings/ca-certificates:/platform/bindings/ca-certificates</binding>

--- a/registry/pom.xml
+++ b/registry/pom.xml
@@ -29,6 +29,10 @@
 		<zt-zip.version>1.14</zt-zip.version>
 		<gcp-libraries-bom.version>26.3.0</gcp-libraries-bom.version>
 		<sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
+		<!--BUILDPACK DATA-->
+		<buildpack.builder>paketobuildpacks/builder-jammy-base</buildpack.builder>
+		<buildpack.java>gcr.io/paketo-buildpacks/java</buildpack.java>
+		<buildpack.telemetry>gcr.io/paketo-buildpacks/opentelemetry</buildpack.telemetry>
 	</properties>
 	<build>
         <plugins>
@@ -37,10 +41,10 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                 <image>
-				    <builder>paketobuildpacks/builder-jammy-base</builder>
+				    <builder>${buildpack.builder}</builder>
                     <buildpacks>
-                        <buildpack>gcr.io/paketo-buildpacks/java</buildpack>
-                        <buildpack>gcr.io/paketo-buildpacks/opentelemetry</buildpack>
+                        <buildpack>${buildpack.java}</buildpack>
+                        <buildpack>${buildpack.telemetry}</buildpack>
                     </buildpacks>
                     <bindings>
                         <binding>${basedir}/../bindings/ca-certificates:/platform/bindings/ca-certificates</binding>


### PR DESCRIPTION
## Alpaquita Linux

Imagen size when using Alpaquita linux as based image

```shell
mvn clean install -Dspring-boot.build-image.skip=false -Dmaven.test.skip=true -Dbuildpack.builder=bellsoft/buildpacks.builder:glibc
```

```shell
user@pop-os:~/git/terrakube$ docker image ls | grep 2.17.0
api-server                               2.17.0               638c3f41d9e5   43 years ago    394MB
executor                                 2.17.0               8d7c7760d51d   43 years ago    338MB
open-registry                            2.17.0               47240ba6106a   43 years ago    332MB
```

Note: Executor  does not include git, running modules like the following wont be supported:

```terraform
module "consul" {
  source = "git@github.com:hashicorp/example.git"
}
```

## Ubuntu Jammy

Imagen size when using Ubuntu Jammy as based image

```shell
mvn clean install -Dspring-boot.build-image.skip=false -Dmaven.test.skip=true
```

```shell
user@pop-os:~/git/terrakube$ docker image ls | grep 2.17.0
api-server                               2.17.0               6b6555bbefbd   43 years ago    483MB
executor                                 2.17.0               5271fd9c9b52   43 years ago    427MB
open-registry                            2.17.0               203bb0f4ce03   43 years ago    421MB
```

Fix #552 