### PR TITLE
Fix length folder in workspace table

### DIFF
--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -44,4 +44,5 @@
     <include file="/db/changelog/local/changelog-2.19.0-override-vcs.xml"/>
     <include file="/db/changelog/local/changelog-2.19.0-allow-refresh.xml"/>
     <include file="/db/changelog/local/changelog-2.19.0-vcs-module-ssh.xml"/>
+    <include file="/db/changelog/local/changelog-2.19.0-workspace-folder-length.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.19.0-workspace-folder-length.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.19.0-workspace-folder-length.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="32" author="alfespa17@gmail.com">
+        <modifyDataType
+                columnName="folder"
+                newDataType="varchar(512)"
+                tableName="workspace"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Adding liquibase database changeset to increase size of the folder column in workspace table.

![image](https://github.com/AzBuilder/terrakube/assets/4461895/d8bf0708-c85d-44e6-9e40-75a5ed750274)

Fix #657 