### PR TITLE
Fix validation for previous jobs

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -83,7 +83,10 @@ public class ScheduleJob implements org.quartz.Job {
 
         log.info("Checking Job {} Status {}", job.getId(), job.getStatus());
         log.info("Checking previous jobs....");
-        Optional<List<Job>> previousJobs = jobRepository.findByWorkspaceAndStatusNotInAndIdLessThan(job.getWorkspace(), Arrays.asList(JobStatus.failed, JobStatus.completed), job.getId());
+        Optional<List<Job>> previousJobs = jobRepository.findByWorkspaceAndStatusNotInAndIdLessThan(job.getWorkspace(),
+                Arrays.asList(JobStatus.failed, JobStatus.completed, JobStatus.rejected, JobStatus.cancelled, JobStatus.waitingApproval, JobStatus.approved),
+                job.getId()
+        );
         if(previousJobs.isPresent() && previousJobs.get().size() > 0 ){
            log.warn("Job {} is waiting for previous jobs to be completed...", jobId);
         } else {


### PR DESCRIPTION
This PR will fix the validation logic to check if a previous job is running before executing the next job.

Related to [this](https://github.com/orgs/AzBuilder/discussions/714#discussion-6222781)