### PR TITLE
fix: the endpoint of api importer

### DIFF
--- a/ui/src/domain/Workspaces/Import.jsx
+++ b/ui/src/domain/Workspaces/Import.jsx
@@ -280,7 +280,7 @@ export const ImportWorkspace = () => {
       const response = await axiosInstance.post(
         `${
           new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin
-        }/importer/tfcloud/workspaces/`,
+        }/importer/tfcloud/workspaces`,
         {
           organizationId: organizationId,
           vcsId: vcsId,


### PR DESCRIPTION
With slash in the end of the endpoint, terrakube api returns status code 404