### PR TITLE
Fix workdir for speculative plan

### DIFF
--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -60,7 +60,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
     private File getTerraformWorkingDir(TerraformJob terraformJob, File workingDirectory) throws IOException {
         File terraformWorkingDir = workingDirectory;
         try {
-            if (!terraformJob.getBranch().equals("remote-content")) {
+            if (!terraformJob.getBranch().equals("remote-content") || (terraformJob.getFolder() != null && !terraformJob.getFolder().equals("/"))) {
                 terraformWorkingDir = new File(workingDirectory.getCanonicalPath() + terraformJob.getFolder());
             }
         } catch (IOException e) {


### PR DESCRIPTION
This will fix the working directory when executing a speculative plan for a workspace that is using a VCS connection