### PR TITLE
GCP Dynamic provider credentials support

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -205,11 +205,11 @@ public class ExecutorService {
             workspaceEnvVariables = dynamicCredentialsService.generateDynamicCredentialsAzure(job, workspaceEnvVariables);
         }
 
-        if (workspaceEnvVariables.containsKey("ENABLE_DYNAMIC_CREDENTIALS_GCP")) {
+        if (workspaceEnvVariables.containsKey("ENABLE_DYNAMIC_CREDENTIALS_AWS")) {
             workspaceEnvVariables = dynamicCredentialsService.generateDynamicCredentialsAws(job, workspaceEnvVariables);
         }
 
-        if (workspaceEnvVariables.containsKey("ENABLE_DYNAMIC_CREDENTIALS_AWS")) {
+        if (workspaceEnvVariables.containsKey("ENABLE_DYNAMIC_CREDENTIALS_GCP")) {
             workspaceEnvVariables = dynamicCredentialsService.generateDynamicCredentialsGcp(job, workspaceEnvVariables);
         }
         return workspaceEnvVariables;

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -141,7 +141,7 @@ public class DynamicCredentialsService {
         log.info("TERRAKUBE_GCP_CREDENTIALS_CONFIG_FILE: {}", googleCredentialConfigFile);
 
         workspaceEnvVariables.put("TERRAKUBE_GCP_CREDENTIALS_FILE", Base64.getEncoder().encodeToString(googleCredentialsFile.getBytes(StandardCharsets.UTF_8)));
-        workspaceEnvVariables.put("TERRAKUBE_GCP_CREDENTIALS_CONFIG_FILE", Base64.getEncoder().encodeToString(googleCredentialsFile.getBytes(StandardCharsets.UTF_8)));
+        workspaceEnvVariables.put("TERRAKUBE_GCP_CREDENTIALS_CONFIG_FILE", Base64.getEncoder().encodeToString(googleCredentialConfigFile.getBytes(StandardCharsets.UTF_8)));
         workspaceEnvVariables.put("GOOGLE_APPLICATION_CREDENTIALS", executorDirectory + "/terrakube_config_dynamic_credentials.json");
 
         return workspaceEnvVariables;

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -141,7 +141,7 @@ public class DynamicCredentialsService {
 
         workspaceEnvVariables.put("TERRAKUBE_GCP_CREDENTIALS_FILE", Base64.getEncoder().encodeToString(googleCredentialsFile.getBytes(StandardCharsets.UTF_8)));
         workspaceEnvVariables.put("TERRAKUBE_GCP_CREDENTIALS_CONFIG_FILE", Base64.getEncoder().encodeToString(googleCredentialsFile.getBytes(StandardCharsets.UTF_8)));
-        workspaceEnvVariables.put("GOOGLE_APPLICATION_CREDENTIALS", executorDirectory);
+        workspaceEnvVariables.put("GOOGLE_APPLICATION_CREDENTIALS", executorDirectory + "/terrakube_dynamic_credentials.json");
 
         return workspaceEnvVariables;
     }

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -140,8 +140,8 @@ public class DynamicCredentialsService {
         log.info("TERRAKUBE_GCP_CREDENTIALS_FILE: {}", googleCredentialsFile);
         log.info("TERRAKUBE_GCP_CREDENTIALS_CONFIG_FILE: {}", googleCredentialConfigFile);
 
-        workspaceEnvVariables.put("TERRAKUBE_GCP_CREDENTIALS_FILE", Base64.getEncoder().encodeToString(googleCredentialsFile.getBytes(StandardCharsets.UTF_8)));
-        workspaceEnvVariables.put("TERRAKUBE_GCP_CREDENTIALS_CONFIG_FILE", Base64.getEncoder().encodeToString(googleCredentialConfigFile.getBytes(StandardCharsets.UTF_8)));
+        workspaceEnvVariables.put("TERRAKUBE_GCP_CREDENTIALS_FILE", googleCredentialsFile);
+        workspaceEnvVariables.put("TERRAKUBE_GCP_CREDENTIALS_CONFIG_FILE", googleCredentialConfigFile);
         workspaceEnvVariables.put("GOOGLE_APPLICATION_CREDENTIALS", executorDirectory + "/terrakube_config_dynamic_credentials.json");
 
         return workspaceEnvVariables;

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -126,7 +126,8 @@ public class DynamicCredentialsService {
                 "  }";
 
         String executorDirectory = String.format(
-                "/home/cnb/.terraform-spring-boot/executor/%s/%s",
+                "/%s/.terraform-spring-boot/executor/%s/%s",
+                FileUtils.getUserDirectoryPath(),
                 job.getOrganization().getId().toString(),
                 job.getWorkspace().getId().toString()
         );

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -141,7 +141,7 @@ public class DynamicCredentialsService {
 
         workspaceEnvVariables.put("TERRAKUBE_GCP_CREDENTIALS_FILE", Base64.getEncoder().encodeToString(googleCredentialsFile.getBytes(StandardCharsets.UTF_8)));
         workspaceEnvVariables.put("TERRAKUBE_GCP_CREDENTIALS_CONFIG_FILE", Base64.getEncoder().encodeToString(googleCredentialsFile.getBytes(StandardCharsets.UTF_8)));
-        workspaceEnvVariables.put("GOOGLE_APPLICATION_CREDENTIALS", executorDirectory + "/terrakube_dynamic_credentials.json");
+        workspaceEnvVariables.put("GOOGLE_APPLICATION_CREDENTIALS", executorDirectory + "/terrakube_config_dynamic_credentials.json");
 
         return workspaceEnvVariables;
     }

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -126,7 +126,7 @@ public class DynamicCredentialsService {
                 "  }";
 
         String executorDirectory = String.format(
-                "/%s/.terraform-spring-boot/executor/%s/%s",
+                "%s/.terraform-spring-boot/executor/%s/%s",
                 FileUtils.getUserDirectoryPath(),
                 job.getOrganization().getId().toString(),
                 job.getWorkspace().getId().toString()

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -126,7 +126,7 @@ public class DynamicCredentialsService {
                 "  }";
 
         String executorDirectory = String.format(
-                "/home/cnb/.terraform-spring-boot/executor/%s/%s/terrakube_config_dynamic_credentials.json",
+                "/home/cnb/.terraform-spring-boot/executor/%s/%s",
                 job.getOrganization().getId().toString(),
                 job.getWorkspace().getId().toString()
         );

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -53,4 +53,5 @@
     <include file="/db/changelog/local/changelog-2.20.0-executor-agent.xml"/>
     <include file="/db/changelog/local/changelog-2.20.0-registry-monorepo.xml"/>
     <include file="/db/changelog/local/changelog-2.21.0-auto-apply.xml"/>
+    <include file="/db/changelog/local/changelog-2.21.0-gcp-dynamic.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.21.0-gcp-dynamic.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.21.0-gcp-dynamic.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="40" author="alfespa17@gmail.com">
+        <modifyDataType
+                columnName="variable_key"
+                newDataType="varchar(64)"
+                tableName="variable"/>
+    </changeSet>
+</databaseChangeLog>

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutor.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutor.java
@@ -4,6 +4,7 @@ import org.terrakube.executor.service.executor.ExecutorJobResult;
 import org.terrakube.executor.service.mode.TerraformJob;
 
 import java.io.File;
+import java.io.IOException;
 
 public interface TerraformExecutor {
 

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -57,7 +57,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         }
     }
 
-    private File getTerraformWorkingDir(TerraformJob terraformJob, File workingDirectory) throws IOException {
+    public File getTerraformWorkingDir(TerraformJob terraformJob, File workingDirectory) throws IOException {
         File terraformWorkingDir = workingDirectory;
         try {
             if (!terraformJob.getBranch().equals("remote-content") || (terraformJob.getFolder() != null && !terraformJob.getFolder().equals("/"))) {

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -20,6 +20,7 @@ import org.eclipse.jgit.util.FS;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.terrakube.executor.service.mode.TerraformJob;
+import org.terrakube.executor.service.terraform.TerraformExecutor;
 import org.terrakube.executor.service.workspace.security.WorkspaceSecurity;
 
 import java.io.*;
@@ -42,10 +43,12 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
 
     WorkspaceSecurity workspaceSecurity;
     boolean enableRegistrySecurity;
+    TerraformExecutor terraformExecutor;
 
-    public SetupWorkspaceImpl(WorkspaceSecurity workspaceSecurity, @Value("${org.terrakube.client.enableSecurity}") boolean enableRegistrySecurity) {
+    public SetupWorkspaceImpl(WorkspaceSecurity workspaceSecurity, @Value("${org.terrakube.client.enableSecurity}") boolean enableRegistrySecurity, TerraformExecutor terraformExecutor) {
         this.workspaceSecurity = workspaceSecurity;
         this.enableRegistrySecurity = enableRegistrySecurity;
+        this.terraformExecutor = terraformExecutor;
     }
 
     @Override
@@ -58,16 +61,41 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
             } else {
                 downloadWorkspaceTarGz(workspaceCloneFolder, terraformJob.getSource());
             }
-            if(terraformJob.getModuleSshKey() != null && terraformJob.getModuleSshKey().length() > 0){
+            if (terraformJob.getModuleSshKey() != null && terraformJob.getModuleSshKey().length() > 0) {
                 generateModuleSshFolder(terraformJob.getModuleSshKey(), terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), terraformJob.getJobId());
             }
 
             if (enableRegistrySecurity)
                 workspaceSecurity.addTerraformCredentials();
+
+            if (terraformJob.getEnvironmentVariables().containsKey("ENABLE_DYNAMIC_CREDENTIALS_GCP")) {
+                setupGcpDynamicCredentials(
+                        workspaceCloneFolder,
+                        terraformJob.getEnvironmentVariables().get("TERRAKUBE_GCP_CREDENTIALS_FILE"),
+                        terraformJob.getEnvironmentVariables().get("TERRAKUBE_GCP_CREDENTIALS_CONFIG_FILE")
+                );
+            }
         } catch (IOException e) {
             log.error(e.getMessage());
         }
         return workspaceCloneFolder != null ? workspaceCloneFolder : new File("/tmp/" + UUID.randomUUID());
+    }
+
+    private void setupGcpDynamicCredentials(File workspaceCloneFolder, String gcpCredentialsFileContent, String gcpCredentialConfigFileContent) {
+        try {
+            log.info("Generating GCP dynamic credentials files inside the workspace execution");
+            String gcpCredentialsFile = Base64.getDecoder().decode(gcpCredentialsFileContent).toString();
+            String gcpCredentialsConfigFile = Base64.getDecoder().decode(gcpCredentialConfigFileContent).toString();
+
+            log.info("WorkingDir: {}", workspaceCloneFolder);
+            log.info("Writing GCP credentials to {}/terrakube_dynamic_credentials.json", workspaceCloneFolder.getAbsolutePath());
+            log.info("Writing GCP credentials Configuration File to {}/terrakube_config_dynamic_credentials.json", workspaceCloneFolder.getAbsolutePath());
+
+            FileUtils.writeStringToFile(new File(workspaceCloneFolder.getAbsolutePath() + "/terrakube_dynamic_credentials.json"), gcpCredentialsFile, Charset.defaultCharset());
+            FileUtils.writeStringToFile(new File(workspaceCloneFolder.getAbsolutePath() + "/terrakube_config_dynamic_credentials.json"), gcpCredentialsConfigFile, Charset.defaultCharset());
+        } catch (Exception ex) {
+            log.error(ex.getMessage());
+        }
     }
 
     private File setupWorkspaceDirectory(String organizationId, String workspaceId) throws IOException {
@@ -101,7 +129,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
                         .setBranch(terraformJob.getBranch())
                         .call();
 
-                if(terraformJob.getCommitId() != null && terraformJob.getCommitId().length() > 0) {
+                if (terraformJob.getCommitId() != null && terraformJob.getCommitId().length() > 0) {
                     log.info("Checkout commit id {}", terraformJob.getCommitId());
                     Git.open(gitCloneFolder).checkout().setName(terraformJob.getCommitId()).call();
                     getCommitId(gitCloneFolder, terraformJob.getCommitId());
@@ -186,7 +214,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
     private void getCommitId(File gitCloneFolder, String commitId) {
         RevCommit latestCommit = null;
         try {
-            if(commitId == null) {
+            if (commitId == null) {
                 latestCommit = Git.init().setDirectory(gitCloneFolder).call().
                         log().
                         setMaxCount(1).

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -84,15 +84,13 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
     private void setupGcpDynamicCredentials(File workspaceCloneFolder, String gcpCredentialsFileContent, String gcpCredentialConfigFileContent) {
         try {
             log.info("Generating GCP dynamic credentials files inside the workspace execution");
-            String gcpCredentialsFile = Base64.getDecoder().decode(gcpCredentialsFileContent).toString();
-            String gcpCredentialsConfigFile = Base64.getDecoder().decode(gcpCredentialConfigFileContent).toString();
 
             log.info("WorkingDir: {}", workspaceCloneFolder);
             log.info("Writing GCP credentials to {}/terrakube_dynamic_credentials.json", workspaceCloneFolder.getAbsolutePath());
             log.info("Writing GCP credentials Configuration File to {}/terrakube_config_dynamic_credentials.json", workspaceCloneFolder.getAbsolutePath());
 
-            FileUtils.writeStringToFile(new File(workspaceCloneFolder.getAbsolutePath() + "/terrakube_dynamic_credentials.json"), gcpCredentialsFile, Charset.defaultCharset());
-            FileUtils.writeStringToFile(new File(workspaceCloneFolder.getAbsolutePath() + "/terrakube_config_dynamic_credentials.json"), gcpCredentialsConfigFile, Charset.defaultCharset());
+            FileUtils.writeStringToFile(new File(workspaceCloneFolder.getAbsolutePath() + "/terrakube_dynamic_credentials.json"), gcpCredentialsFileContent, Charset.defaultCharset());
+            FileUtils.writeStringToFile(new File(workspaceCloneFolder.getAbsolutePath() + "/terrakube_config_dynamic_credentials.json"), gcpCredentialConfigFileContent, Charset.defaultCharset());
         } catch (Exception ex) {
             log.error(ex.getMessage());
         }


### PR DESCRIPTION
Adding support to use gcp dynami provider credential support:

Inside our GCP project we need to do the following:

Add a new workload identity federation

![image](https://github.com/AzBuilder/terrakube/assets/4461895/3189cfa1-0d2c-43ee-a03a-3a216a67fbb2)

Add a name to the identity pool.

![image](https://github.com/AzBuilder/terrakube/assets/4461895/34d920fc-ba4b-4b1c-a74a-0a531e04b3d9)

Select OIDC , add a provider name, use the terrakube api for the issuer URL and leave the default audience

![image](https://github.com/AzBuilder/terrakube/assets/4461895/74618372-2a70-4a3b-9e05-859ea7e64981)

Setup the provider attributes

the attribute mapping should look like the following:

OIDC 1:

```
assertion.sub
```

Condition CEL

```
assertion.sub.startsWith("organization:TERRAKUBE_ORGANIZATION_NAME:workspace:TERRAKUBE_WORKSPACE_NAME")
```

![image](https://github.com/AzBuilder/terrakube/assets/4461895/552e7c5e-7fc8-4b49-a6b7-a4d3d4bd735d)

Once created we can copy the audience and just remove the "https:"

![image](https://github.com/AzBuilder/terrakube/assets/4461895/7e22eddd-a960-4a01-9ca1-e2037be147ef)

Finally we need to grant access to one particular gcp service account.

![image](https://github.com/AzBuilder/terrakube/assets/4461895/d9afc98e-edfb-45bc-ab56-984800eebcc3)


We need to define the following env variables inside the workspace configuration:

- ENABLE_DYNAMIC_CREDENTIALS_GCP=true
- WORKLOAD_IDENTITY_SERVICE_ACCOUNT_EMAIL=xxxx@xxxx.iam.gserviceaccount.com
- WORKLOAD_IDENTITY_AUDIENCE_GCP=//iam.googleapis.com/projects/{{PROJECT-NUMBER}}/locations/global/workloadIdentityPools/{{PROJECT_NAME}}/providers/{{PROVIDER}}


![image](https://github.com/AzBuilder/terrakube/assets/4461895/e68a6583-6a1c-43e4-8550-caf784d46de3)

![image](https://github.com/AzBuilder/terrakube/assets/4461895/a7030cf8-418f-4b7d-82f8-5295b7fd470f)

Example:

```
user@pop-os:~/git/dynamic_creds$ terraform init

Initializing Terraform Cloud...

Initializing provider plugins...
- Finding latest version of hashicorp/google...
- Installing hashicorp/google v5.26.0...
- Installed hashicorp/google v5.26.0 (signed by HashiCorp)

Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform Cloud has been successfully initialized!

You may now begin working with Terraform Cloud. Try running "terraform plan" to
see any changes that are required for your infrastructure.

If you ever set or change modules or Terraform Settings, run "terraform init"
again to reinitialize your working directory.
user@pop-os:~/git/dynamic_creds$ terraform apply

Running apply in Terraform Cloud. Output will stream here. Pressing Ctrl-C
will cancel the remote apply if it's still pending. If the apply started it
will stop streaming the logs, but will not stop the apply running remotely.

Preparing the remote apply...

To view this run in a browser, visit:
https://8080-azbuilder-terrakube-2vs2w68kc0p.ws-us110.gitpod.io/app/simple/simple/runs/3

Waiting for the plan to start...

***************************************
Running Terraform PLAN
***************************************

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_storage_bucket.auto-expire will be created
  + resource "google_storage_bucket" "auto-expire" {
      + effective_labels            = (known after apply)
      + force_destroy               = true
      + id                          = (known after apply)
      + location                    = "US"
      + name                        = "asdfadsfqerqer1fgsdfgt"
      + project                     = (known after apply)
      + project_number              = (known after apply)
      + public_access_prevention    = "enforced"
      + rpo                         = (known after apply)
      + self_link                   = (known after apply)
      + storage_class               = "STANDARD"
      + terraform_labels            = (known after apply)
      + uniform_bucket_level_access = (known after apply)
      + url                         = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.


Do you want to perform these actions in workspace "simple"?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

google_storage_bucket.auto-expire: Creating...
google_storage_bucket.auto-expire: Creation complete after 1s [id=asdfadsfqerqer1fgsdfgt]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

```