### PR TITLE
SSH keys with VCS connection

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
@@ -27,6 +27,7 @@ public class ExecutorContext {
     private boolean refreshOnly;
     private boolean showHeader;
     private String accessToken;
+    private String moduleSshKey;
     private HashMap<String, String> environmentVariables;
     private HashMap<String, String> variables;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -135,6 +135,7 @@ public class ExecutorService {
         try {
             ResponseEntity<ExecutorContext> response = restTemplate.postForEntity(this.executorUrl, executorContext, ExecutorContext.class);
             executorContext.setAccessToken("****");
+            executorContext.setModuleSshKey("****");
             log.info("Sending Job: /n {}", executorContext);
             log.info("Response Status: {}", response.getStatusCode().value());
 

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -5,6 +5,7 @@ import org.springframework.web.client.RestClientException;
 import org.terrakube.api.plugin.scheduler.job.tcl.model.Flow;
 import org.terrakube.api.repository.GlobalVarRepository;
 import org.terrakube.api.repository.JobRepository;
+import org.terrakube.api.repository.SshRepository;
 import org.terrakube.api.rs.globalvar.Globalvar;
 import org.terrakube.api.rs.job.Job;
 import org.terrakube.api.rs.job.JobStatus;
@@ -20,9 +21,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import javax.swing.text.html.Option;
+import java.util.*;
 
 @Slf4j
 @Service
@@ -36,6 +36,10 @@ public class ExecutorService {
 
     @Autowired
     GlobalVarRepository globalVarRepository;
+
+    @Autowired
+    SshRepository sshRepository;
+
 
     @Transactional
     public boolean execute(Job job, String stepId, Flow flow) {
@@ -110,6 +114,14 @@ public class ExecutorService {
                 executorContext.setShowHeader(false);
             }
             executorContext.setBranch(job.getOverrideBranch());
+        }
+
+        if(job.getWorkspace().getModuleSshKey() != null) {
+            String moduleSshId = job.getWorkspace().getModuleSshKey();
+            Optional<Ssh> ssh = sshRepository.findById(UUID.fromString(moduleSshId));
+            if(ssh.isPresent()){
+                executorContext.setModuleSshKey(ssh.get().getPrivateKey());
+            }
         }
         executorContext.setFolder(job.getWorkspace().getFolder());
         executorContext.setRefresh(job.isRefresh());

--- a/api/src/main/java/org/terrakube/api/repository/SshRepository.java
+++ b/api/src/main/java/org/terrakube/api/repository/SshRepository.java
@@ -1,0 +1,9 @@
+package org.terrakube.api.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.terrakube.api.rs.ssh.Ssh;
+
+import java.util.UUID;
+
+public interface SshRepository extends JpaRepository<Ssh, UUID> {
+}

--- a/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
@@ -60,6 +60,9 @@ public class Workspace extends GenericAuditFields {
     @Column(name = "deleted")
     private boolean deleted;
 
+    @Column(name = "module_ssh_key")
+    private String moduleSshKey;
+
     @Column(name = "terraform_version")
     private String terraformVersion;
 

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -43,4 +43,5 @@
     <include file="/db/changelog/local/changelog-2.18.0-webhooks.xml"/>
     <include file="/db/changelog/local/changelog-2.19.0-override-vcs.xml"/>
     <include file="/db/changelog/local/changelog-2.19.0-allow-refresh.xml"/>
+    <include file="/db/changelog/local/changelog-2.19.0-vcs-module-ssh.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.19.0-vcs-module-ssh.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.19.0-vcs-module-ssh.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="31" author="alfespa17@gmail.com">
+        <addColumn tableName="workspace" >
+            <column name="module_ssh_key" type="varchar(36)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
+++ b/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
@@ -28,6 +28,7 @@ public class TerraformJob {
     private boolean showHeader;
     private boolean refresh;
     private boolean refreshOnly;
+    private String moduleSshKey;
     private HashMap<String, String> environmentVariables;
     private HashMap<String, String> variables;
 

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -429,9 +429,18 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                 terraformJob.getWorkspaceId(), workingDirectory, terraformJob.getTerraformVersion());
 
         File sshKeyFile = null;
-        if (terraformJob.getVcsType().startsWith("SSH")) {
+        if (terraformJob.getVcsType().startsWith("SSH") && terraformJob.getModuleSshKey() != null ) {
+            //USING MODULE SSH KEY TO DOWNLOAD THE MODULES AND NOT THE DEFAULT SSH KEY THAT WAS USED TO CLONE THE WORKSPACE
+            String sshFilePath = String.format(SSH_DIRECTORY, FileUtils.getUserDirectoryPath(), terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), terraformJob.getJobId());
+            sshKeyFile = new File(sshFilePath);
+        } else if(terraformJob.getVcsType().startsWith("SSH")){
+            //USING THE SAME SSH KEY THAT WAS USED TO CLONE THE REPOSITORY
             String sshFileName = terraformJob.getVcsType().split("~")[1];
             String sshFilePath = String.format(SSH_DIRECTORY, FileUtils.getUserDirectoryPath(), terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), sshFileName);
+            sshKeyFile = new File(sshFilePath);
+        } else if(terraformJob.getModuleSshKey() != null ){
+            //USING MODULE SSH KEY TO DOWNLOAD THE MODULES IN OTHER CASE FOR EXAMPLE WHEN USING VCS WITH A MODULE SSH KEY
+            String sshFilePath = String.format(SSH_DIRECTORY, FileUtils.getUserDirectoryPath(), terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), terraformJob.getJobId());
             sshKeyFile = new File(sshFilePath);
         }
 

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -429,19 +429,24 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                 terraformJob.getWorkspaceId(), workingDirectory, terraformJob.getTerraformVersion());
 
         File sshKeyFile = null;
-        if (terraformJob.getVcsType().startsWith("SSH") && terraformJob.getModuleSshKey() != null ) {
+        if (terraformJob.getVcsType().startsWith("SSH") && terraformJob.getModuleSshKey() != null && terraformJob.getModuleSshKey().length() > 0) {
             //USING MODULE SSH KEY TO DOWNLOAD THE MODULES AND NOT THE DEFAULT SSH KEY THAT WAS USED TO CLONE THE WORKSPACE
             String sshFilePath = String.format(SSH_DIRECTORY, FileUtils.getUserDirectoryPath(), terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), terraformJob.getJobId());
+            log.warn("1 - Using SSH key from: {}", sshFilePath);
             sshKeyFile = new File(sshFilePath);
         } else if(terraformJob.getVcsType().startsWith("SSH")){
             //USING THE SAME SSH KEY THAT WAS USED TO CLONE THE REPOSITORY
             String sshFileName = terraformJob.getVcsType().split("~")[1];
             String sshFilePath = String.format(SSH_DIRECTORY, FileUtils.getUserDirectoryPath(), terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), sshFileName);
+            log.warn("2 - Using SSH key from: {}", sshFilePath);
             sshKeyFile = new File(sshFilePath);
-        } else if(terraformJob.getModuleSshKey() != null ){
+        } else if(terraformJob.getModuleSshKey() != null && terraformJob.getModuleSshKey().length() > 0){
             //USING MODULE SSH KEY TO DOWNLOAD THE MODULES IN OTHER CASE FOR EXAMPLE WHEN USING VCS WITH A MODULE SSH KEY
             String sshFilePath = String.format(SSH_DIRECTORY, FileUtils.getUserDirectoryPath(), terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), terraformJob.getJobId());
+            log.warn("3 - Using SSH key from: {}", sshFilePath);
             sshKeyFile = new File(sshFilePath);
+        } else {
+            log.warn("Not using any SSH key to download modules");
         }
 
         TerraformProcessData terraformProcessData = TerraformProcessData.builder()

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -58,7 +58,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
             } else {
                 downloadWorkspaceTarGz(workspaceCloneFolder, terraformJob.getSource());
             }
-            if(terraformJob.getModuleSshKey() != null){
+            if(terraformJob.getModuleSshKey() != null && terraformJob.getModuleSshKey().length() > 0){
                 generateModuleSshFolder(terraformJob.getModuleSshKey(), terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), terraformJob.getJobId());
             }
 
@@ -247,12 +247,13 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
     }
 
     private File generateModuleSshFolder(String privateKey, String organizationId, String workspaceId, String jobId) {
+        log.warn("Generate new file SSH Key for modules...");
         String sshFilePath = String.format(SSH_DIRECTORY, FileUtils.getUserDirectoryPath(), organizationId, workspaceId, jobId);
         File sshFile = new File(sshFilePath);
         try {
 
             FileUtils.forceMkdirParent(sshFile);
-            log.info("Creating new module SSH folder for organization {} wordkspace {} with jobId {}", organizationId, workspaceId, jobId);
+            log.info("Creating new module SSH folder for organization {} workspace {} with jobId {}", organizationId, workspaceId, jobId);
             FileUtils.writeStringToFile(sshFile, privateKey + "\n", Charset.defaultCharset());
 
             Set<PosixFilePermission> perms = new HashSet<>();

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -102,6 +102,7 @@ export const WorkspaceDetails = (props) => {
   const [lastRun, setLastRun] = useState("");
   const [executionMode, setExecutionMode] = useState("...");
   const [moduleSshKey, setModuleSshKey] = useState("...");
+  const [sshKeys, setSSHKeys] = useState([]);
   const [vcsProvider, setVCSProvider] = useState("");
   const [resources, setResources] = useState([]);
   const [outputs, setOutputs] = useState([]);
@@ -188,7 +189,7 @@ export const WorkspaceDetails = (props) => {
   const loadSSHKeys = () => {
     axiosInstance.get(`organization/${organizationId}/ssh`).then((response) => {
       console.log(response.data.data);
-      setModuleSshKey(response.data.data);
+      setSSHKeys(response.data.data);
     });
   };
 
@@ -880,7 +881,7 @@ export const WorkspaceDetails = (props) => {
                               workspace.data.attributes.moduleSshKey
                               }
                               placeholder="select SSH Key" style={{ width: 250 }}>
-                            {setModuleSshKey.map(function (sshKey, index) {
+                            {sshKeys.map(function (sshKey, index) {
                               return (
                                   <Option key={sshKey?.id}>{sshKey?.attributes?.name}</Option>
                               );

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -101,6 +101,7 @@ export const WorkspaceDetails = (props) => {
   const [templates, setTemplates] = useState([]);
   const [lastRun, setLastRun] = useState("");
   const [executionMode, setExecutionMode] = useState("...");
+  const [moduleSshKey, setModuleSshKey] = useState("...");
   const [vcsProvider, setVCSProvider] = useState("");
   const [resources, setResources] = useState([]);
   const [outputs, setOutputs] = useState([]);
@@ -184,6 +185,13 @@ export const WorkspaceDetails = (props) => {
     switchKey(key);
   };
 
+  const loadSSHKeys = () => {
+    axiosInstance.get(`organization/${organizationId}/ssh`).then((response) => {
+      console.log(response.data.data);
+      setSSHKeys(response.data.data);
+    });
+  };
+
   const showDrawer = (record) => {
     setOpen(true);
     setResource(record);
@@ -209,7 +217,7 @@ export const WorkspaceDetails = (props) => {
       setTerraformVersions(tfVersions.sort(compareVersions).reverse());
     });
     setLoading(false);
-
+    loadSSHKeys();
     const interval = setInterval(() => {
       loadWorkspace();
     }, 15000);
@@ -786,6 +794,7 @@ export const WorkspaceDetails = (props) => {
                           description: workspace.data.attributes.description,
                           folder: workspace.data.attributes.folder,
                           locked: workspace.data.attributes.locked,
+                          moduleSshKey: workspace.data.attributes.moduleSshKey,
                           executionMode:
                             workspace.data.attributes.executionMode,
                         }}
@@ -859,6 +868,23 @@ export const WorkspaceDetails = (props) => {
                           >
                             <Option key="remote">remote</Option>
                             <Option key="local">local</Option>
+                          </Select>
+                        </Form.Item>
+                        <Form.Item
+                            name="moduleSshKey"
+                            label="Module Ssh Key"
+                            extra="Use this option to add a SSH key to allow module downloads"
+                        >
+                          <Select
+                              defaultValue={
+                              workspace.data.attributes.moduleSshKey
+                              }
+                              placeholder="select SSH Key" style={{ width: 250 }}>
+                            {sshKeys.map(function (sshKey, index) {
+                              return (
+                                  <Option key={sshKey?.id}>{sshKey?.attributes?.name}</Option>
+                              );
+                            })}
                           </Select>
                         </Form.Item>
                         <Form.Item>

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -101,7 +101,6 @@ export const WorkspaceDetails = (props) => {
   const [templates, setTemplates] = useState([]);
   const [lastRun, setLastRun] = useState("");
   const [executionMode, setExecutionMode] = useState("...");
-  const [moduleSshKey, setModuleSshKey] = useState("...");
   const [sshKeys, setSSHKeys] = useState([]);
   const [vcsProvider, setVCSProvider] = useState("");
   const [resources, setResources] = useState([]);
@@ -314,6 +313,7 @@ export const WorkspaceDetails = (props) => {
           folder: values.folder,
           locked: values.locked,
           executionMode: values.executionMode,
+          moduleSshKey: values.moduleSshKey,
           terraformVersion: values.terraformVersion,
         },
       },

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -873,7 +873,7 @@ export const WorkspaceDetails = (props) => {
                         </Form.Item>
                         <Form.Item
                             name="moduleSshKey"
-                            label="Module Ssh Key"
+                            label="Download modules SSH Keys"
                             extra="Use this option to add a SSH key to allow module downloads"
                         >
                           <Select

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -188,7 +188,7 @@ export const WorkspaceDetails = (props) => {
   const loadSSHKeys = () => {
     axiosInstance.get(`organization/${organizationId}/ssh`).then((response) => {
       console.log(response.data.data);
-      setSSHKeys(response.data.data);
+      setModuleSshKey(response.data.data);
     });
   };
 
@@ -880,7 +880,7 @@ export const WorkspaceDetails = (props) => {
                               workspace.data.attributes.moduleSshKey
                               }
                               placeholder="select SSH Key" style={{ width: 250 }}>
-                            {sshKeys.map(function (sshKey, index) {
+                            {setModuleSshKey.map(function (sshKey, index) {
                               return (
                                   <Option key={sshKey?.id}>{sshKey?.attributes?.name}</Option>
                               );


### PR DESCRIPTION
This PR will allow to select a SSH key in the workspace setting, this key will be use to download terraform modules using ssh connection.

Adding a new option inside the workspace setting to select which SSH key should be use to download terraform modules like the following example:

```terraform
module "test" {
  source = "git@github.com:alfespa17/simple-terraform.git"
}
```

![image](https://github.com/AzBuilder/terrakube/assets/4461895/d4c538c5-8112-403b-a9ca-f1f846571a07)

This option can also be use with workspaces with "ssh connection" by default it will be using the SSH key that was selected when creating the workspace but can be used if you want to use a different ssh key for downloading modules.

Fix #640 