### PR TITLE
Support to use remote backend with prefix

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -79,9 +79,10 @@ public class RemoteTfeController {
 
     @Transactional
     @GetMapping(produces = "application/vnd.api+json", path = "organizations/{organizationName}/workspaces")
-    public ResponseEntity<WorkspaceList> listWorkspace(@PathVariable("organizationName") String organizationName, @RequestParam("search[tags]") String searchTags, Principal principal) {
-        log.info("Searching: {} {}", organizationName, searchTags);
-        return ResponseEntity.of(Optional.ofNullable(remoteTfeService.listWorkspace(organizationName, searchTags, (JwtAuthenticationToken) principal)));
+    public ResponseEntity<WorkspaceList> listWorkspace(@PathVariable("organizationName") String organizationName, @RequestParam("search[tags]") Optional<String> searchTags, @RequestParam("search[name]") Optional<String> searchName,  Principal principal) {
+        log.info("Searching Tags: {} {}", organizationName, searchTags.isPresent() ? searchTags.get(): null);
+        log.info("Searching Names: {} {}", organizationName, searchName.isPresent() ? searchName.get(): null);
+        return ResponseEntity.of(Optional.ofNullable(remoteTfeService.listWorkspace(organizationName, searchTags, searchName, (JwtAuthenticationToken) principal)));
     }
 
     @Transactional

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -330,9 +330,8 @@ public class RemoteTfeService {
         }
 
         if (searchName.isPresent()) {
-            String searchNameData = searchTags.get();
-            List<String> listNames = Arrays.stream(searchNameData.split(",")).toList();
-            log.info("Searching workspaces with name: {}", listNames);
+            String searchNameData = searchName.get();
+            log.info("Searching workspaces with name prefix: {}", searchNameData);
             Optional<List<Workspace>> workspaceListByName = workspaceRepository.findWorkspacesByOrganizationNameAndNameStartingWith(organizationName, searchNameData);
             if(workspaceListByName.isPresent())
                 for (Workspace workspace : workspaceListByName.get()) {

--- a/api/src/main/java/org/terrakube/api/repository/WorkspaceRepository.java
+++ b/api/src/main/java/org/terrakube/api/repository/WorkspaceRepository.java
@@ -3,9 +3,13 @@ package org.terrakube.api.repository;
 import org.terrakube.api.rs.workspace.Workspace;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface WorkspaceRepository extends JpaRepository<Workspace, UUID> {
 
     Workspace getByOrganizationNameAndName(String organizationName, String workspaceName);
+
+    Optional<List<Workspace>> findWorkspacesByOrganizationNameAndNameStartingWith(String organizationName, String workspaceNameStartingWidth);
 }


### PR DESCRIPTION
Fix #717 

Adding support to handle the remote backend with a prefix like the following example:

```terraform
terraform {

  backend "remote" {
    hostname = "8080-azbuilder-terrakube-7tnuq3gnkgf.ws-us108.gitpod.io"
    organization = "simple"

    workspaces {
      prefix = "my-app-"
    }
  }
}
```

Example in the UI, using to workspaces with name prefix "my-app-"

![image](https://github.com/AzBuilder/terrakube/assets/4461895/7af102c2-b550-4000-91a5-281f1cf87423)

The terraform init will show both workspaces to select and continue with the flow
```shell
user@pop-os:~/git/simple-terraform$ terraform init

Initializing the backend...

The currently selected workspace (default) does not exist.
  This is expected behavior when the selected workspace did not have an
  existing non-empty state. Please enter a number to select a workspace:
  
  1. 1
  2. 2

  Enter a value: 1


Successfully configured the backend "remote"! Terraform will automatically
use this backend unless the backend configuration changes.
Initializing modules...
- time_module in module

Initializing provider plugins...
- Finding latest version of hashicorp/time...
- Finding latest version of hashicorp/random...
- Finding latest version of hashicorp/null...
- Installing hashicorp/time v0.10.0...
- Installed hashicorp/time v0.10.0 (signed by HashiCorp)
- Installing hashicorp/random v3.6.0...
- Installed hashicorp/random v3.6.0 (signed by HashiCorp)
- Installing hashicorp/null v3.2.2...
- Installed hashicorp/null v3.2.2 (signed by HashiCorp)

Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
```