### PR TITLE
fix: branch name carve out for Github

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
@@ -93,6 +93,7 @@ public class WebhookService {
                         for (String branch: branchList){
                             if (webhookBranch.startsWith(branch)) {
                                 found = true;
+                                break;
                             }
                         }
                         if(found && checkFileChanges(webhookResult.getFileChanges(), workspace.getFolder()))

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -53,7 +53,7 @@ public class GitHubWebhookService extends WebhookServiceBase {
             // Extract branch from the ref
             JsonNode rootNode = objectMapper.readTree(jsonPayload);
             String[] ref = rootNode.path("ref").asText().split("/");
-            String[] extractedBranch = Arrays.copyOfRange(ref, 0, ref.length);
+            String[] extractedBranch = Arrays.copyOfRange(ref, 2, ref.length);
             result.setBranch(String.join("/", extractedBranch));
 
 


### PR DESCRIPTION
The carve-out code for branches in the push event from Github is wrong, need to copy the array from second item.

Additional changes:

1. Also break out once a match is found in the branch comparison