### PR TITLE
Remove ui.env in docker-compose [skip ci]

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -14,8 +14,6 @@ services:
       - 3000:8080
     volumes:
     - ./env-config.js:/app/env-config.js
-    env_file:
-      - ui.env 
   terrakube-executor:
     image: azbuilder/executor:2.20.0
     ports: 

--- a/docker-compose/ui.env
+++ b/docker-compose/ui.env
@@ -1,6 +1,0 @@
-REACT_APP_TERRAKUBE_API_URL=http://terrakube-api:8080/api/v1/
-REACT_APP_CLIENT_ID=example-app
-REACT_APP_AUTHORITY=http://terrakube-dex:5556/dex
-REACT_APP_REDIRECT_URI=http://terrakube-ui:3000
-REACT_APP_REGISTRY_URI=http://terrakube-registry:8075
-REACT_APP_SCOPE=email openid profile offline_access groups


### PR DESCRIPTION
Remove ui.env is not really need it anymore when using docker-compose