### PR TITLE
Globalvar size

### DIFF
--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -56,4 +56,5 @@
     <include file="/db/changelog/local/changelog-2.21.0-gcp-dynamic.xml"/>
     <include file="/db/changelog/local/changelog-2.22.0-actions.xml"/>
     <include file="/db/changelog/local/changelog-2.21.0-has-changes.xml"/>
+    <include file="/db/changelog/local/changelog-2.22.0-global-vars-size.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.22.0-global-vars-size.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.22.0-global-vars-size.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="40" author="alfespa17@gmail.com">
+        <modifyDataType
+                columnName="variable_value"
+                newDataType="varchar(4096)"
+                tableName="globalvar"/>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.22.0-global-vars-size.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.22.0-global-vars-size.xml
@@ -7,7 +7,7 @@
     <changeSet id="40" author="alfespa17@gmail.com">
         <modifyDataType
                 columnName="variable_value"
-                newDataType="varchar(4096)"
+                newDataType="varchar(5120)"
                 tableName="globalvar"/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
A new database changelog has been added, "changelog-2.22.0-global-vars-size.xml", which modifies the data type for the column "variable_value" in the "globalvar" table. The new data type would allow larger variable values, with a size limit of 5120 characters.