### PR TITLE
AWS Dynamic provider credentials support

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -101,7 +101,7 @@ public class DynamicCredentialsService {
         log.info("TERRAKUBE_AWS_CREDENTIALS_FILE: {}", awsWebIdentityToken);
 
         workspaceEnvVariables.put("TERRAKUBE_AWS_CREDENTIALS_FILE", awsWebIdentityToken);
-        workspaceEnvVariables.put("AWS_ROLE_ARN", workspaceEnvVariables.get("WORKLOAD_IDENTITY_AUDIENCE_AWS"));
+        workspaceEnvVariables.put("AWS_ROLE_ARN", workspaceEnvVariables.get("WORKLOAD_IDENTITY_ROLE_AWS"));
         workspaceEnvVariables.put("AWS_WEB_IDENTITY_TOKEN_FILE", getDefaultExecutorPath(job) + "/terrakube_config_dynamic_credentials_aws.txt");
 
         return workspaceEnvVariables;

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -68,11 +68,19 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
             if (enableRegistrySecurity)
                 workspaceSecurity.addTerraformCredentials();
 
+            log.info("Executor WorkingDir: {}", workspaceCloneFolder);
             if (terraformJob.getEnvironmentVariables().containsKey("ENABLE_DYNAMIC_CREDENTIALS_GCP")) {
                 setupGcpDynamicCredentials(
                         workspaceCloneFolder,
                         terraformJob.getEnvironmentVariables().get("TERRAKUBE_GCP_CREDENTIALS_FILE"),
                         terraformJob.getEnvironmentVariables().get("TERRAKUBE_GCP_CREDENTIALS_CONFIG_FILE")
+                );
+            }
+
+            if (terraformJob.getEnvironmentVariables().containsKey("ENABLE_DYNAMIC_CREDENTIALS_AWS")) {
+                setupAwsDynamicCredentials(
+                        workspaceCloneFolder,
+                        terraformJob.getEnvironmentVariables().get("TERRAKUBE_AWS_CREDENTIALS_FILE")
                 );
             }
         } catch (IOException e) {
@@ -81,11 +89,20 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
         return workspaceCloneFolder != null ? workspaceCloneFolder : new File("/tmp/" + UUID.randomUUID());
     }
 
+    private void setupAwsDynamicCredentials(File workspaceCloneFolder, String awsCredentialsFileContent ) {
+        try {
+            log.info("Generating AWS dynamic credentials files inside the workspace execution");
+            log.info("Writing AWS credentials to {}/terrakube_config_dynamic_credentials_aws.txt", workspaceCloneFolder.getAbsolutePath());
+            FileUtils.writeStringToFile(new File(workspaceCloneFolder.getAbsolutePath() + "/terrakube_config_dynamic_credentials_aws.txt"), awsCredentialsFileContent, Charset.defaultCharset());
+            } catch (Exception ex) {
+            log.error(ex.getMessage());
+        }
+    }
+
     private void setupGcpDynamicCredentials(File workspaceCloneFolder, String gcpCredentialsFileContent, String gcpCredentialConfigFileContent) {
         try {
             log.info("Generating GCP dynamic credentials files inside the workspace execution");
 
-            log.info("WorkingDir: {}", workspaceCloneFolder);
             log.info("Writing GCP credentials to {}/terrakube_dynamic_credentials.json", workspaceCloneFolder.getAbsolutePath());
             log.info("Writing GCP credentials Configuration File to {}/terrakube_config_dynamic_credentials.json", workspaceCloneFolder.getAbsolutePath());
 


### PR DESCRIPTION
Adding support to use AWS dynamic provider credential support.

We need to define the following environment variables inside the workspace configuration:

- ENABLE_DYNAMIC_CREDENTIALS_AWS=true
- WORKLOAD_IDENTITY_AUDIENCE_AWS=aws.workload.identity
- WORKLOAD_IDENTITY_ROLE_AWS=XXXXXXXXX
- AWS_REGION=XXXXXXXXX

## AWS Setup with Terraform

To setup the federeated credentials in AWS we can use the following terraform code:

> The aws_iam_policy can be customize in this case we will use it just to deploy S3 as an example

```terraform
provider "aws" {

}

variable "terrakube_api_hostname" {
  type        = string
  default     = "terrakube-api.minikube.net"
  description = "The terrakube API hostname example: terrakube-api.minikube.net"
}

variable "terrakube_federated_credentials_audience" {
  type        = string
  default     = "aws.workload.identity"
  description = "Audience for the federated credentials"
}

variable "terrakube_organization" {
  type        = string
  default     = "simple"
  description = "Audience for the federated credentials"
}

variable "terrakube_workspace" {
  type        = string
  default     = "simple"
  description = "Audience for the federated credentials"
}

data "tls_certificate" "terrakube_certificate" {
  url = "https://${var.terrakube_api_hostname}"
}

resource "aws_iam_openid_connect_provider" "terrakube_provider" {
  url             = data.tls_certificate.terrakube_certificate.url
  client_id_list  = [var.terrakube_federated_credentials_audience]
  thumbprint_list = [data.tls_certificate.terrakube_certificate.certificates[0].sha1_fingerprint]
}

resource "aws_iam_role" "terrakube_role" {
  name = "terrakube-role"

  assume_role_policy = <<EOF
{
 "Version": "2012-10-17",
 "Statement": [
   {
     "Effect": "Allow",
     "Principal": {
       "Federated": "${aws_iam_openid_connect_provider.terrakube_provider.arn}"
     },
     "Action": "sts:AssumeRoleWithWebIdentity",
     "Condition": {
        "StringEquals": {
        "${var.terrakube_api_hostname}:aud": "${var.terrakube_federated_credentials_audience}",
        "${var.terrakube_api_hostname}:sub": "organization:${var.terrakube_organization}:workspace:${var.terrakube_workspace}"
        }
     }
   }
 ]
}
EOF
}

resource "aws_iam_policy" "terrakube_policy" {
  name        = "terrakube-policy"
  description = "terrakube policy"

  policy = <<EOF
{
 "Version": "2012-10-17",
 "Statement": [
   {
     "Effect": "Allow",
     "Action": [
       "s3:*"
     ],
     "Resource": "*"
   }
 ]
}
EOF
}

resource "aws_iam_role_policy_attachment" "terrakube_policy_attachment" {
  role       = aws_iam_role.terrakube_role.name
  policy_arn = aws_iam_policy.terrakube_policy.arn
}

output "role_arn" {
  value = aws_iam_role.terrakube_role.arn
}
```

## Terraform Code Example

```
provider "aws" {

}

terraform {

  cloud {
    organization = "simple"
    hostname = "TERRAKUBE.API.COM"

    workspaces {
      name = "simple-cli"
    }
  }
}

resource "aws_s3_bucket" "example" {
  bucket = "my-tf-test-asdfafasfqerqrqw"

  tags = {
    Name        = "My bucket"
    Environment = "Dev"
  }
}
```

We could also use the following variables.auto.tfvars as an example:

```
terrakube_api_hostname = "terrakube-api.minikube.net"
terrakube_federated_credentials_audience="aws.workload.identity"
terrakube_organization="simple"
terrakube_workspace = "simple-cli"
```

## Workspace Example

![image](https://github.com/AzBuilder/terrakube/assets/4461895/08000665-c77c-41c3-83cb-d6b939d1ef38)

![image](https://github.com/AzBuilder/terrakube/assets/4461895/bd5caf09-1943-47ec-bed8-816170185427)


## Internal Logic

Terrakube will generate the JWT token that is documented in this [page](https://docs.terrakube.io/user-guide/workspaces/dynamic-provider-credentials#token-structure) and will generate a file called "terrakube_config_dynamic_credentials_aws.txt" inside the workspace execution path inside the executor component

Terrakube will add the environment variables dynamically to the workspace execution:
-  "AWS_ROLE_ARN" based on the workspace setup using the value from "WORKLOAD_IDENTITY_AUDIENCE_AWS" 
-  "AWS_WEB_IDENTITY_TOKEN_FILE" with the workspace execution path with the JWT token generated by Terrakube.

Reference:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs#assuming-an-iam-role-using-a-web-identity