### PR TITLE
Backup Raw State in Workspace History

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/importer/tfcloud/services/WorkspaceService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/importer/tfcloud/services/WorkspaceService.java
@@ -284,7 +284,7 @@ public class WorkspaceService {
                         history.getId().toString()));
 
         try {
-            historyRepository.save(history);
+            history = historyRepository.save(history);
             log.info("History created: {}", history.getId());
         } catch (Exception e) {
             log.error(e.getMessage());
@@ -298,7 +298,7 @@ public class WorkspaceService {
             terraformState = readResourceToString(state);
             log.info("State downloaded: {}", terraformState.length());
             storageTypeService.uploadState(workspace.getOrganization().getId().toString(),
-                    workspace.getId().toString(), terraformState);
+                    workspace.getId().toString(), terraformState, history.getId().toString());
             result += "<li>State imported successfully.</li>";
 
         } catch (IOException e) {

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -497,7 +497,7 @@ public class RemoteTfeService {
 
         if (terraformState != null) {
             //upload state to backend storage
-            storageTypeService.uploadState(workspace.getOrganization().getId().toString(), workspace.getId().toString(), terraformState);
+            storageTypeService.uploadState(workspace.getOrganization().getId().toString(), workspace.getId().toString(), terraformState, history.getId().toString());
         } else {
             log.warn("State field is empty, workspace state should be uploaded, creating new archive ...");
             Archive archiveState = new Archive();

--- a/api/src/main/java/org/terrakube/api/plugin/storage/StorageTypeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/StorageTypeService.java
@@ -15,7 +15,7 @@ public interface StorageTypeService {
 
     byte[] getCurrentTerraformState(String organizationId, String workspaceId);
 
-    void uploadState(String organizationId, String workspaceId, String terraformState);
+    void uploadState(String organizationId, String workspaceId, String terraformState, String historyId);
 
     String saveContext(int jobId, String jobContext);
 

--- a/api/src/main/java/org/terrakube/api/plugin/storage/aws/AwsStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/aws/AwsStorageTypeServiceImpl.java
@@ -103,11 +103,13 @@ public class AwsStorageTypeServiceImpl implements StorageTypeService {
     }
 
     @Override
-    public void uploadState(String organizationId, String workspaceId, String terraformState) {
+    public void uploadState(String organizationId, String workspaceId, String terraformState, String historyId) {
         String blobKey = String.format("tfstate/%s/%s/terraform.tfstate", organizationId, workspaceId);
+        String rawBlobKey = String.format("tfstate/%s/%s/state/%s.raw.json", organizationId, workspaceId, historyId);
         log.info("terraformStateFile: {}", blobKey);
+        log.info("terraformRawStateFile: {}", rawBlobKey);
         s3client.putObject(bucketName, blobKey, terraformState);
-
+        s3client.putObject(bucketName, rawBlobKey, terraformState);
     }
 
     @Override

--- a/api/src/main/java/org/terrakube/api/plugin/storage/azure/AzureStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/azure/AzureStorageTypeServiceImpl.java
@@ -98,15 +98,20 @@ public class AzureStorageTypeServiceImpl implements StorageTypeService {
     }
 
     @Override
-    public void uploadState(String organizationId, String workspaceId, String terraformState) {
+    public void uploadState(String organizationId, String workspaceId, String terraformState, String historyId) {
         BlobContainerClient contextContainerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME_STATE);
 
         String stateFileName = String.format("%s/%s/terraform.tfstate", organizationId, workspaceId);
+        String rawStateFileName = String.format("%s/%s/state/%s.raw.json", organizationId, workspaceId, historyId);
         log.info("New State File Az Storage: {}", stateFileName);
+        log.info("New State Raw File Az Storage: {}", rawStateFileName);
         BlobClient blobClient = contextContainerClient.getBlobClient(stateFileName);
+        BlobClient rawBlobClient = contextContainerClient.getBlobClient(rawStateFileName);
 
         BinaryData binaryData = BinaryData.fromBytes(terraformState.getBytes());
+        BinaryData rawBinaryData = BinaryData.fromBytes(terraformState.getBytes());
         blobClient.upload(binaryData, true);
+        rawBlobClient.upload(rawBinaryData, true);
     }
 
     @Override

--- a/api/src/main/java/org/terrakube/api/plugin/storage/controller/TerraformStateController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/controller/TerraformStateController.java
@@ -66,7 +66,8 @@ public class TerraformStateController {
             storageTypeService.uploadState(
                     archiveData.getHistory().getWorkspace().getOrganization().getId().toString(),
                     archiveData.getHistory().getWorkspace().getId().toString(),
-                    terraformState
+                    terraformState,
+                    archiveData.getHistory().getId().toString()
             );
             archiveRepository.deleteById(archiveData.getId());
             return ResponseEntity.status(201).body("");

--- a/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
@@ -30,7 +30,7 @@ public class LocalStorageTypeServiceImpl implements StorageTypeService {
     private static final String NO_DATA_FOUND = "";
     private static final String NO_CONTEXT_FOUND = "{}";
     private static final String LOCAL_BACKEND_DIRECTORY = "/.terraform-spring-boot/local/backend/%s/%s/terraform.tfstate";
-    private static final String LOCAL_HISTORY_BACKEND_DIRECTORY = "/.terraform-spring-boot/local/backend/%s/%s/state/%s.raw.json";
+    private static final String LOCAL_HISTORY_BACKEND_DIRECTORY = "/.terraform-spring-boot/local/state/%s/%s/state/%s.raw.json";
 
     @Override
     public byte[] getStepOutput(String organizationId, String jobId, String stepId) {

--- a/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
@@ -30,6 +30,7 @@ public class LocalStorageTypeServiceImpl implements StorageTypeService {
     private static final String NO_DATA_FOUND = "";
     private static final String NO_CONTEXT_FOUND = "{}";
     private static final String LOCAL_BACKEND_DIRECTORY = "/.terraform-spring-boot/local/backend/%s/%s/terraform.tfstate";
+    private static final String LOCAL_HISTORY_BACKEND_DIRECTORY = "/.terraform-spring-boot/local/backend/%s/%s/state/%s.raw.json";
 
     @Override
     public byte[] getStepOutput(String organizationId, String jobId, String stepId) {
@@ -73,13 +74,18 @@ public class LocalStorageTypeServiceImpl implements StorageTypeService {
     }
 
     @Override
-    public void uploadState(String organizationId, String workspaceId, String terraformState) {
+    public void uploadState(String organizationId, String workspaceId, String terraformState, String historyId) {
         try {
             String newStateFile = String.format(LOCAL_BACKEND_DIRECTORY, organizationId, workspaceId);
+            String newRawStateFile = String.format(LOCAL_HISTORY_BACKEND_DIRECTORY, organizationId, workspaceId, historyId);
             log.info("newFilename: {}", newStateFile);
+            log.info("newRawFilename: {}", newRawStateFile);
             File stateFile = new File(FileUtils.getUserDirectoryPath().concat(FilenameUtils.separatorsToSystem(newStateFile)));
+            File rawStateFile = new File(FileUtils.getUserDirectoryPath().concat(FilenameUtils.separatorsToSystem(newRawStateFile)));
             FileUtils.forceMkdir(stateFile.getParentFile());
+            FileUtils.forceMkdir(rawStateFile.getParentFile());
             FileUtils.writeStringToFile(stateFile, terraformState, Charset.defaultCharset().toString());
+            FileUtils.writeStringToFile(rawStateFile, terraformState, Charset.defaultCharset().toString());
         } catch (IOException e) {
             log.error(e.getMessage());
         }

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<commons-text.version>1.10.0</commons-text.version>
-		<terraform-spring-boot-starter.version>0.12.0</terraform-spring-boot-starter.version>
+		<terraform-spring-boot-starter.version>0.13.0</terraform-spring-boot-starter.version>
 		<terrakube-client-starter.version>0.12.0</terrakube-client-starter.version>
 		<commons-io.version>2.8.0</commons-io.version>
 		<commons-codec>1.15</commons-codec>

--- a/executor/src/main/java/org/terrakube/executor/plugin/tfstate/TerraformState.java
+++ b/executor/src/main/java/org/terrakube/executor/plugin/tfstate/TerraformState.java
@@ -12,5 +12,5 @@ public interface TerraformState {
 
     boolean downloadTerraformPlan(String organizationId, String workspaceId, String jobId, String stepId, File workingDirectory);
 
-    void saveStateJson(TerraformJob terraformJob, String applyJSON);
+    void saveStateJson(TerraformJob terraformJob, String applyJSON, String rawState);
 }

--- a/executor/src/main/java/org/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
@@ -160,19 +160,29 @@ public class AwsTerraformStateImpl implements TerraformState {
     }
 
     @Override
-    public void saveStateJson(TerraformJob terraformJob, String applyJSON) {
+    public void saveStateJson(TerraformJob terraformJob, String applyJSON, String rawState) {
         if (applyJSON != null) {
             String stateFilename = UUID.randomUUID().toString();
             String blobKey = "tfstate/" + terraformJob.getOrganizationId() + "/" + terraformJob.getWorkspaceId() + "/state/" + stateFilename + ".json";
+            String blobKeyRaw = "tfstate/" + terraformJob.getOrganizationId() + "/" + terraformJob.getWorkspaceId() + "/state/" + stateFilename + ".raw.json";
             log.info("terraformStateFile: {}", blobKey);
+            log.info("terraformRawStateFile: {}", blobKeyRaw);
 
             byte[] bytes = StringUtils.getBytesUtf8(applyJSON);
+            byte[] rawBytes = StringUtils.getBytesUtf8(rawState);
             String utf8EncodedString = StringUtils.newStringUtf8(bytes);
+            String rawUtf8EncodedString = StringUtils.newStringUtf8(rawBytes);
 
             s3client.putObject(
                     bucketName,
                     blobKey,
                     utf8EncodedString
+            );
+
+            s3client.putObject(
+                    bucketName,
+                    blobKeyRaw,
+                    rawUtf8EncodedString
             );
 
             String stateURL = terraformStatePathService.getStateJsonPath(terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), stateFilename);

--- a/executor/src/main/java/org/terrakube/executor/plugin/tfstate/azure/AzureTerraformStateImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/plugin/tfstate/azure/AzureTerraformStateImpl.java
@@ -119,7 +119,7 @@ public class AzureTerraformStateImpl implements TerraformState {
             }
             String stateFilename = UUID.randomUUID().toString();
             String blobName = terraformJob.getOrganizationId() + "/" + terraformJob.getWorkspaceId() + "/state/" + stateFilename + ".json";
-            String blobRawName = terraformJob.getOrganizationId() + "/" + terraformJob.getWorkspaceId() + "/state/" + stateFilename + "raw.json";
+            String blobRawName = terraformJob.getOrganizationId() + "/" + terraformJob.getWorkspaceId() + "/state/" + stateFilename + ".raw.json";
             log.info("terraform state file: {}", blobName);
             log.info("terraform raw state file: {}", blobRawName);
             BlobClient blobClient = blobContainerClient.getBlobClient(blobName);

--- a/executor/src/main/java/org/terrakube/executor/plugin/tfstate/azure/AzureTerraformStateImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/plugin/tfstate/azure/AzureTerraformStateImpl.java
@@ -109,7 +109,7 @@ public class AzureTerraformStateImpl implements TerraformState {
     }
 
     @Override
-    public void saveStateJson(TerraformJob terraformJob, String applyJSON) {
+    public void saveStateJson(TerraformJob terraformJob, String applyJSON, String rawState) {
         if (applyJSON != null) {
             BlobContainerClient blobContainerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME);
 
@@ -119,12 +119,18 @@ public class AzureTerraformStateImpl implements TerraformState {
             }
             String stateFilename = UUID.randomUUID().toString();
             String blobName = terraformJob.getOrganizationId() + "/" + terraformJob.getWorkspaceId() + "/state/" + stateFilename + ".json";
-            log.info("terraformStateFile: {}", blobName);
+            String blobRawName = terraformJob.getOrganizationId() + "/" + terraformJob.getWorkspaceId() + "/state/" + stateFilename + "raw.json";
+            log.info("terraform state file: {}", blobName);
+            log.info("terraform raw state file: {}", blobRawName);
             BlobClient blobClient = blobContainerClient.getBlobClient(blobName);
+            BlobClient blobRawClient = blobContainerClient.getBlobClient(blobRawName);
 
             byte[] bytes = StringUtils.getBytesUtf8(applyJSON);
+            byte[] rawBytes = StringUtils.getBytesUtf8(rawState);
             String utf8EncodedString = StringUtils.newStringUtf8(bytes);
+            String rawUtf8EncodedString = StringUtils.newStringUtf8(rawBytes);
             blobClient.upload(BinaryData.fromString(utf8EncodedString));
+            blobRawClient.upload(BinaryData.fromString(rawUtf8EncodedString));
 
             String stateURL =  terraformStatePathService.getStateJsonPath(terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), stateFilename);
 

--- a/executor/src/main/java/org/terrakube/executor/plugin/tfstate/gcp/GcpTerraformStateImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/plugin/tfstate/gcp/GcpTerraformStateImpl.java
@@ -142,18 +142,25 @@ public class GcpTerraformStateImpl implements TerraformState {
     }
 
     @Override
-    public void saveStateJson(TerraformJob terraformJob, String applyJSON) {
+    public void saveStateJson(TerraformJob terraformJob, String applyJSON, String rawState) {
         if (applyJSON != null) {
             String stateFilename = UUID.randomUUID().toString();
             String blobKey = String.format("tfstate/%s/%s/state/%s.json", terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), stateFilename);
+            String rawBlobKey = String.format("tfstate/%s/%s/state/%s.raw.json", terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), stateFilename);
             log.info("terraformGcpStateFile: {}", blobKey);
+            log.info("terraformGcpRawStateFile: {}", rawBlobKey);
 
             String utf8EncodedString = StringUtils.newStringUtf8(StringUtils.getBytesUtf8(applyJSON));
+            String rawUtf8EncodedString = StringUtils.newStringUtf8(StringUtils.getBytesUtf8(rawState));
 
             BlobId blobId = BlobId.of(bucketName, blobKey);
+            BlobId rawBlobId = BlobId.of(bucketName, rawBlobKey);
             BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+            BlobInfo rawBlobInfo = BlobInfo.newBuilder(rawBlobId).build();
             storage.create(blobInfo, utf8EncodedString.getBytes());
+            storage.create(rawBlobInfo, rawUtf8EncodedString.getBytes());
             log.info("File uploaded to bucket {} as {}", bucketName, blobKey);
+            log.info("File uploaded to bucket {} as {}", bucketName, rawBlobKey);
 
             HistoryRequest historyRequest = new HistoryRequest();
             History newHistory = new History();

--- a/executor/src/main/java/org/terrakube/executor/plugin/tfstate/local/LocalTerraformStateImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/plugin/tfstate/local/LocalTerraformStateImpl.java
@@ -126,7 +126,7 @@ public class LocalTerraformStateImpl implements TerraformState {
     }
 
     @Override
-    public void saveStateJson(TerraformJob terraformJob, String applyJSON) {
+    public void saveStateJson(TerraformJob terraformJob, String applyJSON, String rawState) {
         if (applyJSON != null) {
             String stateFilenameUUID = UUID.randomUUID().toString();
             String stateFileName = String.format(LOCAL_PLAN_DIRECTORY_JSON, terraformJob.getOrganizationId(),
@@ -138,8 +138,14 @@ public class LocalTerraformStateImpl implements TerraformState {
                             FilenameUtils.separatorsToSystem(
                                     stateFileName)));
 
+            File localRawStateFile = new File(FileUtils.getUserDirectoryPath()
+                    .concat(
+                            FilenameUtils.separatorsToSystem(
+                                    stateFileName.replace(".json", ".raw.json"))));
+
             try {
                 FileUtils.writeStringToFile(localStateFile, applyJSON, Charset.defaultCharset());
+                FileUtils.writeStringToFile(localRawStateFile, rawState, Charset.defaultCharset());
 
                 String stateURL = terraformStatePathService.getStateJsonPath(terraformJob.getOrganizationId(),
                         terraformJob.getWorkspaceId(), stateFilenameUUID);

--- a/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
+++ b/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
@@ -25,6 +25,7 @@ public class TerraformJob {
     private String vcsType;
     private String accessToken;
     private String terraformOutput;
+    private String rawState;
     private boolean showHeader;
     private boolean refresh;
     private boolean refreshOnly;

--- a/ui/src/domain/Workspaces/States.jsx
+++ b/ui/src/domain/Workspaces/States.jsx
@@ -302,14 +302,7 @@ export const States = ({
                     onMount={handleEditorDidMount}
                     defaultLanguage="json"
                     defaultValue={stateContent}
-                  />,
-                  <Editor
-                  height="60vh"
-                  options={{ readOnly: "true" }}
-                  onMount={handleEditorDidMount}
-                  defaultLanguage="json"
-                  defaultValue={rawStateContent}
-                 />
+                  />
                 )}
               </Card>
             </Col>

--- a/ui/src/domain/Workspaces/States.jsx
+++ b/ui/src/domain/Workspaces/States.jsx
@@ -22,7 +22,6 @@ export const States = ({
 }) => {
   const [currentState, setCurrentState] = useState({});
   const [stateContent, setStateContent] = useState("");
-  const [rawStateContent, setRawStateContent] = useState("");
   const [activeTab, setactivetab] = useState("diagram");
   const [nodes, setNodes] = useState([]);
   const [edges, setEdges] = useState([]);
@@ -161,27 +160,16 @@ export const States = ({
 
     const apiDomain = new URL(window._env_.REACT_APP_TERRAKUBE_API_URL)
       .hostname;
-    if (state.output.includes(apiDomain)) {
+    if (state.output.includes(apiDomain))
       axiosInstance
-          .get(state.output)
-          .then((resp) => {
-            setStateContent(JSON.stringify(resp.data, null, "\t"));
-            loadData(resp);
-          })
-          .catch((err) =>
-              setStateContent(`{"error":"Failed to load state ${err}"}`)
-          );
-
-      axiosInstance
-          .get(state.output.replace(".json",".raw.json"))
-          .then((resp) => {
-            setStateContent(JSON.stringify(resp.data, null, "\t"));
-            loadData(resp);
-          })
-          .catch((err) =>
-              setRawStateContent(`{"error":"Failed to load raw state ${err}"}`)
-          );
-    }
+        .get(state.output)
+        .then((resp) => {
+          setStateContent(JSON.stringify(resp.data, null, "\t"));
+          loadData(resp);
+        })
+        .catch((err) =>
+          setStateContent(`{"error":"Failed to load state ${err}"}`)
+        );
     else
       axiosClient
         .get(state.output)

--- a/ui/src/domain/Workspaces/States.jsx
+++ b/ui/src/domain/Workspaces/States.jsx
@@ -22,6 +22,7 @@ export const States = ({
 }) => {
   const [currentState, setCurrentState] = useState({});
   const [stateContent, setStateContent] = useState("");
+  const [rawStateContent, setRawStateContent] = useState("");
   const [activeTab, setactivetab] = useState("diagram");
   const [nodes, setNodes] = useState([]);
   const [edges, setEdges] = useState([]);
@@ -160,16 +161,27 @@ export const States = ({
 
     const apiDomain = new URL(window._env_.REACT_APP_TERRAKUBE_API_URL)
       .hostname;
-    if (state.output.includes(apiDomain))
+    if (state.output.includes(apiDomain)) {
       axiosInstance
-        .get(state.output)
-        .then((resp) => {
-          setStateContent(JSON.stringify(resp.data, null, "\t"));
-          loadData(resp);
-        })
-        .catch((err) =>
-          setStateContent(`{"error":"Failed to load state ${err}"}`)
-        );
+          .get(state.output)
+          .then((resp) => {
+            setStateContent(JSON.stringify(resp.data, null, "\t"));
+            loadData(resp);
+          })
+          .catch((err) =>
+              setStateContent(`{"error":"Failed to load state ${err}"}`)
+          );
+
+      axiosInstance
+          .get(state.output.replace(".json",".raw.json"))
+          .then((resp) => {
+            setStateContent(JSON.stringify(resp.data, null, "\t"));
+            loadData(resp);
+          })
+          .catch((err) =>
+              setRawStateContent(`{"error":"Failed to load raw state ${err}"}`)
+          );
+    }
     else
       axiosClient
         .get(state.output)
@@ -290,7 +302,14 @@ export const States = ({
                     onMount={handleEditorDidMount}
                     defaultLanguage="json"
                     defaultValue={stateContent}
-                  />
+                  />,
+                  <Editor
+                  height="60vh"
+                  options={{ readOnly: "true" }}
+                  onMount={handleEditorDidMount}
+                  defaultLanguage="json"
+                  defaultValue={rawStateContent}
+                 />
                 )}
               </Card>
             </Col>


### PR DESCRIPTION

This PR will create a backup for the raw terraform state (`terraform pull)` in the workspace state history folder after any apply or destroy, instead of just saving the json state representation of the `terraform show` command.

Example MinIO:

![image](https://github.com/AzBuilder/terrakube/assets/4461895/33b7cbb3-e559-40a0-a834-f92a0b3bf060)

Relatd to #740 