### PR TITLE
Initial OpenTofu support

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
@@ -29,6 +29,7 @@ public class ExecutorContext {
     private String accessToken;
     private String moduleSshKey;
     private String commitId;
+    private boolean tofu;
     private HashMap<String, String> environmentVariables;
     private HashMap<String, String> variables;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -123,6 +123,7 @@ public class ExecutorService {
                 executorContext.setModuleSshKey(ssh.get().getPrivateKey());
             }
         }
+        executorContext.setTofu(job.getWorkspace().isTofu());
         executorContext.setCommitId(job.getCommitId());
         executorContext.setFolder(job.getWorkspace().getFolder());
         executorContext.setRefresh(job.isRefresh());

--- a/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
@@ -60,6 +60,9 @@ public class Workspace extends GenericAuditFields {
     @Column(name = "deleted")
     private boolean deleted;
 
+    @Column(name = "tofu")
+    private boolean tofu = false;
+
     @Column(name = "module_ssh_key")
     private String moduleSshKey;
 

--- a/api/src/main/resources/db/changelog/changelog-demo.xml
+++ b/api/src/main/resources/db/changelog/changelog-demo.xml
@@ -13,4 +13,5 @@
     <include file="/db/changelog/demo-data/gcp.xml"/>
     <include file="/db/changelog/demo-data/simple.xml"/>
     <include file="/db/changelog/demo-data/simple-tag.xml"/>
+    <include file="/db/changelog/demo-data/demo-tofu.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -45,4 +45,5 @@
     <include file="/db/changelog/local/changelog-2.19.0-allow-refresh.xml"/>
     <include file="/db/changelog/local/changelog-2.19.0-vcs-module-ssh.xml"/>
     <include file="/db/changelog/local/changelog-2.19.0-workspace-folder-length.xml"/>
+    <include file="/db/changelog/local/changelog-2.19.0-workspace-tofu.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/demo-data/demo-tofu.xml
+++ b/api/src/main/resources/db/changelog/demo-data/demo-tofu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet author="demo-data" id="demo-6">
+        <update tableName="workspace">
+            <column name="tofu" valueBoolean="false"/>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.19.0-workspace-tofu.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.19.0-workspace-tofu.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="33" author="alfespa17@gmail.com">
+        <addColumn tableName="workspace" >
+            <column name="tofu" type="boolean"/>
+        </addColumn>
+        <update tableName="workspace">
+            <column name="tofu" valueBoolean="false"/>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<commons-text.version>1.10.0</commons-text.version>
-		<terraform-spring-boot-starter.version>0.11.2</terraform-spring-boot-starter.version>
+		<terraform-spring-boot-starter.version>0.12.0</terraform-spring-boot-starter.version>
 		<terrakube-client-starter.version>0.12.0</terrakube-client-starter.version>
 		<commons-io.version>2.8.0</commons-io.version>
 		<commons-codec>1.15</commons-codec>

--- a/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
+++ b/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
@@ -30,6 +30,7 @@ public class TerraformJob {
     private boolean refreshOnly;
     private String moduleSshKey;
     private String commitId;
+    private boolean tofu;
     private HashMap<String, String> environmentVariables;
     private HashMap<String, String> variables;
 

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -107,7 +107,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
             scriptBeforeSuccessPlan = executePreOperationScripts(terraformJob, terraformWorkingDir, planOutput);
 
-            showTerraformMessage("PLAN", planOutput);
+            showTerraformMessage(terraformJob,"PLAN", planOutput);
 
             if (scriptBeforeSuccessPlan)
                 if (isDestroy) {
@@ -180,7 +180,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
             scriptBeforeSuccess = executePreOperationScripts(terraformJob, terraformWorkingDir, applyOutput);
 
-            showTerraformMessage("APPLY", applyOutput);
+            showTerraformMessage(terraformJob, "APPLY", applyOutput);
 
             if (scriptBeforeSuccess) {
                 TerraformProcessData terraformProcessData = getTerraformProcessData(terraformJob, terraformWorkingDir);
@@ -245,7 +245,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
             scriptBeforeSuccess = executePreOperationScripts(terraformJob, terraformWorkingDir, outputDestroy);
 
-            showTerraformMessage("DESTROY", outputDestroy);
+            showTerraformMessage(terraformJob, "DESTROY", outputDestroy);
 
             if (scriptBeforeSuccess) {
                 execution = terraformClient.destroy(
@@ -410,15 +410,19 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         output.accept(
                 colorize("Initializing Terrakube Job " + terraformJob.getJobId() + " Step " + terraformJob.getStepId(),
                         colorMessage));
-        output.accept(colorize("Running Terraform " + terraformJob.getTerraformVersion(), colorMessage));
+        output.accept(colorize(String.format("Running %s ", getIaCType(terraformJob)) + terraformJob.getTerraformVersion(), colorMessage));
         output.accept(colorize("\n\n" + STEP_SEPARATOR, colorMessage));
-        output.accept(colorize("Running Terraform Init: ", colorMessage));
+        output.accept(colorize(String.format("Running %s Init: ",getIaCType(terraformJob)), colorMessage));
     }
 
-    private void showTerraformMessage(String operation, Consumer<String> output) throws InterruptedException {
+    private String getIaCType(TerraformJob terraformJob){
+        return terraformJob.isTofu() ? "Tofu": "Terraform";
+    }
+
+    private void showTerraformMessage(TerraformJob terraformJob, String operation, Consumer<String> output) throws InterruptedException {
         AnsiFormat colorMessage = new AnsiFormat(GREEN_TEXT(), BLACK_BACK(), BOLD());
         output.accept(colorize(STEP_SEPARATOR, colorMessage));
-        output.accept(colorize("Running Terraform " + operation, colorMessage));
+        output.accept(colorize(String.format("Running %s ",getIaCType(terraformJob)) + operation, colorMessage));
         output.accept(colorize(STEP_SEPARATOR, colorMessage));
         Thread.sleep(2000);
     }

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -456,6 +456,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                 .workingDirectory(workingDirectory)
                 .refresh(terraformJob.isRefresh())
                 .refreshOnly(terraformJob.isRefreshOnly())
+                .tofu(terraformJob.isTofu())
                 .sshFile(sshKeyFile)
                 .build();
 

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -859,19 +859,15 @@ export const WorkspaceDetails = (props) => {
                         </Form.Item>
 
                         <Form.Item
-                          name="tofu"
-                          label="Use OpenTofu"
-                          extra="Use this if you want to run the workspace using OpenTofu instead of terraform"
+                            name="tofu"
+                            valuePropName="checked"
+                            label="Use OpenTofu"
+                            tooltip={{
+                              title: "Use OpenTofu",
+                              icon: <InfoCircleOutlined />,
+                            }}
                         >
-                          <Select
-                            defaultValue={
-                              workspace.data.attributes.tofu
-                            }
-                            style={{ width: 250 }}
-                          >
-                            <Option key="false">false</Option>
-                            <Option key="true">true</Option>
-                          </Select>
+                          <Switch />
                         </Form.Item>
                         <Form.Item
                             name="executionMode"

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -315,6 +315,7 @@ export const WorkspaceDetails = (props) => {
           executionMode: values.executionMode,
           moduleSshKey: values.moduleSshKey,
           terraformVersion: values.terraformVersion,
+          tofu: values.tofu,
         },
       },
     };
@@ -798,6 +799,7 @@ export const WorkspaceDetails = (props) => {
                           moduleSshKey: workspace.data.attributes.moduleSshKey,
                           executionMode:
                             workspace.data.attributes.executionMode,
+                          tofu: workspace.data.attributes.tofu,
                         }}
                         layout="vertical"
                         name="form-settings"
@@ -857,15 +859,30 @@ export const WorkspaceDetails = (props) => {
                         </Form.Item>
 
                         <Form.Item
-                          name="executionMode"
-                          label="Execution Mode"
-                          extra="Use this option with terraform remote state/cloud block if you want to execute Terraform CLI remotely and just upload the state to Terrakube"
+                          name="tofu"
+                          label="Use OpenTofu"
+                          extra="Use this if you want to run the workspace using OpenTofu instead of terraform"
                         >
                           <Select
                             defaultValue={
-                              workspace.data.attributes.executionMode
+                              workspace.data.attributes.tofu
                             }
                             style={{ width: 250 }}
+                          >
+                            <Option key="false">false</Option>
+                            <Option key="true">true</Option>
+                          </Select>
+                        </Form.Item>
+                        <Form.Item
+                            name="executionMode"
+                            label="Execution Mode"
+                            extra="Use this option with terraform remote state/cloud block if you want to execute Terraform CLI remotely and just upload the state to Terrakube"
+                        >
+                          <Select
+                              defaultValue={
+                                workspace.data.attributes.executionMode
+                              }
+                              style={{ width: 250 }}
                           >
                             <Option key="remote">remote</Option>
                             <Option key="local">local</Option>


### PR DESCRIPTION
# OpenTofu Support

## Workspace Settings:
Adding option to use OpenTofu inside the workspace settings after creation:

![image](https://github.com/AzBuilder/terrakube/assets/4461895/47774b19-ffa0-4c35-a6d9-0311da64b2d4)

> For now it will require to select 1.6.0 from the dropdown, the dropdown menu will have to be update in order to just show OpenTofu versions

Running a sample vcs with opentofu will show something like the following:

Plan
![image](https://github.com/AzBuilder/terrakube/assets/4461895/a934b910-7b85-4e4b-8cce-a59f3c5dac83)

Apply
![image](https://github.com/AzBuilder/terrakube/assets/4461895/a54d9223-c55d-4390-a8b2-1bc40db49a6d)

Destroy
![image](https://github.com/AzBuilder/terrakube/assets/4461895/76afefd4-74ee-4b7d-b24e-f59321f92f43)

##

## CLI Driven workflow(remote execution):

Tofu login:
```shell
user@pop-os:~/git/simple-terraform$ tofu login 8080-azbuilder-terrakube-w63gqxcwyai.ws-us107.gitpod.io
OpenTofu will request an API token for 8080-azbuilder-terrakube-w63gqxcwyai.ws-us107.gitpod.io using OAuth.

This will work only if you are able to use a web browser on this computer to
complete a login process. If not, you must obtain an API token by another
means and configure it in the CLI configuration manually.

If login is successful, OpenTofu will store the token in plain text in
the following file for use by subsequent commands:
    /home/user/.terraform.d/credentials.tfrc.json

Do you want to proceed?
  Only 'yes' will be accepted to confirm.

  Enter a value: yes

OpenTofu must now open a web browser to the login page for 8080-azbuilder-terrakube-w63gqxcwyai.ws-us107.gitpod.io.

If a browser does not open this automatically, open the following URL to proceed:
    https://5556-azbuilder-terrakube-w63gqxcwyai.ws-us107.gitpod.io/dex/auth?scope=openid+profile+email+offline_access+groups&client_id=example-app&code_challenge=lDrxHHQhGirNX_IAjFOix0KMIdfJvPgWwSJjjzYrCH0&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost%3A10000%2Flogin&response_type=code&state=a00e3fd3-a663-b31e-5e91-e1c484172de4

OpenTofu will now wait for the host to signal that login was successful.


---------------------------------------------------------------------------------

Success! OpenTofu has obtained and saved an API token.

The new API token will be used for any future OpenTofu command that must make
authenticated requests to 8080-azbuilder-terrakube-w63gqxcwyai.ws-us107.gitpod.io.

```

tofu init:
```shell
user@pop-os:~/git/simple-terraform$ tofu init

Initializing cloud backend...
Initializing modules...

Initializing provider plugins...
- Finding latest version of hashicorp/random...
- Finding latest version of hashicorp/null...
- Finding latest version of hashicorp/time...
- Installing hashicorp/random v3.6.0...
- Installed hashicorp/random v3.6.0 (signed, key ID 0C0AF313E5FD9F80)
- Installing hashicorp/null v3.2.2...
- Installed hashicorp/null v3.2.2 (signed, key ID 0C0AF313E5FD9F80)
- Installing hashicorp/time v0.10.0...
- Installed hashicorp/time v0.10.0 (signed, key ID 0C0AF313E5FD9F80)

Providers are signed by their developers.
If you'd like to know more about provider signing, you can read about it here:
https://opentofu.org/docs/cli/plugins/signing/

OpenTofu has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that OpenTofu can guarantee to make the same selections by default when
you run "tofu init" in the future.

Cloud backend has been successfully initialized!

You may now begin working with cloud backend. Try running "tofu plan" to
see any changes that are required for your infrastructure.

If you ever set or change modules or OpenTofu Settings, run "tofu init"
again to reinitialize your working directory.

```

tofu apply
```shell
user@pop-os:~/git/simple-terraform$ tofu apply
Running apply in cloud backend. Output will stream here. Pressing Ctrl-C
will cancel the remote apply if it's still pending. If the apply started it
will stop streaming the logs, but will not stop the apply running remotely.

Preparing the remote apply...

To view this run in a browser, visit:
https://8080-azbuilder-terrakube-w63gqxcwyai.ws-us107.gitpod.io/app/simple/simple/runs/6

Waiting for the plan to start...

***************************************
Running Tofu PLAN
***************************************

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # null_resource.next will be created
  + resource "null_resource" "next" {
      + id = (known after apply)
    }

  # null_resource.next2 will be created
  + resource "null_resource" "next2" {
      + id = (known after apply)
    }

  # null_resource.next3 will be created
  + resource "null_resource" "next3" {
      + id = (known after apply)
    }

  # null_resource.previous will be created
  + resource "null_resource" "previous" {
      + id = (known after apply)
    }

  # time_sleep.wait_30_seconds will be created
  + resource "time_sleep" "wait_30_seconds" {
      + create_duration = (known after apply)
      + id              = (known after apply)
    }

  # module.time_module.random_integer.time will be created
  + resource "random_integer" "time" {
      + id     = (known after apply)
      + max    = 5
      + min    = 1
      + result = (known after apply)
    }

Plan: 6 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + creation_time = (known after apply)
  + fake_data     = {
      + data     = "Hello World"
      + resource = {
          + resource1 = "fake"
        }
    }

Do you want to perform these actions in workspace "simple"?
  OpenTofu will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.time_module.random_integer.time: Creating...
null_resource.previous: Creating...
null_resource.previous: Creation complete after 0s [id=474551093667555354]
module.time_module.random_integer.time: Creation complete after 0s [id=2]
time_sleep.wait_30_seconds: Creating...
time_sleep.wait_30_seconds: Creation complete after 2s [id=2024-01-17T16:31:14Z]
null_resource.next2: Creating...
null_resource.next3: Creating...
null_resource.next: Creating...
null_resource.next2: Creation complete after 0s [id=5406472439273051126]
null_resource.next3: Creation complete after 0s [id=8817326332387053808]
null_resource.next: Creation complete after 0s [id=8873167809616123372]

Apply complete! Resources: 6 added, 0 changed, 0 destroyed.

Outputs:

creation_time = "2s"
fake_data = {
  "data" = "Hello World"
  "resource" = {
    "resource1" = "fake"
  }
}

```

tofu destroy:
```shell
user@pop-os:~/git/simple-terraform$ tofu destroy

Running apply in cloud backend. Output will stream here. Pressing Ctrl-C
will cancel the remote apply if it's still pending. If the apply started it
will stop streaming the logs, but will not stop the apply running remotely.

Preparing the remote apply...

To view this run in a browser, visit:
https://8080-azbuilder-terrakube-w63gqxcwyai.ws-us107.gitpod.io/app/simple/simple/runs/7

Waiting for the plan to start...

***************************************
Running Tofu PLAN
***************************************
null_resource.previous: Refreshing state... [id=474551093667555354]
module.time_module.random_integer.time: Refreshing state... [id=2]
time_sleep.wait_30_seconds: Refreshing state... [id=2024-01-17T16:31:14Z]
null_resource.next: Refreshing state... [id=8873167809616123372]
null_resource.next2: Refreshing state... [id=5406472439273051126]
null_resource.next3: Refreshing state... [id=8817326332387053808]

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  - destroy

OpenTofu will perform the following actions:

  # null_resource.next will be destroyed
  - resource "null_resource" "next" {
      - id = "8873167809616123372" -> null
    }

  # null_resource.next2 will be destroyed
  - resource "null_resource" "next2" {
      - id = "5406472439273051126" -> null
    }

  # null_resource.next3 will be destroyed
  - resource "null_resource" "next3" {
      - id = "8817326332387053808" -> null
    }

  # null_resource.previous will be destroyed
  - resource "null_resource" "previous" {
      - id = "474551093667555354" -> null
    }

  # time_sleep.wait_30_seconds will be destroyed
  - resource "time_sleep" "wait_30_seconds" {
      - create_duration = "2s" -> null
      - id              = "2024-01-17T16:31:14Z" -> null
    }

  # module.time_module.random_integer.time will be destroyed
  - resource "random_integer" "time" {
      - id     = "2" -> null
      - max    = 5 -> null
      - min    = 1 -> null
      - result = 2 -> null
    }

Plan: 0 to add, 0 to change, 6 to destroy.

Changes to Outputs:
  - creation_time = "2s" -> null
  - fake_data     = {
      - data     = "Hello World"
      - resource = {
          - resource1 = "fake"
        }
    } -> null

Do you really want to destroy all resources in workspace "simple"?
  OpenTofu will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

null_resource.next: Destroying... [id=8873167809616123372]
null_resource.next3: Destroying... [id=8817326332387053808]
null_resource.next2: Destroying... [id=5406472439273051126]
null_resource.next2: Destruction complete after 0s
null_resource.next3: Destruction complete after 0s
null_resource.next: Destruction complete after 0s
time_sleep.wait_30_seconds: Destroying... [id=2024-01-17T16:31:14Z]
time_sleep.wait_30_seconds: Destruction complete after 0s
null_resource.previous: Destroying... [id=474551093667555354]
module.time_module.random_integer.time: Destroying... [id=2]
null_resource.previous: Destruction complete after 0s
module.time_module.random_integer.time: Destruction complete after 0s

Apply complete! Resources: 0 added, 0 changed, 6 destroyed.

```

## CLI driven workflow (local execution)

tofu init/apply/destroy
```shell
user@pop-os:~/git/simple-terraform$ tofu init

Initializing cloud backend...
Initializing modules...
- time_module in module

Initializing provider plugins...
- Finding latest version of hashicorp/null...
- Finding latest version of hashicorp/time...
- Finding latest version of hashicorp/random...
- Installing hashicorp/null v3.2.2...
- Installed hashicorp/null v3.2.2 (signed, key ID 0C0AF313E5FD9F80)
- Installing hashicorp/time v0.10.0...
- Installed hashicorp/time v0.10.0 (signed, key ID 0C0AF313E5FD9F80)
- Installing hashicorp/random v3.6.0...
- Installed hashicorp/random v3.6.0 (signed, key ID 0C0AF313E5FD9F80)

Providers are signed by their developers.
If you'd like to know more about provider signing, you can read about it here:
https://opentofu.org/docs/cli/plugins/signing/

OpenTofu has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that OpenTofu can guarantee to make the same selections by default when
you run "tofu init" in the future.

Cloud backend has been successfully initialized!

You may now begin working with cloud backend. Try running "tofu plan" to
see any changes that are required for your infrastructure.

If you ever set or change modules or OpenTofu Settings, run "tofu init"
again to reinitialize your working directory.
user@pop-os:~/git/simple-terraform$ tofu apply

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # null_resource.next will be created
  + resource "null_resource" "next" {
      + id = (known after apply)
    }

  # null_resource.next2 will be created
  + resource "null_resource" "next2" {
      + id = (known after apply)
    }

  # null_resource.next3 will be created
  + resource "null_resource" "next3" {
      + id = (known after apply)
    }

  # null_resource.previous will be created
  + resource "null_resource" "previous" {
      + id = (known after apply)
    }

  # time_sleep.wait_30_seconds will be created
  + resource "time_sleep" "wait_30_seconds" {
      + create_duration = (known after apply)
      + id              = (known after apply)
    }

  # module.time_module.random_integer.time will be created
  + resource "random_integer" "time" {
      + id     = (known after apply)
      + max    = 5
      + min    = 1
      + result = (known after apply)
    }

Plan: 6 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + creation_time = (known after apply)
  + fake_data     = {
      + data     = "Hello World"
      + resource = {
          + resource1 = "fake"
        }
    }

Do you want to perform these actions in workspace "simple"?
  OpenTofu will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

null_resource.previous: Creating...
module.time_module.random_integer.time: Creating...
null_resource.previous: Creation complete after 0s [id=1856061197974411163]
module.time_module.random_integer.time: Creation complete after 0s [id=3]
time_sleep.wait_30_seconds: Creating...
time_sleep.wait_30_seconds: Creation complete after 3s [id=2024-01-17T16:44:57Z]
null_resource.next: Creating...
null_resource.next2: Creating...
null_resource.next3: Creating...
null_resource.next3: Creation complete after 0s [id=7821452570140247826]
null_resource.next: Creation complete after 0s [id=3895004684437478820]
null_resource.next2: Creation complete after 0s [id=9116260504147273393]

Apply complete! Resources: 6 added, 0 changed, 0 destroyed.

Outputs:

creation_time = "3s"
fake_data = {
  "data" = "Hello World"
  "resource" = {
    "resource1" = "fake"
  }
}
user@pop-os:~/git/simple-terraform$ tofu destroy
module.time_module.random_integer.time: Refreshing state... [id=3]
null_resource.previous: Refreshing state... [id=1856061197974411163]
time_sleep.wait_30_seconds: Refreshing state... [id=2024-01-17T16:44:57Z]
null_resource.next: Refreshing state... [id=3895004684437478820]
null_resource.next3: Refreshing state... [id=7821452570140247826]
null_resource.next2: Refreshing state... [id=9116260504147273393]

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

OpenTofu will perform the following actions:

  # null_resource.next will be destroyed
  - resource "null_resource" "next" {
      - id = "3895004684437478820" -> null
    }

  # null_resource.next2 will be destroyed
  - resource "null_resource" "next2" {
      - id = "9116260504147273393" -> null
    }

  # null_resource.next3 will be destroyed
  - resource "null_resource" "next3" {
      - id = "7821452570140247826" -> null
    }

  # null_resource.previous will be destroyed
  - resource "null_resource" "previous" {
      - id = "1856061197974411163" -> null
    }

  # time_sleep.wait_30_seconds will be destroyed
  - resource "time_sleep" "wait_30_seconds" {
      - create_duration = "3s" -> null
      - id              = "2024-01-17T16:44:57Z" -> null
    }

  # module.time_module.random_integer.time will be destroyed
  - resource "random_integer" "time" {
      - id     = "3" -> null
      - max    = 5 -> null
      - min    = 1 -> null
      - result = 3 -> null
    }

Plan: 0 to add, 0 to change, 6 to destroy.

Changes to Outputs:
  - creation_time = "3s" -> null
  - fake_data     = {
      - data     = "Hello World"
      - resource = {
          - resource1 = "fake"
        }
    } -> null

Do you really want to destroy all resources in workspace "simple"?
  OpenTofu will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

null_resource.next3: Destroying... [id=7821452570140247826]
null_resource.next: Destroying... [id=3895004684437478820]
null_resource.next2: Destroying... [id=9116260504147273393]
null_resource.next2: Destruction complete after 0s
null_resource.next3: Destruction complete after 0s
null_resource.next: Destruction complete after 0s
time_sleep.wait_30_seconds: Destroying... [id=2024-01-17T16:44:57Z]
time_sleep.wait_30_seconds: Destruction complete after 0s
null_resource.previous: Destroying... [id=1856061197974411163]
null_resource.previous: Destruction complete after 0s
module.time_module.random_integer.time: Destroying... [id=3]
module.time_module.random_integer.time: Destruction complete after 0s

Destroy complete! Resources: 6 destroyed.

```

Fix #492 