### PR TITLE
fix: workspace duplicate name handling causes unhandled 500 errors in UI

### DIFF
--- a/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
@@ -46,7 +46,7 @@ public class Workspace extends GenericAuditFields {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(name = "name")
+    @Column(name = "name", unique = true)
     private String name;
 
     @Column(name = "description")

--- a/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
@@ -46,7 +46,7 @@ public class Workspace extends GenericAuditFields {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(name = "name", unique = true)
+    @Column(name = "name")
     private String name;
 
     @Column(name = "description")

--- a/ui/src/domain/Workspaces/Create.jsx
+++ b/ui/src/domain/Workspaces/Create.jsx
@@ -358,6 +358,13 @@ export const CreateWorkspace = () => {
               </span>
             );
           }
+          else {
+            message.error(
+              <span>
+                An error occurred while submitting the workspace. Please contact your system administrator.
+              </span>
+            )
+          }
         }
       });
   };


### PR DESCRIPTION
How to reproduce:

1. Create a workspace with a name - for example test-iac, save it
2. Create another workspace with the same name 
3. 
<img width="1093" alt="Screenshot 2024-06-25 at 14 24 30" src="https://github.com/AzBuilder/terrakube/assets/60350753/2f15b257-5319-4331-97fc-12276ba3995c">
