### PR TITLE
Add hostname in CLI driven workflow example

### DIFF
--- a/ui/src/domain/Workspaces/CLIDriven.jsx
+++ b/ui/src/domain/Workspaces/CLIDriven.jsx
@@ -36,7 +36,7 @@ export const CLIDriven = ({ organizationName, workspaceName }) => {
                     <pre className="moduleCode">
                       terraform {"{"} <br />
                       &nbsp;&nbsp;cloud {"{"} <br />
-                        &nbsp;&nbsp;&nbsp;&nbsp;hostname = "{new URL(window._env_.REACT_APP_REGISTRY_URI).hostname}}"<br/>
+                        &nbsp;&nbsp;&nbsp;&nbsp;hostname = "{new URL(window._env_.REACT_APP_REGISTRY_URI).hostname}"<br/>
                       &nbsp;&nbsp;&nbsp;&nbsp;organization = "{organizationName}
                       " <br />
                       <br />
@@ -56,7 +56,7 @@ export const CLIDriven = ({ organizationName, workspaceName }) => {
                       <pre className="moduleCode">
                       terraform {"{"} <br/>
                           &nbsp;&nbsp;backend "remote" {"{"} <br/>
-                          &nbsp;&nbsp;&nbsp;&nbsp;hostname = "{new URL(window._env_.REACT_APP_REGISTRY_URI).hostname}}"<br/>
+                          &nbsp;&nbsp;&nbsp;&nbsp;hostname = "{new URL(window._env_.REACT_APP_REGISTRY_URI).hostname}"<br/>
                           &nbsp;&nbsp;&nbsp;&nbsp;organization = "{organizationName}
                           " <br/>
                       <br/>

--- a/ui/src/domain/Workspaces/CLIDriven.jsx
+++ b/ui/src/domain/Workspaces/CLIDriven.jsx
@@ -36,7 +36,7 @@ export const CLIDriven = ({ organizationName, workspaceName }) => {
                     <pre className="moduleCode">
                       terraform {"{"} <br />
                       &nbsp;&nbsp;cloud {"{"} <br />
-                        &nbsp;&nbsp;&nbsp;&nbsp;hostname = "{new URL(window._env_.REACT_APP_REGISTRY_URI).hostname}"<br/>
+                        &nbsp;&nbsp;&nbsp;&nbsp;hostname = "{new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).hostname}"<br/>
                       &nbsp;&nbsp;&nbsp;&nbsp;organization = "{organizationName}
                       " <br />
                       <br />
@@ -56,7 +56,7 @@ export const CLIDriven = ({ organizationName, workspaceName }) => {
                       <pre className="moduleCode">
                       terraform {"{"} <br/>
                           &nbsp;&nbsp;backend "remote" {"{"} <br/>
-                          &nbsp;&nbsp;&nbsp;&nbsp;hostname = "{new URL(window._env_.REACT_APP_REGISTRY_URI).hostname}"<br/>
+                          &nbsp;&nbsp;&nbsp;&nbsp;hostname = "{new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).hostname}"<br/>
                           &nbsp;&nbsp;&nbsp;&nbsp;organization = "{organizationName}
                           " <br/>
                       <br/>

--- a/ui/src/domain/Workspaces/CLIDriven.jsx
+++ b/ui/src/domain/Workspaces/CLIDriven.jsx
@@ -36,6 +36,7 @@ export const CLIDriven = ({ organizationName, workspaceName }) => {
                     <pre className="moduleCode">
                       terraform {"{"} <br />
                       &nbsp;&nbsp;cloud {"{"} <br />
+                        &nbsp;&nbsp;&nbsp;&nbsp;hostname = "{new URL(window._env_.REACT_APP_REGISTRY_URI).hostname}}"<br/>
                       &nbsp;&nbsp;&nbsp;&nbsp;organization = "{organizationName}
                       " <br />
                       <br />
@@ -52,18 +53,19 @@ export const CLIDriven = ({ organizationName, workspaceName }) => {
                   label: "remote backend",
                   key: "2",
                   children: (
-                    <pre className="moduleCode">
-                      terraform {"{"} <br />
-                      &nbsp;&nbsp;backend "remote" {"{"} <br />
-                      &nbsp;&nbsp;&nbsp;&nbsp;organization = "{organizationName}
-                      " <br />
-                      <br />
-                      &nbsp;&nbsp;&nbsp;&nbsp;workspaces {"{"} <br />
-                      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name = "
-                      {workspaceName}" <br />
-                      &nbsp;&nbsp;&nbsp;&nbsp;{"}"} <br />
-                      &nbsp;&nbsp;{"}"} <br />
-                      {"}"} <br />
+                      <pre className="moduleCode">
+                      terraform {"{"} <br/>
+                          &nbsp;&nbsp;backend "remote" {"{"} <br/>
+                          &nbsp;&nbsp;&nbsp;&nbsp;hostname = "{new URL(window._env_.REACT_APP_REGISTRY_URI).hostname}}"<br/>
+                          &nbsp;&nbsp;&nbsp;&nbsp;organization = "{organizationName}
+                          " <br/>
+                      <br/>
+                          &nbsp;&nbsp;&nbsp;&nbsp;workspaces {"{"} <br/>
+                          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name = "
+                          {workspaceName}" <br/>
+                          &nbsp;&nbsp;&nbsp;&nbsp;{"}"} <br/>
+                          &nbsp;&nbsp;{"}"} <br/>
+                          {"}"} <br/>
                     </pre>
                   ),
                 },


### PR DESCRIPTION
Adding hostname in the CLI driven workflow example for remote and cloud backend

![image](https://github.com/AzBuilder/terrakube/assets/4461895/2201dff2-179d-47cf-875d-2b3b624f1f03)

![image](https://github.com/AzBuilder/terrakube/assets/4461895/44277547-9638-4f29-9c86-436532abf7a3)


Fix #835 