### PR TITLE
Update docker compose to 2.17.0

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   terrakube-api:
-    image: azbuilder/api-server:2.15.3
+    image: azbuilder/api-server:2.17.0
     ports: 
       - 8080:8080
     env_file:
@@ -9,7 +9,7 @@ services:
     depends_on:
     - postgresql-service
   terrakube-ui:
-    image: azbuilder/terrakube-ui:2.15.3
+    image: azbuilder/terrakube-ui:2.17.0
     ports: 
       - 3000:8080
     volumes:
@@ -17,19 +17,19 @@ services:
     env_file:
       - ui.env 
   terrakube-executor:
-    image: azbuilder/executor:2.15.3
+    image: azbuilder/executor:2.17.0
     ports: 
     - 8090:8090
     env_file:
       - executor.env 
   terrakube-registry:
-    image: azbuilder/open-registry:2.15.3
+    image: azbuilder/open-registry:2.17.0
     ports: 
     - 8075:8075
     env_file:
       - registry.env 
   terrakube-dex:
-    image: ghcr.io/dexidp/dex:v2.32.0
+    image: ghcr.io/dexidp/dex:v2.37.0
     container_name: dex-service
     volumes:
     - ./config-ldap.yaml:/etc/dex/config.docker.yaml

--- a/telemetry-compose/docker-compose.yaml
+++ b/telemetry-compose/docker-compose.yaml
@@ -1,13 +1,13 @@
 version: "3.8"
 services:
   terrakube-api:
-    image: azbuilder/api-server:2.14.0
+    image: azbuilder/api-server:2.17.0
     ports:
       - 8080:8080
     env_file:
       - api.env
   terrakube-ui:
-    image: azbuilder/terrakube-ui:2.14.0
+    image: azbuilder/terrakube-ui:2.17.0
     ports:
       - 3000:8080
     volumes:
@@ -15,20 +15,19 @@ services:
     env_file:
       - ui.env
   terrakube-executor:
-    image: azbuilder/executor:2.14.0
+    image: azbuilder/executor:2.17.0
     ports:
       - 8090:8090
     env_file:
       - executor.env
   terrakube-registry:
-    image: azbuilder/open-registry:2.14.0
+    image: azbuilder/open-registry:2.17.0
     ports:
       - 8075:8075
     env_file:
       - registry.env
   terrakube-dex:
-    image: ghcr.io/dexidp/dex:v2.32.0
-    container_name: dex-service
+    image: ghcr.io/dexidp/dex:v2.37.0
     volumes:
       - ./config-ldap.yaml:/etc/dex/config.docker.yaml
     ports:


### PR DESCRIPTION
Update docker-compose examples to use version 2.17.0

Update telemetry-compose example that show how to integrate open telemetry with Terrakube to version 2.17.0

![image](https://github.com/AzBuilder/terrakube/assets/4461895/05fc4954-6ed4-4e2a-a81e-9138e5f26a44)

![image](https://github.com/AzBuilder/terrakube/assets/4461895/b198dbd9-849d-4b90-9a65-11c8c0340926)

![image](https://github.com/AzBuilder/terrakube/assets/4461895/526a801a-79f2-44b2-a7ad-1464b4a0852f)
