### PR TITLE
Support for job agents

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
@@ -30,6 +30,7 @@ public class ExecutorContext {
     private String moduleSshKey;
     private String commitId;
     private boolean tofu;
+    private String agentUrl;
     private HashMap<String, String> environmentVariables;
     private HashMap<String, String> variables;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -133,7 +133,7 @@ public class ExecutorService {
     }
 
     private String getExecutorUrl(Job job){
-        String agentUrl = job.getWorkspace().getAgent() != null ? job.getWorkspace().getAgent().getUrl() : this.executorUrl;
+        String agentUrl = job.getWorkspace().getAgent() != null ? job.getWorkspace().getAgent().getUrl() + "/api/v1/terraform-rs" : this.executorUrl;
         log.info("Job {} Executor agent url: {}", job.getId(), agentUrl);
         return agentUrl;
     }

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -128,7 +128,14 @@ public class ExecutorService {
         executorContext.setFolder(job.getWorkspace().getFolder());
         executorContext.setRefresh(job.isRefresh());
         executorContext.setRefreshOnly(job.isRefreshOnly());
+        executorContext.setAgentUrl(getExecutorUrl(job));
         return sendToExecutor(job, executorContext);
+    }
+
+    private String getExecutorUrl(Job job){
+        String agentUrl = job.getWorkspace().getAgent() != null ? job.getWorkspace().getAgent().getUrl() : this.executorUrl;
+        log.info("Job {} Executor agent url: {}", job.getId(), agentUrl);
+        return agentUrl;
     }
 
     private boolean iacType(Job job){

--- a/api/src/main/java/org/terrakube/api/rs/Organization.java
+++ b/api/src/main/java/org/terrakube/api/rs/Organization.java
@@ -4,6 +4,7 @@ import com.yahoo.elide.annotation.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.Where;
+import org.terrakube.api.rs.agent.Agent;
 import org.terrakube.api.rs.globalvar.Globalvar;
 import org.terrakube.api.rs.hooks.organization.OrganizationManageHook;
 import org.terrakube.api.rs.job.Job;
@@ -74,6 +75,10 @@ public class Organization {
     @UpdatePermission(expression = "user belongs organization")
     @OneToMany(mappedBy = "organization")
     private List<Ssh> ssh;
+
+    @UpdatePermission(expression = "user belongs organization")
+    @OneToMany(mappedBy = "organization")
+    private List<Agent> agent;
 
     @UpdatePermission(expression = "user belongs organization")
     @OneToMany(mappedBy = "organization")

--- a/api/src/main/java/org/terrakube/api/rs/agent/Agent.java
+++ b/api/src/main/java/org/terrakube/api/rs/agent/Agent.java
@@ -9,11 +9,10 @@ import org.terrakube.api.rs.Organization;
 import javax.persistence.*;
 import java.util.UUID;
 
-@ReadPermission(expression = "user belongs organization")
 @CreatePermission(expression = "user is a superuser")
 @UpdatePermission(expression = "user is a superuser")
 @DeletePermission(expression = "user is a superuser")
-@Include
+@Include(rootLevel = false)
 @Getter
 @Setter
 @Entity(name = "agent")

--- a/api/src/main/java/org/terrakube/api/rs/agent/Agent.java
+++ b/api/src/main/java/org/terrakube/api/rs/agent/Agent.java
@@ -1,0 +1,38 @@
+package org.terrakube.api.rs.agent;
+
+import com.yahoo.elide.annotation.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.Type;
+import org.terrakube.api.rs.Organization;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@ReadPermission(expression = "user belongs organization")
+@CreatePermission(expression = "user is a superuser")
+@UpdatePermission(expression = "user is a superuser")
+@DeletePermission(expression = "user is a superuser")
+@Include
+@Getter
+@Setter
+@Entity(name = "agent")
+public class Agent {
+
+    @Id
+    @Type(type = "uuid-char")
+    @GeneratedValue
+    private UUID id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "url")
+    private String url;
+
+    @Column(name = "description")
+    private String description;
+
+    @ManyToOne
+    private Organization organization;
+}

--- a/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.terrakube.api.plugin.security.audit.GenericAuditFields;
 import org.terrakube.api.rs.Organization;
+import org.terrakube.api.rs.agent.Agent;
 import org.terrakube.api.rs.hooks.workspace.WorkspaceManageHook;
 import org.terrakube.api.rs.ssh.Ssh;
 import org.terrakube.api.rs.vcs.Vcs;
@@ -104,5 +105,8 @@ public class Workspace extends GenericAuditFields {
 
     @OneToOne
     private Ssh ssh;
+
+    @OneToOne
+    private Agent agent;
     
 }

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -50,4 +50,5 @@
     <include file="/db/changelog/local/changelog-2.19.0-workspace-default-template.xml"/>
     <include file="/db/changelog/local/changelog-2.19.0-token-expiration.xml"/>
     <include file="/db/changelog/local/changelog-2.20.0-detault-execution-mode.xml"/>
+    <include file="/db/changelog/local/changelog-2.20.0-executor-agent.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.20.0-executor-agent.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.20.0-executor-agent.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="37" author="javier-canizalez@outlook.com">
+        <createTable tableName="agent">
+            <column name="id" type="varchar(36)">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="varchar(64)"/>
+            <column name="description" type="varchar2(64)"/>
+            <column name="url" type="varchar2(256)"/>
+            <column name="organization_id" type="varchar(36)">
+                <constraints nullable="false" foreignKeyName="fk_agent_org" references="organization(id)"/>
+            </column>
+        </createTable>
+        <addColumn tableName="workspace" >
+            <column name="agent_id" type="varchar(36)">
+                <constraints nullable="true" foreignKeyName="fk_workspace_agent" references="agent(id)"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/thunder-tests/thunderCollection.json
+++ b/thunder-tests/thunderCollection.json
@@ -242,6 +242,13 @@
         "containerId": "",
         "created": "2023-09-14T23:33:33.132Z",
         "sortNum": 132485.4
+      },
+      {
+        "_id": "00747fa3-1147-42f8-834d-21cbd57712a2",
+        "name": "Step 16 - Agents",
+        "containerId": "",
+        "created": "2024-03-12T22:39:02.552Z",
+        "sortNum": 132496.3
       }
     ],
     "settings": {

--- a/thunder-tests/thunderclient.json
+++ b/thunder-tests/thunderclient.json
@@ -2868,7 +2868,7 @@
     "method": "PATCH",
     "sortNum": 732500,
     "created": "2024-03-12T22:53:30.698Z",
-    "modified": "2024-03-12T23:08:09.520Z",
+    "modified": "2024-03-12T23:13:04.295Z",
     "headers": [
       {
         "name": "Content-Type",
@@ -2891,12 +2891,35 @@
     "_id": "9f02cece-c891-44ed-bb59-eb6f6f7066ce",
     "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
     "containerId": "00747fa3-1147-42f8-834d-21cbd57712a2",
-    "name": "update workspace with agent Copy",
-    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/workspace/5ed411ca-7ab8-4d2f-b591-02d0d5788afc",
+    "name": "get workspace data",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/workspace/5ed411ca-7ab8-4d2f-b591-02d0d5788afc/relationships/agent",
     "method": "GET",
     "sortNum": 733750,
     "created": "2024-03-12T23:09:01.394Z",
-    "modified": "2024-03-12T23:09:15.381Z",
+    "modified": "2024-03-12T23:15:27.913Z",
+    "headers": [
+      {
+        "name": "Content-Type",
+        "value": "application/vnd.api+json"
+      }
+    ],
+    "params": [],
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
+  },
+  {
+    "_id": "75759a1e-a884-471f-bed6-542baa65a0cf",
+    "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
+    "containerId": "00747fa3-1147-42f8-834d-21cbd57712a2",
+    "name": "remove worskapce agent",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/workspace/5ed411ca-7ab8-4d2f-b591-02d0d5788afc/relationships/agent",
+    "method": "PATCH",
+    "sortNum": 733125,
+    "created": "2024-03-12T23:14:33.452Z",
+    "modified": "2024-03-12T23:15:47.763Z",
     "headers": [
       {
         "name": "Content-Type",
@@ -2906,7 +2929,7 @@
     "params": [],
     "body": {
       "type": "json",
-      "raw": "{\n  \"data\": {\n      \"type\": \"agent\",\n      \"id\": \"f0ddb2e5-c390-4451-bd7f-fe84e74010de\"\n  }\n}",
+      "raw": "{\n  \"data\": null\n}",
       "form": []
     },
     "auth": {

--- a/thunder-tests/thunderclient.json
+++ b/thunder-tests/thunderclient.json
@@ -2807,5 +2807,112 @@
       "bearer": "{{access_token}}"
     },
     "tests": []
+  },
+  {
+    "_id": "129038a1-f63c-4271-b895-6916a8829767",
+    "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
+    "containerId": "00747fa3-1147-42f8-834d-21cbd57712a2",
+    "name": "create agent",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/agent",
+    "method": "POST",
+    "sortNum": 730000,
+    "created": "2024-03-12T22:39:02.553Z",
+    "modified": "2024-03-12T22:41:48.989Z",
+    "headers": [
+      {
+        "name": "Content-Type",
+        "value": "application/vnd.api+json"
+      }
+    ],
+    "params": [],
+    "body": {
+      "type": "json",
+      "raw": "{\n  \"data\": {\n    \"type\": \"agent\",\n    \"attributes\": {\n      \"name\": \"sample-agent\",\n      \"url\": \"http://localhost:8090\",\n      \"description\": \"This is a sample agent\"\n    }\n  }\n}",
+      "form": []
+    },
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
+  },
+  {
+    "_id": "e95afb49-9132-44e4-bcec-2a330a9e02b6",
+    "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
+    "containerId": "00747fa3-1147-42f8-834d-21cbd57712a2",
+    "name": "search all agents",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/agent",
+    "method": "GET",
+    "sortNum": 735000,
+    "created": "2024-03-12T22:39:02.554Z",
+    "modified": "2024-03-12T22:48:04.504Z",
+    "headers": [
+      {
+        "name": "Content-Type",
+        "value": "application/vnd.api+json"
+      }
+    ],
+    "params": [],
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
+  },
+  {
+    "_id": "cdd719db-7103-4e8a-89ef-1418d4d17d37",
+    "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
+    "containerId": "00747fa3-1147-42f8-834d-21cbd57712a2",
+    "name": "update workspace with agent",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/workspace/5ed411ca-7ab8-4d2f-b591-02d0d5788afc/relationships/agent",
+    "method": "PATCH",
+    "sortNum": 732500,
+    "created": "2024-03-12T22:53:30.698Z",
+    "modified": "2024-03-12T23:08:09.520Z",
+    "headers": [
+      {
+        "name": "Content-Type",
+        "value": "application/vnd.api+json"
+      }
+    ],
+    "params": [],
+    "body": {
+      "type": "json",
+      "raw": "{\n  \"data\": {\n      \"type\": \"agent\",\n      \"id\": \"f0ddb2e5-c390-4451-bd7f-fe84e74010de\"\n  }\n}",
+      "form": []
+    },
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
+  },
+  {
+    "_id": "9f02cece-c891-44ed-bb59-eb6f6f7066ce",
+    "colId": "59b30fd1-9a5b-4dab-aaf1-a6bfc4706ff2",
+    "containerId": "00747fa3-1147-42f8-834d-21cbd57712a2",
+    "name": "update workspace with agent Copy",
+    "url": "{{terrakubeApi}}/api/v1/organization/{{organizationId}}/workspace/5ed411ca-7ab8-4d2f-b591-02d0d5788afc",
+    "method": "GET",
+    "sortNum": 733750,
+    "created": "2024-03-12T23:09:01.394Z",
+    "modified": "2024-03-12T23:09:15.381Z",
+    "headers": [
+      {
+        "name": "Content-Type",
+        "value": "application/vnd.api+json"
+      }
+    ],
+    "params": [],
+    "body": {
+      "type": "json",
+      "raw": "{\n  \"data\": {\n      \"type\": \"agent\",\n      \"id\": \"f0ddb2e5-c390-4451-bd7f-fe84e74010de\"\n  }\n}",
+      "form": []
+    },
+    "auth": {
+      "type": "bearer",
+      "bearer": "{{access_token}}"
+    },
+    "tests": []
   }
 ]


### PR DESCRIPTION
This PR will allow to have several agents inside an organization to run the remote jobs.

Create organization agent
```
POST {{terrakubeApi}}/api/v1/organization/{{organizationId}}/agent
{
  "data": {
    "type": "agent",
    "attributes": {
      "name": "sample-agent",
      "url": "http://localhost:8090",
      "description": "This is a sample agent"
    }
  }
}
```

Set workspace to use specific agent
```
PATCH {{terrakubeApi}}/api/v1/organization/{{organizationId}}/workspace/{{workspaceId}}/relationships/agent
{
  "data": {
      "type": "agent",
      "id": "f0ddb2e5-c390-4451-bd7f-fe84e74010de"
  }
}
```

Remove agent from workspace
```
PATCH {{terrakubeApi}}/api/v1/organization/{{organizationId}}/workspace/{{workspaceId}}/relationships/agent
{
  "data":  null
}
```

The logs will show which agent will execute the job like the following:
![image](https://github.com/AzBuilder/terrakube/assets/4461895/46e49072-5ebb-4971-b3d8-62ff2986c317)
