### PR TITLE
Fix webhooks for air gapped servers

### DIFF
--- a/api/src/main/java/org/terrakube/api/rs/hooks/workspace/WorkspaceManageHook.java
+++ b/api/src/main/java/org/terrakube/api/rs/hooks/workspace/WorkspaceManageHook.java
@@ -9,9 +9,12 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.terrakube.api.plugin.softdelete.SoftDeleteService;
 import org.terrakube.api.plugin.vcs.WebhookService;
+import org.terrakube.api.repository.GlobalVarRepository;
 import org.terrakube.api.repository.WebhookRepository;
+import org.terrakube.api.rs.globalvar.Globalvar;
 import org.terrakube.api.rs.webhook.Webhook;
 import org.terrakube.api.rs.workspace.Workspace;
+import org.terrakube.api.rs.workspace.parameters.Category;
 
 import java.util.Optional;
 
@@ -22,6 +25,7 @@ public class WorkspaceManageHook implements LifeCycleHook<Workspace> {
     SoftDeleteService softDeleteService;
     WebhookService webhookService;
     WebhookRepository webhookRepository;
+    GlobalVarRepository globalVarRepository;
 
     @Override
     public void execute(LifeCycleHookBinding.Operation operation,
@@ -55,7 +59,9 @@ public class WorkspaceManageHook implements LifeCycleHook<Workspace> {
                         break;
 
                     case POSTCOMMIT:
-                        webhookService.createWorkspaceWebhook(workspace);
+                        if(globalVarRepository.getGlobalvarByOrganizationAndCategoryAndKey(workspace.getOrganization(), Category.ENV, "TERRAKUBE_DISABLE_WEBHOOK") != null) {
+                            webhookService.createWorkspaceWebhook(workspace);
+                        }
                         break;
 
                     default:

--- a/api/src/main/java/org/terrakube/api/rs/hooks/workspace/WorkspaceManageHook.java
+++ b/api/src/main/java/org/terrakube/api/rs/hooks/workspace/WorkspaceManageHook.java
@@ -59,8 +59,11 @@ public class WorkspaceManageHook implements LifeCycleHook<Workspace> {
                         break;
 
                     case POSTCOMMIT:
-                        if(globalVarRepository.getGlobalvarByOrganizationAndCategoryAndKey(workspace.getOrganization(), Category.ENV, "TERRAKUBE_DISABLE_WEBHOOK") != null) {
+                        if(globalVarRepository.getGlobalvarByOrganizationAndCategoryAndKey(workspace.getOrganization(), Category.ENV, "TERRAKUBE_DISABLE_WEBHOOK") == null) {
+                            log.info("Webhook support is enabled");
                             webhookService.createWorkspaceWebhook(workspace);
+                        } else {
+                            log.warn("Webhook support is disabled");
                         }
                         break;
 


### PR DESCRIPTION
Fix issue to disable webhooks for air gapped servers.

Inside the organization we just need to add the following.

![image](https://github.com/user-attachments/assets/466a5e62-c466-451d-9c53-8f5b8548f2e7)


Fix #1147 