### PR TITLE
fix docker-compose api hostname

### DIFF
--- a/docker-compose/api.env
+++ b/docker-compose/api.env
@@ -6,7 +6,7 @@ DatasourcePassword=terrakubepassword
 GroupValidationType=DEX
 UserValidationType=DEX
 AuthenticationValidationType=DEX
-TerrakubeHostname=http://terrakube-api:8080
+TerrakubeHostname=terrakube-api:8080
 AzBuilderExecutorUrl=http://terrakube-executor:8090/api/v1/terraform-rs
 PatSecret=ejZRSFgheUBOZXAyUURUITUzdmdINDNeUGpSWHlDM1g=
 InternalSecret=S2JeOGNNZXJQTlpWNmhTITkha2NEKkt1VVBVQmFeQjM=


### PR DESCRIPTION
Fix small issue where the docker compose is including a prefix "http://" that is not correct.

Fix #795 