### PR TITLE
Fix failed plan login in CLI driven workflow 

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -50,7 +50,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>3.1.10</version>
                 <configuration>
                 <image>
                     <builder>${buildpack.builder}</builder>

--- a/executor/src/main/java/org/terrakube/executor/plugin/tfstate/azure/AzureTerraformStateImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/plugin/tfstate/azure/AzureTerraformStateImpl.java
@@ -159,7 +159,7 @@ public class AzureTerraformStateImpl implements TerraformState {
                         log.info("Downloading state from {}:", stateUrl);
 
                         URL blobURL = new URL(stateUrl);
-                        String blobName = blobURL.getPath().replace("/tfstate/", "");
+                        String blobName = blobURL.getPath().replace("/tfstate/", "").replace("%2F","/");
 
                         log.info("BlobName: {}", blobName);
 

--- a/executor/src/main/java/org/terrakube/executor/service/status/UpdateJobStatusImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/status/UpdateJobStatusImpl.java
@@ -80,6 +80,7 @@ public class UpdateJobStatusImpl implements UpdateJobStatus {
                         break;
                     case 1:
                         status = "failed";
+                        planChanges = false;
                         break;
                     case 2:
                         status = "pending";

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.10</version>
+        <version>3.1.12</version>
     </parent>
 
     <groupId>org.terrakube</groupId>


### PR DESCRIPTION
Fix failed plan was asking for confirmation and one small issue with the azure backend storage when downloading the terraform plan in the executor logic

![image](https://github.com/AzBuilder/terrakube/assets/4461895/e0dde0c0-bcf1-4ea4-89ee-eeaffc88de47)
