### PR TITLE
feat: support trigger by regex patterns 

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/TclService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/TclService.java
@@ -125,8 +125,8 @@ public class TclService {
                 log.info("Checking import commands in YAML");
                 ImportComands importComands = finalFlow.getImportComands();
                 if (importComands != null) {
-                    log.info("Import commands from {} branch {} folder {}", importComands.getRepository(), importComands.getBranch(), importComands.getFolder());
-                    finalFlow.setCommands(importCommands(importComands.getRepository(), importComands.getBranch(), importComands.getFolder()));
+                    log.info("Import commands from {} branch {} folder {}", importComands.getRepository(), importComands.getBranch(), importComands.getFolder().split(",")[0]);
+                    finalFlow.setCommands(importCommands(importComands.getRepository(), importComands.getBranch(), importComands.getFolder().split(",")[0]));
                 }
 
                 return finalFlow;

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -134,7 +134,7 @@ public class ExecutorService {
         }
         executorContext.setTofu(iacType(job));
         executorContext.setCommitId(job.getCommitId());
-        executorContext.setFolder(job.getWorkspace().getFolder());
+        executorContext.setFolder(job.getWorkspace().getFolder().split(",")[0]);
         executorContext.setRefresh(job.isRefresh());
         executorContext.setRefreshOnly(job.isRefreshOnly());
         executorContext.setAgentUrl(getExecutorUrl(job));

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -276,8 +276,8 @@ public class RemoteTfeService {
             attributes.put("execution-mode", workspace.get().getExecutionMode());
             attributes.put("global-remote-state", true);
 
-            if (workspace.get().getFolder() != null && (workspace.get().getVcs() != null || workspace.get().getSsh() != null) && !workspace.get().getFolder().equals("/")){
-                attributes.put("working-directory", workspace.get().getFolder());
+            if (workspace.get().getFolder() != null && (workspace.get().getVcs() != null || workspace.get().getSsh() != null) && !workspace.get().getFolder().split(",")[0].equals("/")){
+                attributes.put("working-directory", workspace.get().getFolder().split(",")[0]);
             }
 
             boolean isManageWorkspace = validateUserManageWorkspace(workspace.get().getOrganization(), currentUser);

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
@@ -28,7 +28,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 @AllArgsConstructor
 @Slf4j
@@ -145,17 +144,21 @@ public class WebhookService {
     }
 
     private boolean checkFileChanges(List<String> files, String workspaceFolder){
-        if(files != null){
-            AtomicBoolean fileChanged = new AtomicBoolean(false);
-            files.forEach(file-> {
-                log.info("File: {} in {}: {}", file, workspaceFolder.substring(1), file.startsWith(workspaceFolder.substring(1)));
-                if(file.startsWith(workspaceFolder.substring(1)) && !fileChanged.get()){
-                    fileChanged.set(true);
+        String[] triggeredPath = workspaceFolder.split(",");
+        for (String file: files){
+            if(file.startsWith(triggeredPath[0].substring(1))){
+                log.info("Changed file {} in set workspace path {}", file, triggeredPath[0]);
+                return true;
+            }
+            for (int i = 1; i< triggeredPath.length; i++){  
+                if(file.matches(triggeredPath[i])){
+                    log.info("Changed file {} matches set trigger pattern {}", file, triggeredPath[i]);
+                    return true;
                 }
-            });
-            return fileChanged.get();
-        } else
-            return true;
+            }
+        }
+        log.info("Changed files {} doesn't match any of the trigger path pattern {}", files, triggeredPath);
+        return false;
     }
 
 

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -60,8 +60,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
     public File getTerraformWorkingDir(TerraformJob terraformJob, File workingDirectory) throws IOException {
         File terraformWorkingDir = workingDirectory;
         try {
-            if (!terraformJob.getBranch().equals("remote-content") || (terraformJob.getFolder() != null && !terraformJob.getFolder().equals("/"))) {
-                terraformWorkingDir = new File(workingDirectory.getCanonicalPath() + terraformJob.getFolder());
+            if (!terraformJob.getBranch().equals("remote-content") || (terraformJob.getFolder() != null && !terraformJob.getFolder().split(",")[0].equals("/"))) {
+                terraformWorkingDir = new File(workingDirectory.getCanonicalPath() + terraformJob.getFolder().split(",")[0]);
             }
         } catch (IOException e) {
             log.error(e.getMessage());


### PR DESCRIPTION
This change extends the folder settings on workspace settings by allowing multiple fields separated by comma, the first path will be used as the default workspace path for runs triggered from UI, the rest of the paths are regex to match against the changed files in a push event sent from VCS providers.
    
Example folder path: /workspaces/test,modules/.*.tf

related to #703 