### PR TITLE
Adding default value for tofu url

### DIFF
--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -147,7 +147,7 @@ org.terrakube.terraform.json.releasesUrl=${CustomTerraformReleasesUrl}
 #################
 # Tofu Releases #
 #################
-org.terrakube.tofu.json.releasesUrl=${CustomTofuReleasesUrl}
+org.terrakube.tofu.json.releasesUrl=${CustomTofuReleasesUrl:https://api.github.com/repos/opentofu/opentofu/releases}
 
 #########
 # REDIS #

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -148,7 +148,7 @@ org.terrakube.terraform.json.releasesUrl=${CustomTerraformReleasesUrl}
 #################
 # Tofu Releases #
 #################
-org.terrakube.tofu.json.releasesUrl=${CustomTofuReleasesUrl}
+org.terrakube.tofu.json.releasesUrl=${CustomTofuReleasesUrl:https://api.github.com/repos/opentofu/opentofu/releases}
 
 #########
 # REDIS #

--- a/executor/src/main/resources/application.properties
+++ b/executor/src/main/resources/application.properties
@@ -6,7 +6,7 @@ server.port=8090
 org.terrakube.terraform.flags.enableColor=true
 org.terrakube.terraform.flags.jsonOutput=false
 org.terrakube.terraform.flags.terraformReleasesUrl=${CustomTerraformReleasesUrl}
-org.terrakube.terraform.flags.tofuReleasesUrl=${CustomTofuReleasesUrl}
+org.terrakube.terraform.flags.tofuReleasesUrl=${CustomTofuReleasesUrl:https://api.github.com/repos/opentofu/opentofu/releases}
 
 ###########################
 #General Settings Executor#


### PR DESCRIPTION
This will fix using tofu with ephemeral executors feature. I added a default value for the tofu URL

![image](https://github.com/user-attachments/assets/dd4fc99c-2d0c-4425-b879-8368b5e62619)

![image](https://github.com/user-attachments/assets/9f773f90-25d3-4dfb-9604-5c801fe7dfdb)

Fix #1085 