### PR TITLE
Fix mysql case sensitive issue

### DIFF
--- a/api/src/main/java/org/terrakube/api/rs/Organization.java
+++ b/api/src/main/java/org/terrakube/api/rs/Organization.java
@@ -30,7 +30,7 @@ import java.util.UUID;
 @Include
 @Getter
 @Setter
-@Entity
+@Entity(name = "organization")
 @Where(clause = "disabled = false")
 public class Organization {
 

--- a/api/src/main/java/org/terrakube/api/rs/globalvar/Globalvar.java
+++ b/api/src/main/java/org/terrakube/api/rs/globalvar/Globalvar.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 @Include(rootLevel = false)
 @Getter
 @Setter
-@Entity
+@Entity(name = "globalvar")
 public class Globalvar {
 
     @Id

--- a/api/src/main/java/org/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/org/terrakube/api/rs/job/Job.java
@@ -20,7 +20,7 @@ import java.util.List;
 @Include(rootLevel = false)
 @Getter
 @Setter
-@Entity
+@Entity(name = "job")
 public class Job extends GenericAuditFields {
 
     @Id

--- a/api/src/main/java/org/terrakube/api/rs/job/step/Step.java
+++ b/api/src/main/java/org/terrakube/api/rs/job/step/Step.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 @Include
 @Getter
 @Setter
-@Entity
+@Entity(name = "step")
 public class Step {
 
     @Id

--- a/api/src/main/java/org/terrakube/api/rs/module/Module.java
+++ b/api/src/main/java/org/terrakube/api/rs/module/Module.java
@@ -25,7 +25,7 @@ import java.util.*;
 @Include(rootLevel = false)
 @Getter
 @Setter
-@Entity
+@Entity(name = "module")
 public class Module extends GenericAuditFields {
     @Id
     @Type(type = "uuid-char")

--- a/api/src/main/java/org/terrakube/api/rs/provider/Provider.java
+++ b/api/src/main/java/org/terrakube/api/rs/provider/Provider.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 @Include(rootLevel = false)
 @Getter
 @Setter
-@Entity
+@Entity(name = "provider")
 public class Provider {
     @Id
     @Type(type = "uuid-char")

--- a/api/src/main/java/org/terrakube/api/rs/provider/implementation/Implementation.java
+++ b/api/src/main/java/org/terrakube/api/rs/provider/implementation/Implementation.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Include
 @Getter
 @Setter
-@Entity
+@Entity(name = "implementation")
 public class Implementation {
 
     @Id

--- a/api/src/main/java/org/terrakube/api/rs/provider/implementation/Version.java
+++ b/api/src/main/java/org/terrakube/api/rs/provider/implementation/Version.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 @Include(rootLevel = false)
 @Getter
 @Setter
-@Entity
+@Entity(name = "version")
 public class Version {
 
     @Id

--- a/api/src/main/java/org/terrakube/api/rs/ssh/Ssh.java
+++ b/api/src/main/java/org/terrakube/api/rs/ssh/Ssh.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 @Include(rootLevel = false)
 @Getter
 @Setter
-@Entity
+@Entity(name = "ssh")
 public class Ssh extends GenericAuditFields {
 
     @Id

--- a/api/src/main/java/org/terrakube/api/rs/tag/Tag.java
+++ b/api/src/main/java/org/terrakube/api/rs/tag/Tag.java
@@ -15,7 +15,7 @@ import java.util.List;
 @Include(rootLevel = false)
 @Getter
 @Setter
-@Entity
+@Entity(name = "tag")
 public class Tag extends GenericAuditFields {
     @Id
     @Type(type = "uuid-char")

--- a/api/src/main/java/org/terrakube/api/rs/team/Team.java
+++ b/api/src/main/java/org/terrakube/api/rs/team/Team.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 @Include(rootLevel = false)
 @Getter
 @Setter
-@Entity
+@Entity(name = "team")
 public class Team {
 
     @Id

--- a/api/src/main/java/org/terrakube/api/rs/template/Template.java
+++ b/api/src/main/java/org/terrakube/api/rs/template/Template.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 @Include
 @Getter
 @Setter
-@Entity
+@Entity(name = "template")
 public class Template extends GenericAuditFields {
 
     @Id

--- a/api/src/main/java/org/terrakube/api/rs/token/pat/Pat.java
+++ b/api/src/main/java/org/terrakube/api/rs/token/pat/Pat.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @Getter
 @Setter
-@Entity
+@Entity(name = "pat")
 public class Pat extends GenericAuditFields {
     @Id
     @Type(type="uuid-char")

--- a/api/src/main/java/org/terrakube/api/rs/vcs/Vcs.java
+++ b/api/src/main/java/org/terrakube/api/rs/vcs/Vcs.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 @Include(rootLevel = false)
 @Getter
 @Setter
-@Entity
+@Entity(name = "vcs")
 public class Vcs extends GenericAuditFields {
 
     @Id

--- a/api/src/main/java/org/terrakube/api/rs/webhook/Webhook.java
+++ b/api/src/main/java/org/terrakube/api/rs/webhook/Webhook.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Include(rootLevel = false)
 @Getter
 @Setter
-@Entity
+@Entity(name = "webhook")
 public class Webhook {
 
     @Id

--- a/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
@@ -30,7 +30,7 @@ import java.util.UUID;
 @Include
 @Getter
 @Setter
-@Entity
+@Entity(name = "workspace")
 @Where(clause = "deleted = false")
 public class Workspace extends GenericAuditFields {
 

--- a/api/src/main/java/org/terrakube/api/rs/workspace/content/Content.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/content/Content.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 @Getter
 @Setter
-@Entity
+@Entity(name = "content")
 public class Content {
     @Id
     @Type(type="uuid-char")

--- a/api/src/main/java/org/terrakube/api/rs/workspace/history/History.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/history/History.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 @DeletePermission(expression = "user is a super service")
 @Getter
 @Setter
-@Entity
+@Entity(name = "history")
 public class History extends GenericAuditFields {
 
     @Id

--- a/api/src/main/java/org/terrakube/api/rs/workspace/parameters/Variable.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/parameters/Variable.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 @Include(rootLevel = false)
 @Getter
 @Setter
-@Entity
+@Entity(name = "variable")
 public class Variable {
 
     @Id

--- a/api/src/main/java/org/terrakube/api/rs/workspace/schedule/Schedule.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/schedule/Schedule.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 @Include(rootLevel = false)
 @Getter
 @Setter
-@Entity
+@Entity(name = "schedule")
 public class Schedule extends GenericAuditFields {
 
     @Id

--- a/api/src/main/java/org/terrakube/api/rs/workspace/tag/WorkspaceTag.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/tag/WorkspaceTag.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 @Include(rootLevel = false)
 @Getter
 @Setter
-@Entity
+@Entity(name = "workspacetag")
 public class WorkspaceTag extends GenericAuditFields {
     @Id
     @Type(type = "uuid-char")

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>2.17.0</revision>
+        <revision>2.19.0</revision>
         <sonar.organization>azbuilder</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.project.key>AzBuilder_azb-server</sonar.project.key>


### PR DESCRIPTION
This will fix the issue when running Terrakube with mysql 5.7 that is using ***lower_case_table_names=0***

The code is now using the propose solution from [here](https://stackoverflow.com/questions/6218713/hibernate-scheme-naming-differs-between-os)

Fix #603 