### PR TITLE
Adding workspace directory in response

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -247,6 +247,10 @@ public class RemoteTfeService {
             attributes.put("execution-mode", workspace.get().getExecutionMode());
             attributes.put("global-remote-state", true);
 
+            if (workspace.get().getFolder() != null && workspace.get().getVcs() != null && !workspace.get().getFolder().equals("/")){
+                attributes.put("working-directory", workspace.get().getFolder());
+            }
+
             boolean isManageWorkspace = validateUserManageWorkspace(workspace.get().getOrganization(), currentUser);
 
             Map<String, Boolean> defaultAttributes = new HashMap<>();


### PR DESCRIPTION
Adding missing property "working-directory" when using the following method:

```
GET {{TERRAKUBE_API}}/remote/tfe/v2/organizations/{organizationName}/workspaces/{workspaceName}"
```

This will allow to correctly trigger a job from the CLI in a workspace that is connected to a VCS repository.

Trigger from the CLI
```shell
user@pop-os:~/git/webhook/simple-terraform/work1$ terraform init

Initializing Terraform Cloud...
Initializing modules...
- time_module in ../module

Initializing provider plugins...
- Finding latest version of hashicorp/null...
- Finding latest version of hashicorp/time...
- Finding latest version of hashicorp/random...
- Installing hashicorp/null v3.2.2...
- Installed hashicorp/null v3.2.2 (signed by HashiCorp)
- Installing hashicorp/time v0.10.0...
- Installed hashicorp/time v0.10.0 (signed by HashiCorp)
- Installing hashicorp/random v3.6.0...
- Installed hashicorp/random v3.6.0 (signed by HashiCorp)

Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform Cloud has been successfully initialized!

You may now begin working with Terraform Cloud. Try running "terraform plan" to
see any changes that are required for your infrastructure.

If you ever set or change modules or Terraform Settings, run "terraform init"
again to reinitialize your working directory.
user@pop-os:~/git/webhook/simple-terraform/work1$ terraform plan

Running plan in Terraform Cloud. Output will stream here. Pressing Ctrl-C
will stop streaming the logs, but will not stop the plan running remotely.

Preparing the remote plan...

The remote workspace is configured to work with configuration at
/work1 relative to the target repository.

Terraform will upload the contents of the following directory,
excluding files or directories as defined by a .terraformignore file
at /home/user/git/webhook/simple-terraform/.terraformignore (if it is present),
in order to capture the filesystem context the remote workspace expects:
    /home/user/git/webhook/simple-terraform

To view this run in a browser, visit:
https://8080-azbuilder-terrakube-9d5xqdykp92.ws-us108.gitpod.io/app/simple/simple-terraform/runs/2

Waiting for the plan to start...

***************************************
Running Terraform PLAN
***************************************

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # null_resource.next will be created
  + resource "null_resource" "next" {
      + id = (known after apply)
    }

  # null_resource.previous will be created
  + resource "null_resource" "previous" {
      + id = (known after apply)
    }

  # time_sleep.wait_30_seconds will be created
  + resource "time_sleep" "wait_30_seconds" {
      + create_duration = (known after apply)
      + id              = (known after apply)
    }

  # module.time_module.random_integer.time will be created
  + resource "random_integer" "time" {
      + id     = (known after apply)
      + max    = 5
      + min    = 1
      + result = (known after apply)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + creation_time = (known after apply)
  + fake_data     = {
      + data     = "Hello World"
      + resource = {
          + resource1 = "fake"
        }
    }

```

![image](https://github.com/AzBuilder/terrakube/assets/4461895/7f9b0a94-31e4-41a6-ad18-fecc0b991fcb)

Example trigger from the UI.

![image](https://github.com/AzBuilder/terrakube/assets/4461895/d4375e1b-05ab-4766-835a-ed291d32dd94)


