### PR TITLE
Fix validation if the state has no outputs in workspace details page

### DIFF
--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -948,6 +948,7 @@ function setupWorkspaceIncludes(
     .sort((a, b) => a.jobReference - b.jobReference)
     .reverse()[0];
   // reload state only if there is a new version
+  console.log('Get latest state')
   if (currentStateId !== lastState?.id) {
     loadState(lastState, axiosInstance, setOutputs, setResources);
   }
@@ -966,26 +967,36 @@ function loadState(state, axiosInstance, setOutputs, setResources) {
 function parseState(state) {
   var resources = [];
   var outputs = [];
-
-  for (const [key, value] of Object.entries(state?.values?.outputs)) {
-    outputs.push({
-      name: key,
-      type: value.type,
-      value: value.value,
-    });
+  console.log("Current state")
+  console.log(state)
+  if(state?.values?.outputs != null){
+    for (const [key, value] of Object.entries(state?.values?.outputs)) {
+      outputs.push({
+        name: key,
+        type: value.type,
+        value: value.value,
+      });
+    }
+  } else {
+    console.log('State has no outputs')
   }
 
   // parse root module resources
-  for (const [key, value] of Object.entries(
-    state?.values?.root_module?.resources
-  )) {
-    resources.push({
-      name: value.name,
-      type: value.type,
-      provider: value.provider_name,
-      module: "root",
-    });
+  if(state?.values?.root_module?.resources != null){
+    for (const [key, value] of Object.entries(
+      state?.values?.root_module?.resources
+    )) {
+      resources.push({
+        name: value.name,
+        type: value.type,
+        provider: value.provider_name,
+        module: "root",
+      });
+    }
+  } else {
+    console.log('State has no resources')
   }
+  
   return { resources: resources, outputs: outputs };
 }
 


### PR DESCRIPTION
Fix logic if the state has no outputs the resource count in the workspace details and the list of resources are not shown correctly in the UI.

![image](https://github.com/AzBuilder/terrakube/assets/4461895/8a517a35-3f65-40c4-82e3-2b7867dd04ce)

![image](https://github.com/AzBuilder/terrakube/assets/4461895/806254ec-28e6-45b6-a770-c6750606f831)

