### PR TITLE
Cancel old jobs

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.time.DateUtils;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorService;
 import org.terrakube.api.plugin.scheduler.job.tcl.TclService;
@@ -26,10 +27,7 @@ import org.terrakube.api.rs.workspace.Workspace;
 import org.terrakube.api.rs.workspace.schedule.Schedule;
 
 import java.text.ParseException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 import static org.terrakube.api.plugin.scheduler.ScheduleJobService.PREFIX_JOB_CONTEXT;
 
@@ -63,6 +61,21 @@ public class ScheduleJob implements org.quartz.Job {
     public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
         int jobId = jobExecutionContext.getJobDetail().getJobDataMap().getInt(JOB_ID);
         Job job = jobRepository.getReferenceById(jobId);
+
+        Date jobExpiration = DateUtils.addHours(job.getCreatedDate(), 6);
+        Date currentTime = new Date();
+        log.info("Job {} should be completed before {}, current time {}", jobExpiration, currentTime);
+        if(jobExpiration.before(currentTime)){
+            log.error("Job has been running for more than 6 hours, cancelling running job");
+            try {
+                redisTemplate.delete(String.valueOf(job.getId()));
+                log.info("Deleting Job Context {} from Quartz", PREFIX_JOB_CONTEXT + job.getId());
+                updateJobStepsWithStatus(job.getId(), JobStatus.failed);
+                jobExecutionContext.getScheduler().deleteJob(new JobKey(PREFIX_JOB_CONTEXT + job.getId()));
+            } catch (Exception e) {
+                log.error(e.getMessage());
+            }
+        }
 
         log.info("Checking Job {} Status {}", job.getId(), job.getStatus());
         log.info("Checking previous jobs....");


### PR DESCRIPTION
If for some reason a job has been running for more than 6 hours this PR will cancel the job and mark it as failed