### PR TITLE
Azure Dynamic provider credentials support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ terrakubeDemo1.crt
 terrakubeDemo2.crt
 bindings/ca-certificates/terrakubeDemo1.pem
 bindings/ca-certificates/terrakubeDemo2.pem
+
+private.pem
+public.pem

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -284,12 +284,12 @@ public class ExecutorService {
 
         String privateKeyPEMFinal = "";
         String line;
-        BufferedReader bufReader = new BufferedReader(new StringReader(privateKeyPEMFinal));
+        BufferedReader bufReader = new BufferedReader(new StringReader(rsaPrivateKey));
         while( (line=bufReader.readLine()) != null )
         {
             privateKeyPEMFinal += line;
         }
-        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(rsaPrivateKey));
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(privateKeyPEMFinal));
         KeyFactory kf = KeyFactory.getInstance("RSA");
 
         return kf.generatePrivate(keySpec);

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -1,6 +1,8 @@
 package org.terrakube.api.plugin.scheduler.job.tcl.executor;
 
+import io.jsonwebtoken.Jwts;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
 import org.springframework.web.client.RestClientException;
 import org.terrakube.api.plugin.scheduler.job.tcl.model.Flow;
 import org.terrakube.api.repository.GlobalVarRepository;
@@ -21,6 +23,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 @Slf4j
@@ -30,6 +42,9 @@ public class ExecutorService {
     @Value("${org.terrakube.executor.url}")
     private String executorUrl;
 
+    @Value("${org.terrakube.hostname}")
+    String hostname;
+
     @Autowired
     JobRepository jobRepository;
 
@@ -38,6 +53,9 @@ public class ExecutorService {
 
     @Autowired
     SshRepository sshRepository;
+
+    @Value("${org.terrakube.dynamic.credentials.private-key-path}")
+    String privateKeyPath;
 
 
     @Transactional
@@ -50,7 +68,7 @@ public class ExecutorService {
         executorContext.setJobId(String.valueOf(job.getId()));
         executorContext.setStepId(stepId);
 
-        if(job.getWorkspace().getBranch().equals("remote-content")){
+        if (job.getWorkspace().getBranch().equals("remote-content")) {
             log.warn("Running remote operation, disable headers");
             executorContext.setShowHeader(false);
         } else {
@@ -101,12 +119,12 @@ public class ExecutorService {
         executorContext.setCommandList(flow.getCommands());
         executorContext.setType(flow.getType());
         executorContext.setTerraformVersion(job.getWorkspace().getTerraformVersion());
-        if(job.getOverrideSource() == null) {
+        if (job.getOverrideSource() == null) {
             executorContext.setSource(job.getWorkspace().getSource());
         } else {
             executorContext.setSource(job.getOverrideSource());
         }
-        if(job.getOverrideBranch() == null) {
+        if (job.getOverrideBranch() == null) {
             executorContext.setBranch(job.getWorkspace().getBranch());
         } else {
             if (job.getOverrideBranch().equals("remote-content")) {
@@ -115,10 +133,10 @@ public class ExecutorService {
             executorContext.setBranch(job.getOverrideBranch());
         }
 
-        if(job.getWorkspace().getModuleSshKey() != null) {
+        if (job.getWorkspace().getModuleSshKey() != null) {
             String moduleSshId = job.getWorkspace().getModuleSshKey();
             Optional<Ssh> ssh = sshRepository.findById(UUID.fromString(moduleSshId));
-            if(ssh.isPresent()){
+            if (ssh.isPresent()) {
                 executorContext.setModuleSshKey(ssh.get().getPrivateKey());
             }
         }
@@ -131,14 +149,14 @@ public class ExecutorService {
         return sendToExecutor(job, executorContext);
     }
 
-    private String getExecutorUrl(Job job){
+    private String getExecutorUrl(Job job) {
         String agentUrl = job.getWorkspace().getAgent() != null ? job.getWorkspace().getAgent().getUrl() + "/api/v1/terraform-rs" : this.executorUrl;
         log.info("Job {} Executor agent url: {}", job.getId(), agentUrl);
         return agentUrl;
     }
 
-    private boolean iacType(Job job){
-        return job.getWorkspace().getIacType() != null && job.getWorkspace().getIacType().equals("terraform") ? false: true;
+    private boolean iacType(Job job) {
+        return job.getWorkspace().getIacType() != null && job.getWorkspace().getIacType().equals("terraform") ? false : true;
     }
 
     private boolean sendToExecutor(Job job, ExecutorContext executorContext) {
@@ -180,6 +198,10 @@ public class ExecutorService {
         } else {
             log.info("Loading default env variables to job");
             workspaceEnvVariables = loadDefault(job, Category.ENV, workspaceEnvVariables);
+        }
+
+        if (workspaceEnvVariables.containsKey("ENABLE_DYNAMIC_CREDENTIALS")) {
+            workspaceEnvVariables = generateDynamicCredentials(job, workspaceEnvVariables);
         }
         return workspaceEnvVariables;
     }
@@ -226,5 +248,50 @@ public class ExecutorService {
                 }
             }
         return workspaceData;
+    }
+
+    private HashMap<String, String> generateDynamicCredentials(Job job, HashMap<String, String> workspaceEnvVariables) {
+        Instant now = Instant.now();
+        String jwtToken = null;
+        try {
+            jwtToken = Jwts.builder()
+                    .setSubject(String.format("organization:%s:workspace:%s", job.getOrganization().getName(), job.getWorkspace().getName()))
+                    .setAudience(workspaceEnvVariables.get("WORKLOAD_IDENTITY_AUDIENCE"))
+                    .setId(UUID.randomUUID().toString())
+                    .setHeaderParam("kid", "03446895-220d-47e1-9564-4eeaa3691b42")
+                    .claim("terrakube_workspace_id", job.getWorkspace().getId())
+                    .claim("terrakube_organization_id", job.getOrganization().getId())
+                    .claim("terrakube_job_id", String.valueOf(job.getId()))
+                    .setIssuedAt(Date.from(now))
+                    .setIssuer(String.format("https://%s", hostname))
+                    .setExpiration(Date.from(now.plus(30, ChronoUnit.MINUTES)))
+                    .signWith(getPrivateKey())
+                    .compact();
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+
+        log.info("ARM_OIDC_TOKEN: {}", jwtToken);
+        workspaceEnvVariables.put("ARM_OIDC_TOKEN", jwtToken);
+        return workspaceEnvVariables;
+    }
+
+    private PrivateKey getPrivateKey() throws Exception {
+        String rsaPrivateKey = FileUtils.readFileToString(new File(privateKeyPath), StandardCharsets.UTF_8);
+
+        rsaPrivateKey = rsaPrivateKey.replace("-----BEGIN PRIVATE KEY-----", "");
+        rsaPrivateKey = rsaPrivateKey.replace("-----END PRIVATE KEY-----", "");
+
+        String privateKeyPEMFinal = "";
+        String line;
+        BufferedReader bufReader = new BufferedReader(new StringReader(privateKeyPEMFinal));
+        while( (line=bufReader.readLine()) != null )
+        {
+            privateKeyPEMFinal += line;
+        }
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(rsaPrivateKey));
+        KeyFactory kf = KeyFactory.getInstance("RSA");
+
+        return kf.generatePrivate(keySpec);
     }
 }

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -204,6 +204,14 @@ public class ExecutorService {
         if (workspaceEnvVariables.containsKey("ENABLE_DYNAMIC_CREDENTIALS_AZURE")) {
             workspaceEnvVariables = dynamicCredentialsService.generateDynamicCredentialsAzure(job, workspaceEnvVariables);
         }
+
+        if (workspaceEnvVariables.containsKey("ENABLE_DYNAMIC_CREDENTIALS_GCP")) {
+            workspaceEnvVariables = dynamicCredentialsService.generateDynamicCredentialsAws(job, workspaceEnvVariables);
+        }
+
+        if (workspaceEnvVariables.containsKey("ENABLE_DYNAMIC_CREDENTIALS_AWS")) {
+            workspaceEnvVariables = dynamicCredentialsService.generateDynamicCredentialsGcp(job, workspaceEnvVariables);
+        }
         return workspaceEnvVariables;
     }
 

--- a/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
@@ -36,6 +36,8 @@ public class DexWebSecurityAdapter {
                                     .requestMatchers("/callback/v1/**").permitAll()
                                     .requestMatchers("/webhook/v1/**").permitAll()
                                     .requestMatchers("/.well-known/terraform.json").permitAll()
+                                    .requestMatchers("/.well-known/openid-configuration").permitAll()
+                                    .requestMatchers("/.well-known/jwks").permitAll()
                                     .requestMatchers("/remote/tfe/v2/ping").permitAll()
                                     .requestMatchers(HttpMethod.PUT, "/remote/tfe/v2/configuration-versions/*").permitAll()
                                     .requestMatchers(HttpMethod.PUT,"/tfstate/v1/archive/*/terraform.tfstate").permitAll()

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -73,6 +73,18 @@ public class DynamicCredentialsService {
         return workspaceEnvVariables;
     }
 
+    @Transactional
+    public HashMap<String, String> generateDynamicCredentialsAws(Job job, HashMap<String, String> workspaceEnvVariables) {
+        log.warn("AWS Dynamic Credentials not implemented yet");
+        return workspaceEnvVariables;
+    }
+
+    @Transactional
+    public HashMap<String, String> generateDynamicCredentialsGcp(Job job, HashMap<String, String> workspaceEnvVariables) {
+        log.warn("GCP Dynamic Credentials not implemented yet");
+        return workspaceEnvVariables;
+    }
+
     private PrivateKey getPrivateKey() throws Exception {
         String rsaPrivateKey = FileUtils.readFileToString(new File(privateKeyPath), StandardCharsets.UTF_8);
 

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -1,0 +1,118 @@
+package org.terrakube.api.plugin.token.dynamic;
+
+import io.jsonwebtoken.Jwts;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.terrakube.api.rs.job.Job;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.UUID;
+
+@Slf4j
+@Service
+public class DynamicCredentialsService {
+
+    @Value("${org.terrakube.hostname}")
+    String hostname;
+
+    @Value("${org.terrakube.dynamic.credentials.public-key-path}")
+    String publicKeyPath;
+
+    @Value("${org.terrakube.dynamic.credentials.private-key-path}")
+    String privateKeyPath;
+
+    @Value("${org.terrakube.dynamic.credentials.kid}")
+    String kid;
+
+    @Value("${org.terrakube.dynamic.credentials.ttl}")
+    int dynamicCredentialTtl;
+
+    @Transactional
+    public HashMap<String, String> generateDynamicCredentialsAzure(Job job, HashMap<String, String> workspaceEnvVariables) {
+        Instant now = Instant.now();
+        String jwtToken = "";
+        if (privateKeyPath != null && !privateKeyPath.isEmpty())
+            try {
+                jwtToken = Jwts.builder()
+                        .setSubject(String.format("organization:%s:workspace:%s", job.getOrganization().getName(), job.getWorkspace().getName()))
+                        .setAudience(workspaceEnvVariables.get("WORKLOAD_IDENTITY_AUDIENCE_AZURE"))
+                        .setId(UUID.randomUUID().toString())
+                        .setHeaderParam("kid", kid)
+                        .claim("terrakube_workspace_id", job.getWorkspace().getId())
+                        .claim("terrakube_organization_id", job.getOrganization().getId())
+                        .claim("terrakube_job_id", String.valueOf(job.getId()))
+                        .setIssuedAt(Date.from(now))
+                        .setIssuer(String.format("https://%s", hostname))
+                        .setExpiration(Date.from(now.plus(dynamicCredentialTtl, ChronoUnit.MINUTES)))
+                        .signWith(getPrivateKey())
+                        .compact();
+
+                log.info("ARM_OIDC_TOKEN: {}", jwtToken);
+                workspaceEnvVariables.put("ARM_OIDC_TOKEN", jwtToken);
+            } catch (Exception e) {
+                log.error(e.getMessage());
+            }
+        else {
+            log.error("DynamicCredentialPrivateKeyPath not set, to generate Azure Dynamic Credentials the value is need it");
+        }
+
+        return workspaceEnvVariables;
+    }
+
+    private PrivateKey getPrivateKey() throws Exception {
+        String rsaPrivateKey = FileUtils.readFileToString(new File(privateKeyPath), StandardCharsets.UTF_8);
+
+        rsaPrivateKey = rsaPrivateKey.replace("-----BEGIN PRIVATE KEY-----", "");
+        rsaPrivateKey = rsaPrivateKey.replace("-----END PRIVATE KEY-----", "");
+
+        String privateKeyPEMFinal = "";
+        String line;
+        BufferedReader bufReader = new BufferedReader(new StringReader(rsaPrivateKey));
+        while ((line = bufReader.readLine()) != null) {
+            privateKeyPEMFinal += line;
+        }
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(privateKeyPEMFinal));
+        KeyFactory kf = KeyFactory.getInstance("RSA");
+
+        return kf.generatePrivate(keySpec);
+    }
+
+    public String getPublicKey() {
+        String publicKeyPEM = "";
+        try {
+            publicKeyPEM = FileUtils.readFileToString(new File(publicKeyPath), StandardCharsets.UTF_8);
+
+            publicKeyPEM = publicKeyPEM.replace("-----BEGIN PUBLIC KEY-----", "");
+            publicKeyPEM = publicKeyPEM.replace("-----END PUBLIC KEY-----", "");
+
+            String publicKeyPEMFinal = "";
+            String line;
+            BufferedReader bufReader = new BufferedReader(new StringReader(publicKeyPEM));
+            while ((line = bufReader.readLine()) != null) {
+                publicKeyPEMFinal += line;
+            }
+
+            log.info("Dynamic Credentials Public Key: {}", publicKeyPEMFinal);
+            return publicKeyPEMFinal;
+        } catch (Exception ex) {
+            publicKeyPEM = "";
+            log.error(ex.getMessage());
+        }
+
+        return publicKeyPEM;
+    }
+}

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/JwksController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/JwksController.java
@@ -3,8 +3,6 @@ package org.terrakube.api.plugin.token.dynamic;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -12,11 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
-import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPublicKey;
@@ -41,7 +35,7 @@ public class JwksController {
     private JwkData jwkData;
 
     @GetMapping(produces = "application/json")
-    public ResponseEntity<JwkData> jwksEndpoint() throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+    public ResponseEntity<JwkData> jwksEndpoint() throws NoSuchAlgorithmException, InvalidKeySpecException {
         if (jwkData == null) {
             jwkData = getJwkData();
         }
@@ -49,7 +43,7 @@ public class JwksController {
 
     }
 
-    private JwkData getJwkData() throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+    private JwkData getJwkData() throws NoSuchAlgorithmException, InvalidKeySpecException {
         String publicKey = dynamicCredentialsService.getPublicKey();
 
         if(publicKey != null && !publicKey.isEmpty()) {

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/JwksController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/JwksController.java
@@ -1,0 +1,98 @@
+package org.terrakube.api.plugin.token.dynamic;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@RestController
+@RequestMapping("/.well-known/jwks")
+public class JwksController {
+
+    private JwkData jwkData;
+    public static final String kid = "03446895-220d-47e1-9564-4eeaa3691b42";
+
+    @Value("${org.terrakube.dynamic.credentials.public-key-path}")
+    String publicKeyPath;
+
+    @GetMapping(produces = "application/json")
+    public ResponseEntity<JwkData> jwksEndpoint() throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+
+        if (jwkData == null) {
+            jwkData = getJwkData();
+        }
+        return ResponseEntity.of(Optional.of(jwkData));
+
+    }
+
+    private JwkData getJwkData() throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+
+        String publicKeyPEM = FileUtils.readFileToString(new File(publicKeyPath), StandardCharsets.UTF_8);
+
+        publicKeyPEM = publicKeyPEM.replace("-----BEGIN PUBLIC KEY-----", "");
+        publicKeyPEM = publicKeyPEM.replace("-----END PUBLIC KEY-----", "");
+
+        log.info("Dynamic Credentials Public Key: {}", publicKeyPEM);
+
+        byte[] encoded = Base64.getDecoder().decode(publicKeyPEM);
+
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        X509EncodedKeySpec keySpec = new X509EncodedKeySpec(encoded);
+
+        RSAPublicKey rsa = (RSAPublicKey) keyFactory.generatePublic(keySpec);
+        String exponent = Base64.getUrlEncoder().encodeToString(rsa.getPublicExponent().toByteArray());
+        String modulus = Base64.getUrlEncoder().encodeToString(rsa.getModulus().toByteArray());
+        log.info("RSA Exponent: {}", exponent);
+        log.info("RSA Modulus: {}", modulus);
+
+        JwkData jwkData = new JwkData();
+        jwkData.setKeys(new ArrayList());
+
+        JwkElement jwkElement = new JwkElement();
+        jwkElement.setKty("RSA");
+        jwkElement.setN(modulus);
+        jwkElement.setE(exponent);
+        jwkElement.setKid(kid);
+        jwkElement.setUse("sig");
+        jwkElement.setAlg("RS256");
+
+        return  jwkData;
+    }
+}
+
+@Getter
+@Setter
+class JwkData {
+    List<JwkElement> keys;
+}
+
+@Getter
+@Setter
+class JwkElement {
+
+    private String kty;
+    private String use;
+    private String n;
+    private String e;
+    private String kid;
+    private String alg;
+}

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/JwksController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/JwksController.java
@@ -86,6 +86,8 @@ public class JwksController {
         jwkElement.setUse("sig");
         jwkElement.setAlg("RS256");
 
+        jwkData.getKeys().add(jwkElement);
+
         return  jwkData;
     }
 }

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/JwksController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/JwksController.java
@@ -11,8 +11,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
@@ -52,11 +54,17 @@ public class JwksController {
         publicKeyPEM = publicKeyPEM.replace("-----BEGIN PUBLIC KEY-----", "");
         publicKeyPEM = publicKeyPEM.replace("-----END PUBLIC KEY-----", "");
 
-        publicKeyPEM = StringUtils.strip(publicKeyPEM, "\n");
+        String publicKeyPEMFinal = "";
+        String line;
+        BufferedReader bufReader = new BufferedReader(new StringReader(publicKeyPEM));
+        while( (line=bufReader.readLine()) != null )
+        {
+            publicKeyPEMFinal += line;
+        }
 
-        log.info("Dynamic Credentials Public Key: {}", publicKeyPEM);
+        log.info("Dynamic Credentials Public Key: {}", publicKeyPEMFinal);
 
-        byte[] encoded = Base64.getDecoder().decode(publicKeyPEM);
+        byte[] encoded = Base64.getDecoder().decode(publicKeyPEMFinal);
 
         KeyFactory keyFactory = KeyFactory.getInstance("RSA");
         X509EncodedKeySpec keySpec = new X509EncodedKeySpec(encoded);

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/JwksController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/JwksController.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -50,6 +51,8 @@ public class JwksController {
 
         publicKeyPEM = publicKeyPEM.replace("-----BEGIN PUBLIC KEY-----", "");
         publicKeyPEM = publicKeyPEM.replace("-----END PUBLIC KEY-----", "");
+
+        publicKeyPEM = StringUtils.strip(publicKeyPEM, "\n");
 
         log.info("Dynamic Credentials Public Key: {}", publicKeyPEM);
 

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/OpenIdConfigurationController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/OpenIdConfigurationController.java
@@ -1,0 +1,98 @@
+package org.terrakube.api.plugin.token.dynamic;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@RestController
+@RequestMapping("/.well-known/openid-configuration")
+public class OpenIdConfigurationController {
+
+    @Value("${org.terrakube.hostname}")
+    String hostname;
+
+    OpenIdConfiguration openIdConfiguration;
+
+    @GetMapping(produces = "application/json")
+    public ResponseEntity<OpenIdConfiguration> openIdConfigurationEndpoint() {
+        if (this.openIdConfiguration == null) {
+            this.openIdConfiguration = getDefaultOpenIdConfiguration();
+        }
+
+        return ResponseEntity.of(Optional.ofNullable(this.openIdConfiguration));
+    }
+
+
+    private OpenIdConfiguration getDefaultOpenIdConfiguration() {
+        log.info("Loading default OpenId Configuration data...");
+        OpenIdConfiguration openIdData = new OpenIdConfiguration();
+
+        String issuer = String.format("https://%s", hostname);
+
+        openIdData.setIssuer(issuer);
+        openIdData.setJwksUri(issuer + "/.well-known/jwks");
+        openIdData.setResponseTypesSupported(new ArrayList<>());
+        openIdData.getResponseTypesSupported().add("id_token");
+
+        openIdData.setClaimsSupported(new ArrayList<>());
+        openIdData.getClaimsSupported().add("sub");
+        openIdData.getClaimsSupported().add("aud");
+        openIdData.getClaimsSupported().add("exp");
+        openIdData.getClaimsSupported().add("iat");
+        openIdData.getClaimsSupported().add("iss");
+        openIdData.getClaimsSupported().add("jti");
+        openIdData.getClaimsSupported().add("terrakube_workspace_id");
+        openIdData.getClaimsSupported().add("terrakube_organization_id");
+        openIdData.getClaimsSupported().add("terrakube_job_id");
+
+        openIdData.setIdTokenSigningAlgValuesSupported(new ArrayList<>());
+        openIdData.getIdTokenSigningAlgValuesSupported().add("RS256");
+
+        openIdData.setScopesSupported(new ArrayList<>());
+
+        openIdData.getScopesSupported().add("openid");
+
+        openIdData.setSubjectTypesSupported(new ArrayList<>());
+        openIdData.getSubjectTypesSupported().add("public");
+
+        return openIdData;
+    }
+
+}
+
+@Getter
+@Setter
+class OpenIdConfiguration {
+
+    @JsonProperty("issuer")
+    private String issuer;
+
+    @JsonProperty("jwks_uri")
+    private String jwksUri;
+
+    @JsonProperty("response_types_supported")
+    private List<String> responseTypesSupported;
+
+    @JsonProperty("claims_supported")
+    private List<String> claimsSupported;
+
+    @JsonProperty("id_token_signing_alg_values_supported")
+    private List<String> idTokenSigningAlgValuesSupported;
+
+    @JsonProperty("scopes_supported")
+    private List<String> scopesSupported;
+
+    @JsonProperty("subject_types_supported")
+    private List<String> subjectTypesSupported;
+}

--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -157,4 +157,10 @@ org.terrakube.api.module.cache.minIdle=${ModuleCacheMinIdle:64}
 org.terrakube.api.module.cache.timeout=${ModuleCacheTimeout:600000}
 org.terrakube.api.module.cache.schedule=${ModuleCacheSchedule:0 */3 * ? * *}
 
+#######################
+# Dynamic Credentials #
+#######################
+org.terrakube.dynamic.credentials.public-key-path=${DynamicCredentialPublicKeyPath:}
+org.terrakube.dynamic.credentials.private-key-path=${DynamicCredentialPrivateKeyPath:}
+
 # logging.level.org.springframework.security=DEBUG

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -161,6 +161,8 @@ org.terrakube.api.module.cache.schedule=${ModuleCacheSchedule:0 */3 * ? * *}
 #######################
 # Dynamic Credentials #
 #######################
+org.terrakube.dynamic.credentials.kid=${DynamicCredentialId:03446895-220d-47e1-9564-4eeaa3691b42}
+org.terrakube.dynamic.credentials.ttl=${DynamicCredentialTtl:30}
 org.terrakube.dynamic.credentials.public-key-path=${DynamicCredentialPublicKeyPath:}
 org.terrakube.dynamic.credentials.private-key-path=${DynamicCredentialPrivateKeyPath:}
 

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -158,4 +158,10 @@ org.terrakube.api.module.cache.minIdle=${ModuleCacheMinIdle:64}
 org.terrakube.api.module.cache.timeout=${ModuleCacheTimeout:600000}
 org.terrakube.api.module.cache.schedule=${ModuleCacheSchedule:0 */3 * ? * *}
 
+#######################
+# Dynamic Credentials #
+#######################
+org.terrakube.dynamic.credentials.public-key-path=${DynamicCredentialPublicKeyPath:}
+org.terrakube.dynamic.credentials.private-key-path=${DynamicCredentialPrivateKeyPath:}
+
 # logging.level.org.springframework.security=DEBUG

--- a/scripts/setupDevelopmentEnvironment.sh
+++ b/scripts/setupDevelopmentEnvironment.sh
@@ -47,6 +47,8 @@ function generateApiVars(){
   echo "TerrakubeRedisPort=6379" >> .envApi
   echo "TerrakubeRedisSSL=false" >> .envApi
   echo "#TerrakubeRedisUsername=default" >> .envApi
+  echo "DynamicCredentialPublicKeyPath=/gitpod/" >> .envApi
+  echo "DynamicCredentialPrivateKeyPath=/gitpod/" >> .envApi
   echo "TerrakubeRedisPassword=password123456" >> .envApi
   echo "#TERRAKUBE_ADMIN_GROUP=$TERRAKUBE_ADMIN_GROUP" >> .envApi
 }
@@ -274,4 +276,8 @@ fi
 
 cp ./scripts/template/azure/.envAzureSample .envAzure
 cp ./scripts/template/google/.envGcpSample .envGcp
+
+openssl genrsa -out private.pem 2048
+openssl rsa -in private.pem -outform PEM -pubout -out public.pem
+
 echo "Setup Development Environment Completed"

--- a/scripts/setupDevelopmentEnvironment.sh
+++ b/scripts/setupDevelopmentEnvironment.sh
@@ -277,7 +277,9 @@ fi
 cp ./scripts/template/azure/.envAzureSample .envAzure
 cp ./scripts/template/google/.envGcpSample .envGcp
 
-openssl genrsa -out private.pem 2048
-openssl rsa -in private.pem -outform PEM -pubout -out public.pem
+openssl genrsa -out private_temp.pem 2048
+openssl rsa -in private_temp.pem -outform PEM -pubout -out public.pem
+openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in private_temp.pem -out private.pem
+rm private_temp.pem
 
 echo "Setup Development Environment Completed"


### PR DESCRIPTION
This pull request add support to manage Azure Dynamic Provider credentials so Terrakube can automatically authenticate with Azure without storing any service principal secret.

## Generate Public and Private Key.

To use Azure Dynamic Provider credentials we need to genera a public and private key that will be use to generate a validate the federated tokens, we can use the following commands

```
openssl genrsa -out private_temp.pem 2048
openssl rsa -in private_temp.pem -outform PEM -pubout -out public.pem
```

You need to make sure the private key starts with "-----BEGIN PRIVATE KEY-----" if not the following command can be used to transform the private key to the correct format
```
openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in private_temp.pem -out private.pem
```

The public and private key need to be mounted inside the container and the path should be specify in the following environment variables

- DynamicCredentialPublicKeyPath
- DynamicCredentialPrivateKeyPath

## Public Endpoints Requirements

To use Azure Dynamic Provider credentials the following public endpoints were added and need to be accessible so Azure Entra can validate the federated token. 

```
GET https://TERRAKUBE.MYSUPERDOMAIN.COM/.well-known/openid-configuration
{
  "issuer": "https://TERRAKUBE.MYSUPERDOMAIN.COM",
  "jwks_uri": "https://TERRAKUBE.MYSUPERDOMAIN.COM/.well-known/jwks",
  "response_types_supported": [
    "id_token"
  ],
  "claims_supported": [
    "sub",
    "aud",
    "exp",
    "iat",
    "iss",
    "jti",
    "terrakube_workspace_id",
    "terrakube_organization_id",
    "terrakube_job_id"
  ],
  "id_token_signing_alg_values_supported": [
    "RS256"
  ],
  "scopes_supported": [
    "openid"
  ],
  "subject_types_supported": [
    "public"
  ]
}
```

```
GET https://TERRAKUBE.MYSUPERDOMAIN.COM/.well-known/jwks
{
  "keys": [
    {
      "kty": "RSA",
      "use": "sig",
      "n": "ALEzGE4Rn2WhxOhIuXAzq7e-WvRLCJfoqrHMUXtpt6gefNmWGo9trbea84KyeKdvzE9wBwWxnz_U5d_utmLLztVA2FLdDfnndh7pF4Fp7hB-lhaT1hV2EsiFsc9oefCYmkzXmHylfNQOuqNlRA_2Xu5pHovrF79WW01hWSjhGTkpj6pxFG4t7Tl54SWnJ83CvGDAKuoO9c1M1iTKikB3ENMK8WfU-wZJ4oLTAfhSydqZxZuGRhiwPGsEQOpRynyHJ54XWZHmFdsWs_eGRsfs1iTPbiQSBZbaEwz36HF4QdqFzzLGd67sTtZku_YEsUbJW8cbK6nOFEdR0BSTtSV-lPk=",
      "e": "AQAB",
      "kid": "03446895-220d-47e1-9564-4eeaa3691b42",
      "alg": "RS256"
    }
  ]
}
```

## Environment Variables:

The following environment variables were added:

- DynamicCredentialId = This will be the kid in the JWKS endpoint (Default value: 03446895-220d-47e1-9564-4eeaa3691b42)
- DynamicCredentialTtl= The TTL for the federated token generated internally in Terrakube (Defafult: 30)
- DynamicCredentialPublicKeyPath= The path to the public key to validate the federated tokens
- DynamicCredentialPrivateKeyPath=The path to the private key to generate the federated tokens

## Register Application

We need to register a new application in Microsoft Entra like the following example:

![image](https://github.com/AzBuilder/terrakube/assets/4461895/412aa44a-7dc3-41d1-a1ac-13c3ac6052b3)

Once we have the application we need to add a federated credential.

![image](https://github.com/AzBuilder/terrakube/assets/4461895/0cebaed1-d476-4350-8044-ab2fbbf742ad)

Select type "Other" and fill the following information:

- Issuer: https://terrakube-api.mysuperdomain.com
- Subject: organization:MY_ORGANIZATION_NAME:workspace:MY_WORKSPACE_NAME
- Audience: api://AzureADTokenExchange

![image](https://github.com/AzBuilder/terrakube/assets/4461895/cef0f7dc-0d7e-497b-a4c1-001d05626880)

You need to grant access to your azure resources to the application, for example "Contributor" or any other role

![image](https://github.com/AzBuilder/terrakube/assets/4461895/04616c83-34c9-45ed-a5f5-6a089a45b2e6)

Inside our workspace you will have to add the following environment variables

- ARM_TENANT_ID=YOUR AZURE TENANT ID
- ARM_SUBSCRIPTION_ID=YOUR AZURE SUBSCRIPTION ID
- ARM_CLIENT_ID=YOUR AZURE APPLICATION ID
- ARM_USE_OIDC=true
- ENABLE_DYNAMIC_CREDENTIALS_AZURE=true
- WORKLOAD_IDENTITY_AUDIENCE_AZURE=api://AzureADTokenExchange

![image](https://github.com/AzBuilder/terrakube/assets/4461895/1fcd3acc-1c47-4c17-8e8e-bc23bc30f8dd)

When running a job Terrakube will correctly authenticate to Azure without any credentials inside the workspace

![image](https://github.com/AzBuilder/terrakube/assets/4461895/d24dac6a-e506-4742-bdae-90b1e0113fef)

Terraform example using the CLI driven workflow:

```terraform
terraform {

  cloud {
    organization = "simple"
    hostname = "8080-azbuilder-terrakube-tr6130m2jsz.ws-us110.gitpod.io"

    workspaces {
      name = "simple"
    }
  }
}

# Configure the Microsoft Azure Provider
provider "azurerm" {
  features {}
  use_cli              = false

}

resource "azurerm_resource_group" "example" {
  name     = "example2"
  location = "East US 2"
}

```

## Running example:
```shell
user@pop-os:~/git/dynamic_creds$ terraform apply

Running apply in Terraform Cloud. Output will stream here. Pressing Ctrl-C
will cancel the remote apply if it's still pending. If the apply started it
will stop streaming the logs, but will not stop the apply running remotely.

Preparing the remote apply...

To view this run in a browser, visit:
https://8080-azbuilder-terrakube-tr6130m2jsz.ws-us110.gitpod.io/app/simple/simple/runs/2

Waiting for the plan to start...

***************************************
Running Terraform PLAN
***************************************

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_resource_group.example will be created
  + resource "azurerm_resource_group" "example" {
      + id       = (known after apply)
      + location = "eastus2"
      + name     = "example2"
    }

Plan: 1 to add, 0 to change, 0 to destroy.


Do you want to perform these actions in workspace "simple"?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

azurerm_resource_group.example: Creating...
azurerm_resource_group.example: Creation complete after 2s [id=/subscriptions/583006a4-7a57-4a3d-899c-620faa582f6d/resourceGroups/example2]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

```