### PR TITLE
Support for --auto-approve flag

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -153,10 +153,15 @@ public class ScheduleJob implements org.quartz.Job {
                     }
                     break;
                 case approval:
-                    job.setStatus(JobStatus.waitingApproval);
-                    job.setApprovalTeam(flow.get().getTeam());
-                    jobRepository.save(job);
-                    log.info("Waiting Approval for Job {} Step Id {}", job.getId(), stepId);
+                    if(!job.isAutoApply()) {
+                        job.setStatus(JobStatus.waitingApproval);
+                        job.setApprovalTeam(flow.get().getTeam());
+                        jobRepository.save(job);
+                        log.info("Waiting Approval for Job {} Step Id {}", job.getId(), stepId);
+                    } else {
+                        log.info("Auto Approving is enabled for Job {} Step Id {}", job.getId(), stepId);
+                        executeApprovedJobs(job);
+                    }
                     break;
                 case disableWorkspace:
                     log.warn("Disable workspace {} updating status to COMPLETED", job.getId());

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -692,8 +692,14 @@ public class RemoteTfeService {
         boolean isDestroy = runsData.getData().getAttributes().get("is-destroy") != null
                 ? (boolean) runsData.getData().getAttributes().get("is-destroy")
                 : false;
+
+        boolean autoApply = runsData.getData().getAttributes().get("auto-apply") != null
+                ? (boolean) runsData.getData().getAttributes().get("auto-apply")
+                : false;
+
         log.info("Creating new Terrakube Job");
         log.info("Workspace {} Configuration {}", workspaceId, configurationId);
+        log.info("isDestroy {} autoApply {}", isDestroy, autoApply);
         Workspace workspace = workspaceRepository.getReferenceById(UUID.fromString(workspaceId));
         String sourceTarGz = String.format("https://%s/remote/tfe/v2/configuration-versions/%s/terraformContent.tar.gz",
                 hostname, configurationId);
@@ -712,6 +718,7 @@ public class RemoteTfeService {
         job.setWorkspace(workspace);
         job.setOrganization(workspace.getOrganization());
         job.setStatus(JobStatus.pending);
+        job.setAutoApply(autoApply);
         job.setComments("terraform-cli");
         job.setVia("CLI");
         job.setTemplateReference(template.getId().toString());

--- a/api/src/main/java/org/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/org/terrakube/api/rs/job/Job.java
@@ -44,6 +44,10 @@ public class Job extends GenericAuditFields {
     @Column(name = "commit_id")
     private String commitId;
 
+    @Exclude
+    @Column(name = "auto_apply")
+    private boolean autoApply = false;
+
     @Column(name = "terraform_plan")
     private String terraformPlan;
 

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -52,4 +52,5 @@
     <include file="/db/changelog/local/changelog-2.20.0-detault-execution-mode.xml"/>
     <include file="/db/changelog/local/changelog-2.20.0-executor-agent.xml"/>
     <include file="/db/changelog/local/changelog-2.20.0-registry-monorepo.xml"/>
+    <include file="/db/changelog/local/changelog-2.21.0-auto-apply.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.21.0-auto-apply.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.21.0-auto-apply.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="39" author="alfespa17@gmail.com">
+        <addColumn tableName="job" >
+            <column name="auto_apply" type="boolean" defaultValueBoolean="false"/>
+        </addColumn>
+        <update tableName="job">
+            <column name="auto_apply" valueBoolean="false"/>
+        </update>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Adding support to auto approve the cli driven workflow when using:

```shell
terraform apply --auto-approve
```

```shell
user@pop-os:~/git/simple-terraform$ terraform init

Initializing Terraform Cloud...
Initializing modules...
- time_module in module

Initializing provider plugins...
- Finding latest version of hashicorp/null...
- Finding latest version of hashicorp/time...
- Finding latest version of hashicorp/random...
- Installing hashicorp/null v3.2.2...
- Installed hashicorp/null v3.2.2 (signed by HashiCorp)
- Installing hashicorp/time v0.11.1...
- Installed hashicorp/time v0.11.1 (signed by HashiCorp)
- Installing hashicorp/random v3.6.1...
- Installed hashicorp/random v3.6.1 (signed by HashiCorp)

Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform Cloud has been successfully initialized!

You may now begin working with Terraform Cloud. Try running "terraform plan" to
see any changes that are required for your infrastructure.

If you ever set or change modules or Terraform Settings, run "terraform init"
again to reinitialize your working directory.
user@pop-os:~/git/simple-terraform$ terraform apply --auto-approve

Running apply in Terraform Cloud. Output will stream here. Pressing Ctrl-C
will cancel the remote apply if it's still pending. If the apply started it
will stop streaming the logs, but will not stop the apply running remotely.

Preparing the remote apply...

To view this run in a browser, visit:
https://8080-azbuilder-terrakube-jdlq1j61x7k.ws-us110.gitpod.io/app/simple/auto-approve/runs/1

Waiting for the plan to start...

***************************************
Running Terraform PLAN
***************************************

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # null_resource.next will be created
  + resource "null_resource" "next" {
      + id = (known after apply)
    }

  # null_resource.next2 will be created
  + resource "null_resource" "next2" {
      + id = (known after apply)
    }

  # null_resource.next3 will be created
  + resource "null_resource" "next3" {
      + id = (known after apply)
    }

  # null_resource.previous will be created
  + resource "null_resource" "previous" {
      + id = (known after apply)
    }

  # time_sleep.wait_30_seconds will be created
  + resource "time_sleep" "wait_30_seconds" {
      + create_duration = (known after apply)
      + id              = (known after apply)
    }

  # module.time_module.random_integer.time will be created
  + resource "random_integer" "time" {
      + id     = (known after apply)
      + max    = 5
      + min    = 1
      + result = (known after apply)
    }

Plan: 6 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + creation_time = (known after apply)
  + fake_data     = {
      + data     = "Hello World"
      + resource = {
          + resource1 = "fake"
        }
    }

module.time_module.random_integer.time: Creating...
module.time_module.random_integer.time: Creation complete after 0s [id=5]
null_resource.previous: Creating...
null_resource.previous: Creation complete after 0s [id=2269151485616574662]
time_sleep.wait_30_seconds: Creating...
time_sleep.wait_30_seconds: Creation complete after 5s [id=2024-04-16T22:25:15Z]
null_resource.next3: Creating...
null_resource.next2: Creating...
null_resource.next: Creating...
null_resource.next: Creation complete after 0s [id=7860036023219461249]
null_resource.next2: Creation complete after 0s [id=4537697783711434539]
null_resource.next3: Creation complete after 0s [id=1374695310245285023]

Apply complete! Resources: 6 added, 0 changed, 0 destroyed.

Outputs:

creation_time = "5s"
fake_data = {
  "data" = "Hello World"
  "resource" = {
    "resource1" = "fake"
  }
}

```

Fix #815 