### PR TITLE
Change logging level for some messages

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -158,7 +158,7 @@ public class ExecutorService {
             ResponseEntity<ExecutorContext> response = restTemplate.postForEntity(getExecutorUrl(job), executorContext, ExecutorContext.class);
             executorContext.setAccessToken("****");
             executorContext.setModuleSshKey("****");
-            log.info("Sending Job: /n {}", executorContext);
+            log.debug("Sending Job: /n {}", executorContext);
             log.info("Response Status: {}", response.getStatusCode().value());
 
             if (response.getStatusCode().equals(HttpStatus.ACCEPTED)) {

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -52,7 +52,7 @@ public class DynamicCredentialsService {
                 job.getId()
         );
 
-        log.info("ARM_OIDC_TOKEN: {}", jwtToken);
+        log.debug("ARM_OIDC_TOKEN: {}", jwtToken);
         workspaceEnvVariables.put("ARM_OIDC_TOKEN", jwtToken);
 
         return workspaceEnvVariables;
@@ -98,7 +98,7 @@ public class DynamicCredentialsService {
                 job.getId()
         );
 
-        log.info("TERRAKUBE_AWS_CREDENTIALS_FILE: {}", awsWebIdentityToken);
+        log.debug("TERRAKUBE_AWS_CREDENTIALS_FILE: {}", awsWebIdentityToken);
 
         workspaceEnvVariables.put("TERRAKUBE_AWS_CREDENTIALS_FILE", awsWebIdentityToken);
         workspaceEnvVariables.put("AWS_ROLE_ARN", workspaceEnvVariables.get("WORKLOAD_IDENTITY_ROLE_AWS"));
@@ -146,8 +146,8 @@ public class DynamicCredentialsService {
 
         googleCredentialConfigFile = String.format(googleCredentialConfigFile, audience, serviceAccountEmail, executorDirectory);
 
-        log.info("TERRAKUBE_GCP_CREDENTIALS_FILE: {}", googleCredentialsFile);
-        log.info("TERRAKUBE_GCP_CREDENTIALS_CONFIG_FILE: {}", googleCredentialConfigFile);
+        log.debug("TERRAKUBE_GCP_CREDENTIALS_FILE: {}", googleCredentialsFile);
+        log.debug("TERRAKUBE_GCP_CREDENTIALS_CONFIG_FILE: {}", googleCredentialConfigFile);
 
         workspaceEnvVariables.put("TERRAKUBE_GCP_CREDENTIALS_FILE", googleCredentialsFile);
         workspaceEnvVariables.put("TERRAKUBE_GCP_CREDENTIALS_CONFIG_FILE", googleCredentialConfigFile);


### PR DESCRIPTION
Change logic for logging level in some classes if we need to see the information this can be customize like the following:

`JAVA_TOOL_OPTIONS="-Dlogging.level.org.terrakube.api.plugin.scheduler.job.tcl.executor=DEBUG"`