### PR TITLE
Fix environment variables in terraform init

### DIFF
--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<commons-text.version>1.10.0</commons-text.version>
-		<terraform-spring-boot-starter.version>0.10.1</terraform-spring-boot-starter.version>
+		<terraform-spring-boot-starter.version>0.11.1</terraform-spring-boot-starter.version>
 		<terrakube-client-starter.version>0.12.0</terrakube-client-starter.version>
 		<commons-io.version>2.8.0</commons-io.version>
 		<commons-codec>1.15</commons-codec>

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -376,7 +376,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             initBanner(terraformJob, output);
 
         TerraformProcessData terraformProcessData = getTerraformProcessData(terraformJob, workingDirectory);
-        terraformProcessData.setTerraformEnvironmentVariables(new HashMap<>());
+        terraformProcessData.setTerraformEnvironmentVariables(terraformProcessData.getTerraformEnvironmentVariables());
         terraformProcessData.setTerraformVariables(new HashMap<>());
 
         if (terraformJob.isShowHeader())


### PR DESCRIPTION
Using the folowing terraform code in a VCS repository

```terraform
module "sample" {
  source  = "app.terraform.io/alfespa17/sample/google"
  version = "0.4.0"
  time= "5s"
}
```

With a private module in app.terraform.io like the follwing:
![image](https://github.com/AzBuilder/terrakube/assets/4461895/c4498c0c-f13f-488a-bb69-88757cf5e4a7)

Adding TF_TOKEN_app_terraform_io as environment variable to the workspace inside terrakube

![image](https://github.com/AzBuilder/terrakube/assets/4461895/3b2cedf9-8629-41a6-aae8-ff47045cef03)

When running terraform operations it will authenticate correctly to app.terraform.io. Example:

![image](https://github.com/AzBuilder/terrakube/assets/4461895/94e042d7-c30a-43b6-a208-4b0d71322a76)


Running a terraform plan without using TF_TOKEN_app_terraform_io will return 401 like the following:

![image](https://github.com/AzBuilder/terrakube/assets/4461895/a2a1beb0-c636-4855-9818-23c488a63987)


Fix #631 

I got it working @ben-balk-oc