### PR TITLE
GCP Dynamic Provider Credentials Setup example with Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ bindings/ca-certificates/terrakubeDemo2.pem
 
 private.pem
 public.pem
+
+*.terraform*
+terraform.tfstate
+terraform.tfstate.backup
+variables.auto.tfvars

--- a/dynamic-credential-setup/gcp/README.md
+++ b/dynamic-credential-setup/gcp/README.md
@@ -1,0 +1,55 @@
+# Setup Terrakube Dynamic Credentials (AWS)
+
+## Requirements
+
+Make sure to mount your public and private key to the API container as explained [here](https://docs.terrakube.io/user-guide/workspaces/dynamic-provider-credentials#generate-public-and-private-key)
+
+Validate the following endpoints are working:
+
+- https://terrakube-api.mydomain.com/.well-known/jwks
+- https://terrakube-api.mydomain.com/.well-known/openid-configuration
+
+Set terraform variables using: ***"variables.auto.tfvars"***
+
+```terraform
+terrakube_token = "TERRAKUBE_PERSONAL_ACCESS_TOKEN"
+terrakube_hostname = "terrakube-api.mydomain.com"
+terrakube_organization_name = "simple"
+terrakube_workspace_name = "dynamic-workspace"
+gcp_project_id = "my-gcp-project"
+```
+
+> To generate the API token check [here](https://docs.terrakube.io/user-guide/organizations/api-tokens)
+
+Run Terraform apply to create all the federated credential setup in GCP and a sample workspace in terrakube for testing
+
+To test the following terraform code can be used:
+
+
+```terraform
+terraform {
+
+  cloud {
+    organization = "terrakube_organization_name"
+    hostname = "terrakube-api.mydomain.com"
+
+    workspaces {
+      name = "terrakube_workspace_name"
+    }
+  }
+}
+
+provider "google" {
+  project     = "my-gcp-project"
+  region      = "us-central1"
+  zone        = "us-central1-c"
+}
+
+resource "google_storage_bucket" "auto-expire" {
+  name          = "mysuperbukcetname"
+  location      = "US"
+  force_destroy = true
+
+  public_access_prevention = "enforced"
+}
+```

--- a/dynamic-credential-setup/gcp/datasource.tf
+++ b/dynamic-credential-setup/gcp/datasource.tf
@@ -1,0 +1,6 @@
+data "google_project" "project" {
+}
+
+data "terrakube_organization" "org" {
+  name = var.terrakube_organization_name
+}

--- a/dynamic-credential-setup/gcp/main.tf
+++ b/dynamic-credential-setup/gcp/main.tf
@@ -1,0 +1,103 @@
+resource "google_project_service" "services" {
+  count   = length(var.gcp_service_list)
+  service = var.gcp_service_list[count.index]
+}
+
+resource "random_string" "random" {
+  length           = 3
+  special          = false
+  lower = true
+  upper = false
+  numeric = false
+}
+
+locals {
+  workload_identity_pool_id = format("terrakube-pool%s",random_string.random.result)
+  workload_identity_pool_provider_id = format("terrakube-provider-%s",random_string.random.result)
+}
+
+resource "google_iam_workload_identity_pool" "terrakube_pool" {
+  workload_identity_pool_id = local.workload_identity_pool_id
+}
+
+resource "google_iam_workload_identity_pool_provider" "terrakube_provider" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.terrakube_pool.workload_identity_pool_id
+  workload_identity_pool_provider_id = local.workload_identity_pool_provider_id
+  attribute_mapping = {
+    "google.subject"                      = "assertion.sub",
+    "attribute.aud"                       = "assertion.aud",
+    "attribute.terrakube_workspace_id"    = "assertion.terrakube_workspace_id",
+    "attribute.terrakube_organization_id" = "assertion.terrakube_organization_id",
+    "attribute.terrakube_job_id"          = "assertion.terrakube_job_id"
+  }
+  oidc {
+    issuer_uri = "https://${var.terrakube_hostname}"
+  }
+  attribute_condition = "assertion.sub.startsWith(\"organization:${var.terrakube_organization_name}:workspace:${var.terrakube_workspace_name}\")"
+
+  depends_on = [ google_iam_workload_identity_pool.terrakube_pool ]
+}
+
+resource "google_service_account" "terrakube_service_account" {
+  account_id   = "terrakube-service-account${random_string.random.result}"
+  display_name = "Service Account${random_string.random.result}"
+}
+
+resource "google_service_account_iam_member" "terrakube_service_account_member" {
+  service_account_id = google_service_account.terrakube_service_account.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.terrakube_pool.name}/*"
+}
+
+resource "google_project_iam_member" "terrakube_project_member" {
+  project = var.gcp_project_id
+  role    = "roles/editor"
+  member  = "serviceAccount:${google_service_account.terrakube_service_account.email}"
+}
+
+resource "terrakube_workspace_cli" "dynamic_credentials_workspace" {
+  organization_id = data.terrakube_organization.org.id
+  name            = var.terrakube_workspace_name
+  description     = "Sample description"
+  execution_mode  = "remote"
+  iac_type        = "terraform"
+  iac_version     = "1.5.7"
+
+  depends_on = [ data.terrakube_organization.org ]
+}
+
+
+resource "terrakube_workspace_variable" "env1" {
+  organization_id = data.terrakube_organization.org.id
+  workspace_id    = terrakube_workspace_cli.dynamic_credentials_workspace.id
+  key             = "ENABLE_DYNAMIC_CREDENTIALS_GCP"
+  value           = "true"
+  description     = "ENABLE_DYNAMIC_CREDENTIALS_GCP"
+  category        = "ENV"
+  sensitive       = false
+  hcl             = false
+}
+
+
+resource "terrakube_workspace_variable" "env2" {
+  organization_id = data.terrakube_organization.org.id
+  workspace_id    = terrakube_workspace_cli.dynamic_credentials_workspace.id
+  key             = "WORKLOAD_IDENTITY_SERVICE_ACCOUNT_EMAIL"
+  value           = google_service_account.terrakube_service_account.email
+  description     = "WORKLOAD_IDENTITY_SERVICE_ACCOUNT_EMAIL"
+  category        = "ENV"
+  sensitive       = false
+  hcl             = false
+}
+
+
+resource "terrakube_workspace_variable" "env3" {
+  organization_id = data.terrakube_organization.org.id
+  workspace_id    = terrakube_workspace_cli.dynamic_credentials_workspace.id
+  key             = "WORKLOAD_IDENTITY_AUDIENCE_GCP"
+  value           = "//iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.terrakube_pool.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.terrakube_provider.workload_identity_pool_provider_id}"
+  description     = "WORKLOAD_IDENTITY_AUDIENCE_GCP"
+  category        = "ENV"
+  sensitive       = false
+  hcl             = false
+}

--- a/dynamic-credential-setup/gcp/output.tf
+++ b/dynamic-credential-setup/gcp/output.tf
@@ -1,0 +1,12 @@
+
+output "audience" {
+  value = "//iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.terrakube_pool.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.terrakube_provider.workload_identity_pool_provider_id}"
+}
+
+output "service_account_email" {
+  value = google_service_account.terrakube_service_account.email
+}
+
+output "terrakube_org_id" {
+  value = data.terrakube_organization.org.id
+}

--- a/dynamic-credential-setup/gcp/provider.tf
+++ b/dynamic-credential-setup/gcp/provider.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    terrakube = {
+      source = "AzBuilder/terrakube"
+    }
+  }
+}
+
+provider "google" {
+  project = var.gcp_project_id
+  region  = "global"
+}
+
+provider "terrakube" {
+  endpoint = "https://${var.terrakube_hostname}"
+  token = var.terrakube_token
+}

--- a/dynamic-credential-setup/gcp/variables.tf
+++ b/dynamic-credential-setup/gcp/variables.tf
@@ -1,0 +1,36 @@
+variable "terrakube_token" {
+  type = string
+}
+
+variable "terrakube_hostname" {
+  type        = string
+  default     = "app.terraform.io"
+  description = "The hostname Terrakube instance you'd like to use with GCP"
+}
+
+variable "terrakube_organization_name" {
+  type        = string
+  description = "The name of your Terrakube organization"
+}
+
+variable "terrakube_workspace_name" {
+  type        = string
+  default     = "my-gcp-workspace"
+  description = "The name of the workspace that you'd like to create and connect to GCP"
+}
+
+variable "gcp_project_id" {
+  type        = string
+  description = "The ID for your GCP project"
+}
+
+variable "gcp_service_list" {
+  description = "APIs required for the project"
+  type        = list(string)
+  default = [
+    "iam.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "sts.googleapis.com",
+    "iamcredentials.googleapis.com"
+  ]
+}


### PR DESCRIPTION
Adding small terraform code to setup the dynamic credentials in GCP and how to test using a simple workspace in terrakube using the remote CLI driven workflow