### PR TITLE
Ephemeral Executor Support

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -40,6 +40,7 @@
         </sonar.coverage.jacoco.xmlReportPaths>
         <maven-artifact.version>3.8.8</maven-artifact.version>
         <commons-io.version>2.16.1</commons-io.version>
+        <kubernetes-client.version>6.13.1</kubernetes-client.version>
         <!--BUILDPACK DATA-->
         <buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.292</buildpack.builder>
         <buildpack.java>gcr.io/paketo-buildpacks/java:13.0.1</buildpack.java>
@@ -315,6 +316,12 @@
             <version>9.37.3</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+            <version>${kubernetes-client.version}</version>
+        </dependency>
+
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralConfiguration.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralConfiguration.java
@@ -1,0 +1,23 @@
+package org.terrakube.api.plugin.scheduler.job.tcl.executor.ephemeral;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@Setter
+@PropertySources({
+        @PropertySource(value = "classpath:application.properties", ignoreResourceNotFound = true),
+        @PropertySource(value = "classpath:application-${spring.profiles.active}.properties", ignoreResourceNotFound = true)
+})
+@ConfigurationProperties(prefix = "org.terrakube.executor.ephemeral")
+public class EphemeralConfiguration {
+
+    private String namespace;
+    private String image;
+    private String secret;
+}

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
@@ -1,0 +1,106 @@
+package org.terrakube.api.plugin.scheduler.job.tcl.executor.ephemeral;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.EnvFromSource;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.SecretEnvSource;
+import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorContext;
+import org.terrakube.api.rs.job.Job;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class EphemeralExecutorService {
+
+    KubernetesClient kubernetesClient;
+    EphemeralConfiguration ephemeralConfiguration;
+
+    public boolean sendToEphemeralExecutor(Job job, ExecutorContext executorContext) {
+        final String jobName = "job-" + job.getId();
+        deleteEphemeralJob(job);
+        log.info("Ephemeral Executor Image {}, Job: {}, Namespace: {}", ephemeralConfiguration.getImage(), jobName, ephemeralConfiguration.getNamespace());
+        SecretEnvSource secretEnvSource = new SecretEnvSource();
+        secretEnvSource.setName(ephemeralConfiguration.getSecret());
+        EnvFromSource envFromSource = new EnvFromSource();
+        envFromSource.setSecretRef(secretEnvSource);
+        final List<EnvFromSource> executorEnvVarFromSecret = Arrays.asList(envFromSource);
+
+        EnvVar executorFlagBatch = new EnvVar();
+        executorFlagBatch.setName("EphemeralFlagBatch");
+        executorFlagBatch.setValue("true");
+
+        EnvVar executorFlagBatchJsonContent = new EnvVar();
+        try {
+            executorFlagBatchJsonContent.setName("EphemeralJobData");
+            ObjectMapper mapper = new ObjectMapper();
+            String jobJson = mapper.writeValueAsString(executorContext);
+            executorFlagBatchJsonContent.setValue(Base64.getEncoder().encodeToString(jobJson.getBytes("UTF-8")));
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+
+        final List<EnvVar> executorEnvVarFlags = Arrays.asList(executorFlagBatch, executorFlagBatchJsonContent);
+
+
+        io.fabric8.kubernetes.api.model.batch.v1.Job k8sJob = new JobBuilder()
+                .withApiVersion("batch/v1")
+                .withNewMetadata()
+                .withName(jobName)
+                .withNamespace(ephemeralConfiguration.getNamespace())
+                .withLabels(Collections.singletonMap("jobId", executorContext.getJobId()))
+                .withLabels(Collections.singletonMap("organizationId", executorContext.getOrganizationId()))
+                .withLabels(Collections.singletonMap("workspaceId", executorContext.getWorkspaceId()))
+                .endMetadata()
+                .withNewSpec()
+                .withNewTemplate()
+                .withNewSpec()
+                .addNewContainer()
+                .withName(jobName)
+                .withEnvFrom(executorEnvVarFromSecret)
+                .withImage(ephemeralConfiguration.getImage())
+                .withEnv(executorEnvVarFlags)
+                .endContainer()
+                .withRestartPolicy("Never")
+                .endSpec()
+                .endTemplate()
+                .endSpec()
+                .build();
+
+        log.info("Running ephemeral job");
+        kubernetesClient.batch().v1().jobs().inNamespace("terrakube").createOrReplace(k8sJob);
+        return true;
+    }
+
+    public void deleteEphemeralJob(Job job){
+        try {
+            io.fabric8.kubernetes.api.model.batch.v1.Job jobK8s = kubernetesClient
+                    .batch()
+                    .jobs()
+                    .inNamespace(ephemeralConfiguration.getNamespace())
+                    .withName("job-" + job.getId())
+                    .get();
+
+            if (jobK8s != null) {
+                kubernetesClient
+                        .batch()
+                        .jobs()
+                        .inNamespace(ephemeralConfiguration.getNamespace())
+                        .withName("job-" + job.getId())
+                        .delete();
+            }
+
+        } catch (Exception ex) {
+            log.error(ex.getMessage());
+        }
+    }
+}

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/K8sClientAutoConfiguration.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/K8sClientAutoConfiguration.java
@@ -1,0 +1,18 @@
+package org.terrakube.api.plugin.scheduler.job.tcl.executor.ephemeral;
+
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+@ConditionalOnMissingBean(KubernetesClient.class)
+public class K8sClientAutoConfiguration {
+
+    @Bean
+    public KubernetesClient kubernetesClient() {
+        return new DefaultKubernetesClient();
+    }
+}

--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -87,6 +87,13 @@ spring.quartz.jdbc.initialize-schema=never
 ##############
 org.terrakube.executor.url=${AzBuilderExecutorUrl}
 
+###########################
+#EPHEMERAL EXECUTOR CONFIG#
+##########################
+org.terrakube.executor.ephemeral.namespace=${ExecutorEphemeralNamespace:terrakube}
+org.terrakube.executor.ephemeral.image=${ExecutorEphemeralImage:azbuilder/api-server:2.22.0}
+org.terrakube.executor.ephemeral.secret=${ExecutorEphemeralSecret:terrakube-executor-secrets}
+
 #################
 #Storage Service#
 #################

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -87,6 +87,13 @@ spring.quartz.jdbc.initialize-schema=never
 ##############
 org.terrakube.executor.url=${AzBuilderExecutorUrl}
 
+###########################
+#EPHEMERAL EXECUTOR CONFIG#
+##########################
+org.terrakube.executor.ephemeral.namespace=${ExecutorEphemeralNamespace:terrakube}
+org.terrakube.executor.ephemeral.image=${ExecutorEphemeralImage:azbuilder/executor:2.22.0}
+org.terrakube.executor.ephemeral.secret=${ExecutorEphemeralSecret:terrakube-executor-secrets}
+
 #################
 #Storage Service#
 #################

--- a/ephemeral-executor-config/rbac_role.yml
+++ b/ephemeral-executor-config/rbac_role.yml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: terrakube
+  name: terrakube-api-role
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/ephemeral-executor-config/rbac_role_binding.yml
+++ b/ephemeral-executor-config/rbac_role_binding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: terrakube-api-role-binding
+  namespace: terrakube
+subjects:
+- kind: ServiceAccount
+  name: terrakube-api-service-account
+  namespace: terrakube
+roleRef:
+  kind: Role
+  name: terrakube-api-role
+  apiGroup: rbac.authorization.k8s.io

--- a/ephemeral-executor-config/service_account.yml
+++ b/ephemeral-executor-config/service_account.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: terrakube-api-service-account
+  namespace: terrakube

--- a/executor/src/main/java/org/terrakube/executor/configuration/ExecutorFlagsProperties.java
+++ b/executor/src/main/java/org/terrakube/executor/configuration/ExecutorFlagsProperties.java
@@ -11,11 +11,12 @@ import org.springframework.stereotype.Component;
 @Setter
 @PropertySource(value = "classpath:application.properties", ignoreResourceNotFound = true)
 @PropertySource(value = "classpath:application-${spring.profiles.active}.properties", ignoreResourceNotFound = true)
-@ConfigurationProperties(prefix = "org.executor.executor.flags")
+@ConfigurationProperties(prefix = "org.terrakube.executor.flags")
 public class ExecutorFlagsProperties {
 
-    private boolean batch;
-    private String batchJobFilePath;
+    private boolean ephemeral;
+    private String ephemeralJobData;
+    private String batchJobFile;
     private boolean disableAcknowledge;
 
 }

--- a/executor/src/main/java/org/terrakube/executor/service/executor/ExecutorJobImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/executor/ExecutorJobImpl.java
@@ -89,7 +89,7 @@ public class ExecutorJobImpl implements ExecutorJob {
             log.error(e.getMessage());
         }
 
-        if (executorFlagsProperties.isBatch())
+        if (executorFlagsProperties.isEphemeral())
             shutdownService.shutdownApplication();
     }
 

--- a/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
+++ b/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
@@ -32,6 +32,7 @@ public class TerraformJob {
     private String moduleSshKey;
     private String commitId;
     private boolean tofu;
+    private String agentUrl;
     private HashMap<String, String> environmentVariables;
     private HashMap<String, String> variables;
 

--- a/executor/src/main/resources/application.properties
+++ b/executor/src/main/resources/application.properties
@@ -11,9 +11,11 @@ org.terrakube.terraform.flags.tofuReleasesUrl=${CustomTofuReleasesUrl}
 ###########################
 #General Settings Executor#
 ###########################
-org.terrakube.executor.flags.batch=${ExecutorFlagBatch}
-org.terrakube.executor.flags.batchJobFilePath=${ExecutorFlagBatchJobFilePath}
-org.terrakube.executor.flags.disableAcknowledge=${ExecutorFlagDisableAcknowledge}
+
+## This will be the new flag used to trigger the ephemeral jobs
+org.terrakube.executor.flags.ephemeral=${EphemeralFlagBatch:false}
+org.terrakube.executor.flags.ephemeralJobData=${EphemeralJobData:}
+org.terrakube.executor.flags.disableAcknowledge=${ExecutorFlagDisableAcknowledge:false}
 
 ###################
 #State/Output Type#

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>2.21.0</revision>
+        <revision>2.22.0</revision>
         <sonar.organization>azbuilder</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.project.key>AzBuilder_azb-server</sonar.project.key>


### PR DESCRIPTION
This will allow to run the executor component in `"ephemeral"` mode.

The following environment variables were added in the API:
- ExecutorEphemeralNamespace (Default value: "terrakube")
- ExecutorEphemeralImage (Defatul value: "azbuilder/executor:2.22.0" )
- ExecutorEphemeralSecret (Default value: "terrakube-executor-secrets" )

> The above is basically to control where the job will be created and executed and to mount the secrets required by the executor component

The following environment variables were added in the Executor:

- EphemeralFlagBatch (Default value: "false")
- EphemeralJobData, this contains all the data that the executor need to run.

## Requirements

To use Ephemeral executors we need to create the following configuration:

### Service Account Creation

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: terrakube-api-service-account
  namespace: terrakube
```

### Role Creation

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  namespace: terrakube
  name: terrakube-api-role
rules:
- apiGroups: ["batch"]
  resources: ["jobs"]
  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
```

### Role Binding Creation

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: terrakube-api-role-binding
  namespace: terrakube
subjects:
- kind: ServiceAccount
  name: terrakube-api-service-account
  namespace: terrakube
roleRef:
  kind: Role
  name: terrakube-api-role
  apiGroup: rbac.authorization.k8s.io
```
### Helm Chart Configuration

Once the above configuration is created we can deploy the Terrakube API like the following example:

```
## API properties
api:
  image: "azbuilder/api-server"
  version: "2.22.0"
  serviceAccountName: "terrakube-api-service-account"
  env:
  - name: ExecutorEphemeralNamespace
    value: terrakube
  - name: ExecutorEphemeralImage
    value: azbuilder/executor:2.22.0
  - name: ExecutorEphemeralSecret
    value: terrakube-executor-secrets
```

### Workspace Configuration

Add the environment variable `TERRAKUBE_ENABLE_EPHEMERAL_EXECUTOR=1` like the image below

![image](https://github.com/user-attachments/assets/1e6ccef8-6c5a-4522-9c68-e41f14ce549d)

### Workspace Execution

Now when the job is running internally Terrakube will create a K8S job and will execute each step of the job in a `"ephemeral executor"`

![image](https://github.com/user-attachments/assets/52d8972e-f95c-4792-a69f-cc552e1199ac)

Example:

![image](https://github.com/user-attachments/assets/d03250c2-8b84-4e47-9a28-ff823d04bd62)

![image](https://github.com/user-attachments/assets/2fa71ab9-db2c-4d61-a947-0707bfa3b9e9)

![image](https://github.com/user-attachments/assets/9ca553ec-f270-44da-9555-eb5a578e6212)





Fix #843 
