### PR TITLE
Only show CLI drive overview if the state history length is 0

### DIFF
--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -415,7 +415,7 @@ export const WorkspaceDetails = (props) => {
                   <Row>
                     <Col span={19} style={{paddingRight:"20px"}}>
                       {workspace.data.attributes.source === "empty" &&
-                      workspace.data.attributes.branch === "remote-content" ? (
+                      workspace.data.attributes.branch === "remote-content" && workspace.data.relationships.history.data.length < 1 ? (
                         <CLIDriven
                           organizationName={organizationName}
                           workspaceName={workspaceName}


### PR DESCRIPTION
Show the CLI drive workflow information only when there is no state history otherwise show the details.

With state history
![image](https://github.com/AzBuilder/terrakube/assets/4461895/0afdd7e2-1253-402b-99f0-cacdaca5652d)

![image](https://github.com/AzBuilder/terrakube/assets/4461895/81861276-3550-421a-a4e2-58e63cb630b1)

Without state history
![image](https://github.com/AzBuilder/terrakube/assets/4461895/4a398e07-3108-435a-8ed7-bd2eecc0168f)

![image](https://github.com/AzBuilder/terrakube/assets/4461895/1c197643-9806-49e7-a268-df26d1b8f5bc)

After running an apply
![image](https://github.com/AzBuilder/terrakube/assets/4461895/595c3d8d-60e6-443a-85db-eae3c209f9b3)

![image](https://github.com/AzBuilder/terrakube/assets/4461895/c29bf774-cb29-4e80-988e-22c2b8ba45c8)

