### PR TITLE
Github Webhook - Validate File changes

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
@@ -28,6 +28,7 @@ public class ExecutorContext {
     private boolean showHeader;
     private String accessToken;
     private String moduleSshKey;
+    private String commitId;
     private HashMap<String, String> environmentVariables;
     private HashMap<String, String> variables;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -123,6 +123,7 @@ public class ExecutorService {
                 executorContext.setModuleSshKey(ssh.get().getPrivateKey());
             }
         }
+        executorContext.setCommitId(job.getCommitId());
         executorContext.setFolder(job.getWorkspace().getFolder());
         executorContext.setRefresh(job.isRefresh());
         executorContext.setRefreshOnly(job.isRefreshOnly());

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookResult.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookResult.java
@@ -2,13 +2,18 @@ package org.terrakube.api.plugin.vcs;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
 
 @Getter
 @Setter
+@ToString
 public class WebhookResult {
     private String branch;
     private boolean isValid;
     private String event;
     private String createdBy;
     private String via;
+    private List<String> fileChanges;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookResult.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookResult.java
@@ -16,4 +16,5 @@ public class WebhookResult {
     private String createdBy;
     private String via;
     private List<String> fileChanges;
+    private String commit;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @AllArgsConstructor
 @Slf4j
@@ -82,7 +83,7 @@ public class WebhookService {
                     // if the webhook is a valid request we can create a new job
                     if(webhookResult.isValid()){
                         // only execute the job if the branch is the same
-                        if(webhookResult.getBranch().equals(workspace.getBranch()))
+                        if(webhookResult.getBranch().equals(workspace.getBranch()) && checkFileChanges(webhookResult.getFileChanges(), workspace.getFolder()))
                         {
                            ObjectMapper objectMapper = new ObjectMapper();
                             try {
@@ -125,6 +126,20 @@ public class WebhookService {
                 break;
         }
         return result;
+    }
+
+    private boolean checkFileChanges(List<String> files, String workspaceFolder){
+        if(files != null){
+            AtomicBoolean fileChanged = new AtomicBoolean(false);
+            files.forEach(file-> {
+                log.info("File: {} in {}: {}", file, workspaceFolder, file.startsWith(workspaceFolder));
+                if(file.startsWith(workspaceFolder) && !fileChanged.get()){
+                    fileChanged.set(true);
+                }
+            });
+            return fileChanged.get();
+        } else
+            return true;
     }
 
 

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
@@ -109,9 +109,7 @@ public class WebhookService {
                                 job.setCreatedDate(triggerDate);
                                 job.setUpdatedDate(triggerDate);
                                 job.setVia(webhookResult.getVia());
-                                //if(webhookResult.getCommit() != null){
-                                //    job.setOverrideBranch(webhookResult.getCommit());
-                                //}
+                                job.setCommitId(webhookResult.getCommit());
                                 Job savedJob = jobRepository.save(job);
                                 scheduleJobService.createJobContext(savedJob);
                             } catch (Exception e) {

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
@@ -109,6 +109,9 @@ public class WebhookService {
                                 job.setCreatedDate(triggerDate);
                                 job.setUpdatedDate(triggerDate);
                                 job.setVia(webhookResult.getVia());
+                                if(webhookResult.getCommit() != null){
+                                    job.setOverrideBranch(webhookResult.getCommit());
+                                }
                                 Job savedJob = jobRepository.save(job);
                                 scheduleJobService.createJobContext(savedJob);
                             } catch (Exception e) {

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
@@ -132,8 +132,8 @@ public class WebhookService {
         if(files != null){
             AtomicBoolean fileChanged = new AtomicBoolean(false);
             files.forEach(file-> {
-                log.info("File: {} in {}: {}", file, workspaceFolder, file.startsWith(workspaceFolder));
-                if(file.startsWith(workspaceFolder) && !fileChanged.get()){
+                log.info("File: {} in {}: {}", file, workspaceFolder.substring(1), file.startsWith(workspaceFolder));
+                if(file.startsWith(workspaceFolder.substring(1)) && !fileChanged.get()){
                     fileChanged.set(true);
                 }
             });

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
@@ -109,9 +109,9 @@ public class WebhookService {
                                 job.setCreatedDate(triggerDate);
                                 job.setUpdatedDate(triggerDate);
                                 job.setVia(webhookResult.getVia());
-                                if(webhookResult.getCommit() != null){
-                                    job.setOverrideBranch(webhookResult.getCommit());
-                                }
+                                //if(webhookResult.getCommit() != null){
+                                //    job.setOverrideBranch(webhookResult.getCommit());
+                                //}
                                 Job savedJob = jobRepository.save(job);
                                 scheduleJobService.createJobContext(savedJob);
                             } catch (Exception e) {

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/controller/WebHookController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/controller/WebHookController.java
@@ -31,6 +31,7 @@ public class WebHookController {
         log.info("Processing webhook {}", webhookId);
         try {
             String jsonPayload = objectMapper.writeValueAsString(payload);
+            log.info("webhook payload: {}", jsonPayload);
             webhookService.processWebhook(webhookId, jsonPayload,headers);
         } catch (Exception e) {
             log.error("Error processing webhook", e);

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookModel.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookModel.java
@@ -1,0 +1,20 @@
+package org.terrakube.api.plugin.vcs.provider.github;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class GitHubWebhookModel {
+    List<Commit> commits;
+}
+
+@Getter
+@Setter
+class Commit{
+    List<String> added;
+    List<String> modified;
+    List<String> removed;
+}

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookModel.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookModel.java
@@ -1,5 +1,6 @@
 package org.terrakube.api.plugin.vcs.provider.github;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -7,6 +8,7 @@ import java.util.List;
 
 @Getter
 @Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class GitHubWebhookModel {
     List<Commit> commits;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookModel.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookModel.java
@@ -11,6 +11,7 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GitHubWebhookModel {
     List<Commit> commits;
+    HeadCommit head_commit;
 }
 
 @Getter
@@ -20,4 +21,11 @@ class Commit{
     List<String> added;
     List<String> modified;
     List<String> removed;
+}
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+class HeadCommit{
+    String id;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookModel.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookModel.java
@@ -15,6 +15,7 @@ public class GitHubWebhookModel {
 
 @Getter
 @Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
 class Commit{
     List<String> added;
     List<String> modified;

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -49,6 +49,7 @@ public class GitHubWebhookService extends WebhookServiceBase {
             String extractedBranch = ref.split("/")[2];
             result.setBranch(extractedBranch);
 
+
             // Extract the user who triggered the webhook
             JsonNode pusherNode = rootNode.path("pusher");
             String pusher = pusherNode.path("email").asText();
@@ -63,6 +64,7 @@ public class GitHubWebhookService extends WebhookServiceBase {
             result.setFileChanges(new ArrayList());
             try {
                 GitHubWebhookModel gitHubWebhookModel = new ObjectMapper().readValue(jsonPayload, GitHubWebhookModel.class);
+                result.setCommit(gitHubWebhookModel.getHead_commit().getId());
                 gitHubWebhookModel.getCommits().forEach(commit -> {
                     for (String addedObject : commit.getAdded()) {
                         log.info("New: {}", addedObject);

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -33,30 +33,7 @@ public class GitHubWebhookService extends WebhookServiceBase {
     }
 
     public WebhookResult processWebhook(String jsonPayload, Map<String, String> headers, String token) {
-        WebhookResult temp = handleWebhook(jsonPayload, headers, token, "x-hub-signature-256", "Github", this::handleEvent);
-        temp.setFileChanges(new ArrayList());
-        try {
-            GitHubWebhookModel gitHubWebhookModel = new ObjectMapper().readValue(jsonPayload, GitHubWebhookModel.class);
-            gitHubWebhookModel.getCommits().forEach(commit -> {
-                for (String addedObject : commit.getAdded()) {
-                    log.info("New: {}", addedObject);
-                    temp.getFileChanges().add(addedObject);
-                }
-
-                for (String removedObject : commit.getRemoved()) {
-                    log.info("Removed: {}", removedObject);
-                    temp.getFileChanges().add(removedObject);
-                }
-
-                for (String modifedObject : commit.getModified()) {
-                    log.info("Modified: {}", modifedObject);
-                    temp.getFileChanges().add(modifedObject);
-                }
-            });
-        } catch (JsonProcessingException e) {
-            log.error(e.getMessage());
-        }
-        return temp;
+        return handleWebhook(jsonPayload, headers, token, "x-hub-signature-256", "Github", this::handleEvent);
     }
 
     private WebhookResult handleEvent(String jsonPayload, WebhookResult result,  Map<String, String> headers) {
@@ -81,6 +58,29 @@ public class GitHubWebhookService extends WebhookServiceBase {
             {
                 log.error("Error parsing JSON response", e);
                 result.setBranch("");
+            }
+
+            result.setFileChanges(new ArrayList());
+            try {
+                GitHubWebhookModel gitHubWebhookModel = new ObjectMapper().readValue(jsonPayload, GitHubWebhookModel.class);
+                gitHubWebhookModel.getCommits().forEach(commit -> {
+                    for (String addedObject : commit.getAdded()) {
+                        log.info("New: {}", addedObject);
+                        result.getFileChanges().add(addedObject);
+                    }
+
+                    for (String removedObject : commit.getRemoved()) {
+                        log.info("Removed: {}", removedObject);
+                        result.getFileChanges().add(removedObject);
+                    }
+
+                    for (String modifedObject : commit.getModified()) {
+                        log.info("Modified: {}", modifedObject);
+                        result.getFileChanges().add(modifedObject);
+                    }
+                });
+            } catch (JsonProcessingException e) {
+                log.error(e.getMessage());
             }
         }
 

--- a/api/src/main/java/org/terrakube/api/repository/JobRepository.java
+++ b/api/src/main/java/org/terrakube/api/repository/JobRepository.java
@@ -3,10 +3,13 @@ package org.terrakube.api.repository;
 import org.terrakube.api.rs.job.Job;
 import org.terrakube.api.rs.job.JobStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.terrakube.api.rs.workspace.Workspace;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface JobRepository extends JpaRepository<Job, Integer> {
 
     List<Job> findAllByStatus(JobStatus status);
+    Optional<List<Job>> findByWorkspaceAndStatusNotInAndIdLessThan(Workspace workspace, List<JobStatus> jobStatuses, int jobId);
 }

--- a/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
+++ b/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
@@ -29,6 +29,7 @@ public class TerraformJob {
     private boolean refresh;
     private boolean refreshOnly;
     private String moduleSshKey;
+    private String commitId;
     private HashMap<String, String> environmentVariables;
     private HashMap<String, String> variables;
 


### PR DESCRIPTION
When having multiple VCS private workspaces validate file changes to trigger a job in a specific wokspace only

![image](https://github.com/AzBuilder/terrakube/assets/4461895/7f7607c5-16df-46a6-8227-86c6c98c557a)

The webhook will also generate a job for a particular commit id:

![image](https://github.com/AzBuilder/terrakube/assets/4461895/f9d14e45-7741-48c1-88cb-1e1594d64967)

It will also execute jobs in order of creation 
