### PR TITLE
Gitlab Webhook - Validate File changes

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -76,20 +76,21 @@ public class GitLabWebhookService {
                 try {
                     GitlabWebhookModel gitlabWebhookModel = new ObjectMapper().readValue(jsonPayload, GitlabWebhookModel.class);
                     result.setCommit(gitlabWebhookModel.getCheckoutSha());
-                    gitlabWebhookModel.getCommits().forEach(commit -> {
-                        for (String addedObject : commit.getAdded()) {
-                            log.info("New Gitlab Object: {}", addedObject);
-                            result.getFileChanges().add(addedObject);
+                    gitlabWebhookModel.getCommits().forEach(commitData -> {
+
+                        for (String gitlabmodified : commitData.getModified()) {
+                            result.getFileChanges().add(gitlabmodified);
+                            log.info("Modified Gitlab Object: {}", gitlabmodified);
                         }
 
-                        for (String removedObject : commit.getRemoved()) {
-                            log.info("Removed Gitlab Object: {}", removedObject);
-                            result.getFileChanges().add(removedObject);
+                        for (String gitlabRemoved : commitData.getRemoved()) {
+                            result.getFileChanges().add(gitlabRemoved);
+                            log.info("Removed Gitlab Object: {}", gitlabRemoved);
                         }
 
-                        for (String modifedObject : commit.getModified()) {
-                            log.info("Modified Gitlab Object: {}", modifedObject);
-                            result.getFileChanges().add(modifedObject);
+                        for (String gitlabAdded : commitData.getAdded()) {
+                            log.info("New Gitlab Object: {}", gitlabAdded);
+                            result.getFileChanges().add(gitlabAdded);
                         }
                     });
                 } catch (JsonProcessingException e) {

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/gitlab/GitlabWebhookModel.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/gitlab/GitlabWebhookModel.java
@@ -1,0 +1,29 @@
+package org.terrakube.api.plugin.vcs.provider.gitlab;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GitlabWebhookModel {
+    @JsonProperty("checkout_sha")
+    String checkoutSha;
+    List<Commit> commits;
+    String ref;
+    String before;
+    String after;
+}
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+class Commit{
+    List<String> added;
+    List<String> modified;
+    List<String> removed;
+}


### PR DESCRIPTION
Correctly validate file changes in push events if multiple workspace are using the same repository with a private vcs gitlab connection.

![image](https://github.com/AzBuilder/terrakube/assets/4461895/312160d7-069d-41f4-a7c5-523cf71929e6)

Queue multiple push correctly:

![image](https://github.com/AzBuilder/terrakube/assets/4461895/eee9b352-ac47-449c-9997-311729972538)
