### PR TITLE
Fix http 500 error in expired tokens

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolver.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolver.java
@@ -53,7 +53,7 @@ public class DexAuthenticationManagerResolver implements AuthenticationManagerRe
                 issuer = jwtTypeInternal;
             }
         }catch (Exception ex){
-            log.error(ex.getMessage());
+            log.info(ex.getMessage());
         }
         switch (issuer) {
             case jwtTypePat:

--- a/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolver.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolver.java
@@ -46,8 +46,9 @@ public class DexAuthenticationManagerResolver implements AuthenticationManagerRe
     @Override
     public AuthenticationManager resolve(HttpServletRequest request) {
         ProviderManager providerManager = null;
-        String issuer = getIssuer(request);
+        String issuer = "";
         try{
+            issuer = getIssuer(request);
             if (isTokenDeleted(getTokenId(request))){
                 //FORCE TOKEN TO USE INTERNAL AUTH SO IT CAN ALWAYS FAIL
                 issuer = jwtTypeInternal;

--- a/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolver.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolver.java
@@ -1,7 +1,5 @@
 package org.terrakube.api.plugin.security.authentication.dex;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Header;
 import io.jsonwebtoken.Jwt;
@@ -27,7 +25,8 @@ import org.terrakube.api.rs.token.pat.Pat;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import javax.servlet.http.HttpServletRequest;
-import java.util.*;
+import java.util.Optional;
+import java.util.UUID;
 
 @Builder
 @Getter
@@ -80,23 +79,14 @@ public class DexAuthenticationManagerResolver implements AuthenticationManagerRe
     }
 
     private String getIssuer(HttpServletRequest request) {
-        Map<String, Object> jwtBodyMap = getJwtBodyData(request);
-        log.debug("Issuer {}", (String) jwtBodyMap.get("iss"));
-        return (String) jwtBodyMap.get("iss");
-    }
+        String token = request.getHeader("authorization").replace("Bearer ", "");
+        String withoutSignature = token.substring(0, token.lastIndexOf('.') + 1);
+        Jwt<Header, Claims> untrusted = Jwts.parserBuilder().build().parseClaimsJwt(withoutSignature);
+        log.debug("Token {}", token);
+        log.debug("Token Without Signature {}", withoutSignature);
+        log.debug("Issuer {}", untrusted.getBody().getIssuer());
 
-    private Map<String, Object> getJwtBodyData(HttpServletRequest request){
-        String tokenBase64 = request.getHeader("authorization").replace("Bearer ", "");
-        String[] tokenChunks = tokenBase64.split("\\.");
-        Base64.Decoder defaultDecoder = Base64.getDecoder();
-        String tokenBodyData = new String(defaultDecoder.decode(tokenChunks[1]));
-        Map<String,Object> jwtBodyMap = new HashMap();
-        try {
-            jwtBodyMap = new ObjectMapper().readValue(tokenBodyData, HashMap.class);
-        } catch (JsonProcessingException e) {
-            log.error(e.getMessage());
-        }
-        return jwtBodyMap;
+        return untrusted.getBody().getIssuer();
     }
 
     private String getTokenId(HttpServletRequest request) {


### PR DESCRIPTION
Fix #742 

This will fix the http code 500 error when sending an expired jwt token, the change will capture correctly the exception "ExpiredJwtException" when executing "Jwts.parserBuilder().build().parseClaimsJwt" and correctly return http code 401

![image](https://github.com/AzBuilder/terrakube/assets/4461895/cf80bd44-4b3a-4dd4-93fa-30da76398c6e)

![image](https://github.com/AzBuilder/terrakube/assets/4461895/66f037c2-d843-4412-b614-79e20873ed62)
