### PR TITLE
Update dependency versions in pom.xml files

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -23,7 +23,7 @@
         <lombok.version>1.18.34</lombok.version>
         <jgit.version>6.10.0.202406032230-r</jgit.version>
         <rest-assured.version>5.5.0</rest-assured.version>
-        <junit-jupiter-api.version>5.9.0</junit-jupiter-api.version>
+        <junit-jupiter-api.version>5.10.3</junit-jupiter-api.version>
         <!--groovy.version>4.0.20</groovy.version-->
         <postgresql.version>42.7.3</postgresql.version>
         <mysql.version>8.0.30</mysql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.12</version>
+        <version>3.2.8</version>
     </parent>
 
     <groupId>org.terrakube</groupId>

--- a/registry/pom.xml
+++ b/registry/pom.xml
@@ -22,7 +22,7 @@
 		<commons-io.version>2.16.1</commons-io.version>
 		<mockserver-spring-test-listener.version>5.13.2</mockserver-spring-test-listener.version>
 		<rest-assured.version>5.5.0</rest-assured.version>
-		<junit-jupiter-api.version>5.7.2</junit-jupiter-api.version>
+		<junit-jupiter-api.version>5.10.3</junit-jupiter-api.version>
 		<!--groovy.version>3.0.8</groovy.version-->
 		<aws-sdk.version>1.12.767</aws-sdk.version>
 		<zt-zip.version>1.17</zt-zip.version>


### PR DESCRIPTION
Upgraded Spring Boot from version 3.1.12 to 3.2.8 in the main pom.xml to ensure compatibility with new features and security updates. Also updated JUnit Jupiter API from version 5.7.2 to 5.10.3 in registry/pom.xml, which includes several bug fixes and improvements.