### PR TITLE
Fix terrakube registry response code

### DIFF
--- a/registry/src/main/java/org/terrakube/registry/controller/ModuleWebServiceImpl.java
+++ b/registry/src/main/java/org/terrakube/registry/controller/ModuleWebServiceImpl.java
@@ -51,7 +51,7 @@ public class ModuleWebServiceImpl {
         responseHeaders.set(
                 "Access-Control-Expose-Headers","X-Terraform-Get"
         );
-        return ResponseEntity.ok().headers(responseHeaders).body(null);
+        return ResponseEntity.noContent().headers(responseHeaders).build();
     }
 
     @GetMapping(


### PR DESCRIPTION
Fix response code in terrakube registry to be able to work correctly with tofu

```
user@pop-os:~/git/simple-terraform$ terraform init

Initializing the backend...
Initializing modules...
Downloading 8075-azbuilder-terrakube-sm2t1umnh4z.ws-us107.gitpod.io/azure/network/azurerm 5.3.0 for network...
- network in .terraform/modules/network
- time_module in module

Initializing provider plugins...
- Reusing previous version of hashicorp/time from the dependency lock file
- Reusing previous version of hashicorp/random from the dependency lock file
- Finding hashicorp/azurerm versions matching ">= 3.0.0, < 4.0.0"...
- Reusing previous version of hashicorp/null from the dependency lock file
- Installing hashicorp/random v3.6.0...
- Installed hashicorp/random v3.6.0 (signed by HashiCorp)
- Installing hashicorp/azurerm v3.86.0...
- Installed hashicorp/azurerm v3.86.0 (signed by HashiCorp)
- Installing hashicorp/null v3.2.2...
- Installed hashicorp/null v3.2.2 (signed by HashiCorp)
- Installing hashicorp/time v0.10.0...
- Installed hashicorp/time v0.10.0 (signed by HashiCorp)

Terraform has made some changes to the provider dependency selections recorded
in the .terraform.lock.hcl file. Review those changes and commit them to your
version control system if they represent changes you intended to make.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
user@pop-os:~/git/simple-terraform$ rm -rf .terraform
```

Example using tofu
```
user@pop-os:~/git/simple-terraform$ tofu init

Initializing the backend...
Initializing modules...
Downloading 8075-azbuilder-terrakube-sm2t1umnh4z.ws-us107.gitpod.io/azure/network/azurerm 5.3.0 for network...
- network in .terraform/modules/network
- time_module in module

Initializing provider plugins...
- Finding latest version of hashicorp/null...
- Finding latest version of hashicorp/time...
- Finding hashicorp/azurerm versions matching ">= 3.0.0, < 4.0.0"...
- Finding latest version of hashicorp/random...
- Installing hashicorp/time v0.10.0...
- Installed hashicorp/time v0.10.0 (signed, key ID 0C0AF313E5FD9F80)
- Installing hashicorp/azurerm v3.86.0...
- Installed hashicorp/azurerm v3.86.0 (signed, key ID 0C0AF313E5FD9F80)
- Installing hashicorp/random v3.6.0...
- Installed hashicorp/random v3.6.0 (signed, key ID 0C0AF313E5FD9F80)
- Installing hashicorp/null v3.2.2...
- Installed hashicorp/null v3.2.2 (signed, key ID 0C0AF313E5FD9F80)

Providers are signed by their developers.
If you'd like to know more about provider signing, you can read about it here:
https://opentofu.org/docs/cli/plugins/signing/

OpenTofu has made some changes to the provider dependency selections recorded
in the .terraform.lock.hcl file. Review those changes and commit them to your
version control system if they represent changes you intended to make.

OpenTofu has been successfully initialized!

You may now begin working with OpenTofu. Try running "tofu plan" to see
any changes that are required for your infrastructure. All OpenTofu commands
should now work.

If you ever set or change modules or backend configuration for OpenTofu,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
user@pop-os:~/git/simple-terraform$ tofu -version
OpenTofu v1.6.0
on linux_amd64
+ provider registry.opentofu.org/hashicorp/azurerm v3.86.0
+ provider registry.opentofu.org/hashicorp/null v3.2.2
+ provider registry.opentofu.org/hashicorp/random v3.6.0
+ provider registry.opentofu.org/hashicorp/time v0.10.0
user@pop-os:~/git/simple-terraform$ terraform -version
Terraform v1.5.7
on linux_amd64
+ provider registry.opentofu.org/hashicorp/azurerm v3.86.0
+ provider registry.opentofu.org/hashicorp/null v3.2.2
+ provider registry.opentofu.org/hashicorp/random v3.6.0
+ provider registry.opentofu.org/hashicorp/time v0.10.0

Your version of Terraform is out of date! The latest version
is 1.6.6. You can update by downloading from https://www.terraform.io/downloads.html

```

fix #669 