### PR TITLE
Allow to use refresh=false in cli-driven workflow

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJobTrigger.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJobTrigger.java
@@ -45,6 +45,8 @@ public class ScheduleJobTrigger implements org.quartz.Job {
         if (!schedule.getWorkspace().isLocked()) {
             log.info("Creating new job for triggerId: {}", triggerId);
             Job job = new Job();
+            job.setRefresh(true);
+            job.setRefreshOnly(false);
             job.setWorkspace(schedule.getWorkspace());
             job.setOrganization(schedule.getWorkspace().getOrganization());
             if (schedule.getTemplateReference() != null) {

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
@@ -23,6 +23,8 @@ public class ExecutorContext {
     private String branch;
     private String folder;
     private String vcsType;
+    private boolean refresh;
+    private boolean refreshOnly;
     private boolean showHeader;
     private String accessToken;
     private HashMap<String, String> environmentVariables;

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -112,6 +112,8 @@ public class ExecutorService {
             executorContext.setBranch(job.getOverrideBranch());
         }
         executorContext.setFolder(job.getWorkspace().getFolder());
+        executorContext.setRefresh(job.isRefresh());
+        executorContext.setRefreshOnly(job.isRefreshOnly());
         return sendToExecutor(job, executorContext);
     }
 

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -444,6 +444,8 @@ public class RemoteTfeService {
         job.setWorkspace(workspace);
         job.setOrganization(workspace.getOrganization());
         job.setStatus(JobStatus.completed);
+        job.setRefresh(true);
+        job.setRefreshOnly(false);
         job = jobRepository.save(job);
 
         //dummy step
@@ -687,6 +689,8 @@ public class RemoteTfeService {
                 getTemplateName(configurationId, isDestroy));
         log.info("Creating Job");
         Job job = new Job();
+        job.setRefresh(runsData.getData().getAttributes().get("refresh") != null ? (boolean) runsData.getData().getAttributes().get("refresh") : true);
+        job.setRefreshOnly(runsData.getData().getAttributes().get("refresh-only") != null ? (boolean) runsData.getData().getAttributes().get("refresh-only") : false);
         job.setWorkspace(workspace);
         job.setOrganization(workspace.getOrganization());
         job.setStatus(JobStatus.pending);

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
@@ -97,6 +97,8 @@ public class WebhookService {
                                     return result;
                                 }
                                 Job job = new Job();
+                                job.setRefresh(true);
+                                job.setRefreshOnly(false);
                                 job.setOrganization(workspace.getOrganization());
                                 job.setWorkspace(workspace);
                                 job.setTemplateReference(templateId);

--- a/api/src/main/java/org/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/org/terrakube/api/rs/job/Job.java
@@ -65,6 +65,12 @@ public class Job extends GenericAuditFields {
     @Column(name = "via")
     private String via = "UI";
 
+    @Column(name = "refresh")
+    private boolean refresh = true;
+
+    @Column(name = "refresh_only")
+    private boolean refreshOnly = false;
+
     @ManyToOne
     private Organization organization;
 

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -42,4 +42,5 @@
     <include file="/db/changelog/local/changelog-2.18.0-vcs-custom-endpoint.xml"/>
     <include file="/db/changelog/local/changelog-2.18.0-webhooks.xml"/>
     <include file="/db/changelog/local/changelog-2.19.0-override-vcs.xml"/>
+    <include file="/db/changelog/local/changelog-2.19.0-allow-refresh.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/demo-data/aws.xml
+++ b/api/src/main/resources/db/changelog/demo-data/aws.xml
@@ -65,7 +65,7 @@
 
         <insert tableName="template">
             <column name="id"               value="1cf54790-a23d-4c19-afe0-a4db072ea70c" />
-            <column name="name"             value="Destroy" />
+            <column name="name"             value="Terraform-Destroy" />
             <column name="description"      value="Running terraform destroy" />
             <column name="version"          value="1.0.0" />
             <column name="tcl"              value="ZmxvdzoKICAtIHR5cGU6ICJ0ZXJyYWZvcm1EZXN0cm95IgogICAgc3RlcDogMTAwCg==" />

--- a/api/src/main/resources/db/changelog/demo-data/gcp.xml
+++ b/api/src/main/resources/db/changelog/demo-data/gcp.xml
@@ -65,7 +65,7 @@
 
         <insert tableName="template">
             <column name="id"               value="17aadd37-3ba3-4af2-87d4-88a3c12d7679" />
-            <column name="name"             value="Destroy" />
+            <column name="name"             value="Terraform-Destroy" />
             <column name="description"      value="Running terraform destroy" />
             <column name="version"          value="1.0.0" />
             <column name="tcl"              value="ZmxvdzoKICAtIHR5cGU6ICJ0ZXJyYWZvcm1EZXN0cm95IgogICAgc3RlcDogMTAwCg==" />

--- a/api/src/main/resources/db/changelog/demo-data/simple.xml
+++ b/api/src/main/resources/db/changelog/demo-data/simple.xml
@@ -87,7 +87,7 @@
 
         <insert tableName="template">
             <column name="id"               value="d944e19d-bc3e-41b0-bdf9-1881e1a459c4" />
-            <column name="name"             value="Destroy" />
+            <column name="name"             value="Terraform-Destroy" />
             <column name="description"      value="Running terraform destroy" />
             <column name="version"          value="1.0.0" />
             <column name="tcl"              value="ZmxvdzoKICAtIHR5cGU6ICJ0ZXJyYWZvcm1EZXN0cm95IgogICAgc3RlcDogMTAwCg==" />

--- a/api/src/main/resources/db/changelog/local/changelog-2.19.0-allow-refresh.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.19.0-allow-refresh.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="28" author="alfespa17@gmail.com">
+        <addColumn tableName="job" >
+            <column name="refresh" valueBoolean="true"/>
+        </addColumn>
+        <addColumn tableName="job" >
+            <column name="refresh_only" type="false"/>
+        </addColumn>
+        <update tableName="job">
+            <column name="refresh" valueBoolean="true"/>
+        </update>
+        <update tableName="job">
+            <column name="refresh_only" valueBoolean="false"/>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.19.0-allow-refresh.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.19.0-allow-refresh.xml
@@ -4,7 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
             http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
-    <changeSet id="28" author="alfespa17@gmail.com">
+    <changeSet id="30" author="alfespa17@gmail.com">
         <addColumn tableName="job" >
             <column name="refresh" valueBoolean="true"/>
         </addColumn>

--- a/api/src/main/resources/db/changelog/local/changelog-2.19.0-allow-refresh.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.19.0-allow-refresh.xml
@@ -6,10 +6,10 @@
             http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
     <changeSet id="30" author="alfespa17@gmail.com">
         <addColumn tableName="job" >
-            <column name="refresh" valueBoolean="true"/>
+            <column name="refresh" type="boolean"/>
         </addColumn>
         <addColumn tableName="job" >
-            <column name="refresh_only" type="false"/>
+            <column name="refresh_only" type="boolean"/>
         </addColumn>
         <update tableName="job">
             <column name="refresh" valueBoolean="true"/>

--- a/api/src/main/resources/db/changelog/local/changelog-2.19.0-override-vcs.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.19.0-override-vcs.xml
@@ -4,7 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
             http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
-    <changeSet id="30" author="alfespa17@gmail.com">
+    <changeSet id="28" author="alfespa17@gmail.com">
         <addColumn tableName="job" >
             <column name="override_source" type="varchar(256)"/>
         </addColumn>

--- a/api/src/main/resources/db/changelog/local/changelog-2.19.0-override-vcs.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.19.0-override-vcs.xml
@@ -4,7 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
             http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
-    <changeSet id="28" author="alfespa17@gmail.com">
+    <changeSet id="30" author="alfespa17@gmail.com">
         <addColumn tableName="job" >
             <column name="override_source" type="varchar(256)"/>
         </addColumn>

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<commons-text.version>1.10.0</commons-text.version>
-		<terraform-spring-boot-starter.version>0.11.1</terraform-spring-boot-starter.version>
+		<terraform-spring-boot-starter.version>0.11.2</terraform-spring-boot-starter.version>
 		<terrakube-client-starter.version>0.12.0</terrakube-client-starter.version>
 		<commons-io.version>2.8.0</commons-io.version>
 		<commons-codec>1.15</commons-codec>

--- a/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
+++ b/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
@@ -26,6 +26,8 @@ public class TerraformJob {
     private String accessToken;
     private String terraformOutput;
     private boolean showHeader;
+    private boolean refresh;
+    private boolean refreshOnly;
     private HashMap<String, String> environmentVariables;
     private HashMap<String, String> variables;
 

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -440,6 +440,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                 .terraformVariables(terraformJob.getVariables())
                 .terraformEnvironmentVariables(terraformJob.getEnvironmentVariables())
                 .workingDirectory(workingDirectory)
+                .refresh(terraformJob.isRefresh())
+                .refreshOnly(terraformJob.isRefreshOnly())
                 .sshFile(sshKeyFile)
                 .build();
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.17</version>
+        <version>2.7.18</version>
     </parent>
 
     <groupId>org.terrakube</groupId>


### PR DESCRIPTION
Running the following simple terraform using cli-driven workflow:

```
user@pop-os:~/git/simple-terraform$ terraform apply
Running apply in Terraform Cloud. Output will stream here. Pressing Ctrl-C
will cancel the remote apply if it's still pending. If the apply started it
will stop streaming the logs, but will not stop the apply running remotely.

Preparing the remote apply...

To view this run in a browser, visit:
https://8080-azbuilder-terrakube-3it4oxf0vpt.ws-us107.gitpod.io/app/simple/simple-terraform/runs/1

Waiting for the plan to start...

***************************************
Running Terraform PLAN
***************************************

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # null_resource.next will be created
  + resource "null_resource" "next" {
      + id = (known after apply)
    }

  # null_resource.next2 will be created
  + resource "null_resource" "next2" {
      + id = (known after apply)
    }

  # null_resource.previous will be created
  + resource "null_resource" "previous" {
      + id = (known after apply)
    }

  # time_sleep.wait_30_seconds will be created
  + resource "time_sleep" "wait_30_seconds" {
      + create_duration = (known after apply)
      + id              = (known after apply)
    }

  # module.time_module.random_integer.time will be created
  + resource "random_integer" "time" {
      + id     = (known after apply)
      + max    = 5
      + min    = 1
      + result = (known after apply)
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + creation_time = (known after apply)
  + fake_data     = {
      + data     = "Hello World"
      + resource = {
          + resource1 = "fake"
        }
    }

Do you want to perform these actions in workspace "simple-terraform"?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

null_resource.previous: Creating...
null_resource.previous: Creation complete after 0s [id=2942672164070633234]
module.time_module.random_integer.time: Creating...
module.time_module.random_integer.time: Creation complete after 0s [id=4]
time_sleep.wait_30_seconds: Creating...
time_sleep.wait_30_seconds: Creation complete after 4s [id=2023-12-28T20:29:16Z]
null_resource.next: Creating...
null_resource.next2: Creating...
null_resource.next: Creation complete after 0s [id=1447023117451433293]
null_resource.next2: Creation complete after 0s [id=8910164257527828565]

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

creation_time = "4s"
fake_data = {
  "data" = "Hello World"
  "resource" = {
    "resource1" = "fake"
  }
}

```

Changing a little the terraform plan without using the -refresh=false will generate the following refresh in the plan:

```
user@pop-os:~/git/simple-terraform$ terraform plan

Running plan in Terraform Cloud. Output will stream here. Pressing Ctrl-C
will stop streaming the logs, but will not stop the plan running remotely.

Preparing the remote plan...

To view this run in a browser, visit:
https://8080-azbuilder-terrakube-3it4oxf0vpt.ws-us107.gitpod.io/app/simple/simple-terraform/runs/2

Waiting for the plan to start...

***************************************
Running Terraform PLAN
***************************************
null_resource.previous: Refreshing state... [id=2942672164070633234]
module.time_module.random_integer.time: Refreshing state... [id=4]
time_sleep.wait_30_seconds: Refreshing state... [id=2023-12-28T20:29:16Z]
null_resource.next: Refreshing state... [id=1447023117451433293]
null_resource.next2: Refreshing state... [id=8910164257527828565]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # null_resource.next3 will be created
  + resource "null_resource" "next3" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

```

Running again using the -refresh=false will show the plan without doing the refresh like the following:
```
terraform plan -refresh=false

Running plan in Terraform Cloud. Output will stream here. Pressing Ctrl-C
will stop streaming the logs, but will not stop the plan running remotely.

Preparing the remote plan...

To view this run in a browser, visit:
https://8080-azbuilder-terrakube-3it4oxf0vpt.ws-us107.gitpod.io/app/simple/simple-terraform/runs/3

Waiting for the plan to start...

***************************************
Running Terraform PLAN
***************************************

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # null_resource.next3 will be created
  + resource "null_resource" "next3" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

```
Fix #647 