### PR TITLE
feat: #107 send status check back to Github

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
@@ -9,6 +9,7 @@ import org.terrakube.api.repository.WebhookRepository;
 import org.terrakube.api.repository.WorkspaceRepository;
 import org.terrakube.api.rs.Organization;
 import org.terrakube.api.rs.job.Job;
+import org.terrakube.api.rs.job.JobStatus;
 import org.terrakube.api.rs.template.Template;
 import org.terrakube.api.rs.vcs.Vcs;
 import org.terrakube.api.rs.webhook.Webhook;
@@ -124,11 +125,11 @@ public class WebhookService {
                                 job.setVia(webhookResult.getVia());
                                 job.setCommitId(webhookResult.getCommit());
                                 Job savedJob = jobRepository.save(job);
+                                sendCommitStatus(savedJob);
                                 scheduleJobService.createJobContext(savedJob);
                             } catch (Exception e) {
                                 log.error("Error creating the job", e);
                             }
-
                         }
                     }
                 }
@@ -221,5 +222,15 @@ public class WebhookService {
     webhookRepository.save(savedWebhook);
   }
  }
-
+ 
+ 
+ private void sendCommitStatus(Job job) {
+    switch (job.getWorkspace().getVcs().getVcsType()) {
+        case GITHUB:
+            gitHubWebhookService.sendCommitStatus(job, JobStatus.pending);
+            break;
+        default:
+            break;
+    }
+ }
 }

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GithubCommitStatus.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GithubCommitStatus.java
@@ -1,0 +1,8 @@
+package org.terrakube.api.plugin.vcs.provider.github;
+
+public enum GithubCommitStatus {
+   pending,
+   error,
+   failure,
+   success 
+}

--- a/api/src/main/java/org/terrakube/api/rs/job/JobVia.java
+++ b/api/src/main/java/org/terrakube/api/rs/job/JobVia.java
@@ -1,0 +1,9 @@
+package org.terrakube.api.rs.job;
+
+public enum JobVia {
+   UI,
+   CLI,
+   Github,
+   Gitlab,
+   Bitbucket
+}


### PR DESCRIPTION
https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28

Github allows external checks to mark commits with set states, this change does that.

Additional changes:

1. Add a JobVia enum class to unify the value of the `via` field
2. Add a GithubCommitStatus enum class to convert from JobStatus to allowed Github commit status.

fix #1069