### PR TITLE
Update Elide Swagger configuration to Elide API Docs

### DIFF
--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -23,8 +23,9 @@ elide.json-api.path=/api/v1
 elide.json-api.enabled=true
 elide.graphql.path=/graphql/api/v1
 elide.graphql.enabled=true
-elide.swagger.path=/doc
-elide.swagger.enabled=true
+elide.api-docs.path=/doc
+elide.api-docs.enabled=true
+elide.api-docs.version=openapi_3_0
 
 ######################
 #ENABLE ELIDE FILTERS#

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -23,8 +23,9 @@ elide.json-api.path=/api/v1
 elide.json-api.enabled=true
 elide.graphql.path=/graphql/api/v1
 elide.graphql.enabled=true
-elide.swagger.path=/doc
-elide.swagger.enabled=true
+elide.api-docs.path=/doc
+elide.api-docs.enabled=true
+elide.api-docs.version=openapi_3_0
 
 ######################
 #ENABLE ELIDE FILTERS#


### PR DESCRIPTION
This commit updates the Elide Swagger configuration in both "application-demo.properties" and "application.properties". The updates change Swagger paths and enablement to conform to the new Elide API Docs configuration, as well as setting the API Docs version to "openapi_3_0".

![image](https://github.com/AzBuilder/terrakube/assets/4461895/fc6ff244-c924-48cc-a21f-2e962da38d33)

![image](https://github.com/AzBuilder/terrakube/assets/4461895/8fab784c-fb0c-4576-83c5-cb117c0cccb9)


Fix #1005 