### PR TITLE
Update ephemeral executor with node selector configuration

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralConfiguration.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralConfiguration.java
@@ -7,6 +7,8 @@ import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.PropertySources;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 @Component
 @Getter
 @Setter
@@ -20,4 +22,5 @@ public class EphemeralConfiguration {
     private String namespace;
     private String image;
     private String secret;
+    private Map<String, String> nodeSelector;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
@@ -28,7 +28,7 @@ public class EphemeralExecutorService {
     public boolean sendToEphemeralExecutor(Job job, ExecutorContext executorContext) {
         final String jobName = "job-" + job.getId();
         deleteEphemeralJob(job);
-        log.info("Ephemeral Executor Image {}, Job: {}, Namespace: {}", ephemeralConfiguration.getImage(), jobName, ephemeralConfiguration.getNamespace());
+        log.info("Ephemeral Executor Image {}, Job: {}, Namespace: {}, NodeSelector: {}", ephemeralConfiguration.getImage(), jobName, ephemeralConfiguration.getNamespace(), ephemeralConfiguration.getNodeSelector());
         SecretEnvSource secretEnvSource = new SecretEnvSource();
         secretEnvSource.setName(ephemeralConfiguration.getSecret());
         EnvFromSource envFromSource = new EnvFromSource();
@@ -51,7 +51,6 @@ public class EphemeralExecutorService {
 
         final List<EnvVar> executorEnvVarFlags = Arrays.asList(executorFlagBatch, executorFlagBatchJsonContent);
 
-
         io.fabric8.kubernetes.api.model.batch.v1.Job k8sJob = new JobBuilder()
                 .withApiVersion("batch/v1")
                 .withNewMetadata()
@@ -64,6 +63,7 @@ public class EphemeralExecutorService {
                 .withNewSpec()
                 .withNewTemplate()
                 .withNewSpec()
+                .withNodeSelector(ephemeralConfiguration.getNodeSelector())
                 .addNewContainer()
                 .withName(jobName)
                 .withEnvFrom(executorEnvVarFromSecret)

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/K8sClientAutoConfiguration.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/K8sClientAutoConfiguration.java
@@ -2,17 +2,20 @@ package org.terrakube.api.plugin.scheduler.job.tcl.executor.ephemeral;
 
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 
+@Slf4j
 @Configuration
 @ConditionalOnMissingBean(KubernetesClient.class)
 public class K8sClientAutoConfiguration {
 
     @Bean
-    public KubernetesClient kubernetesClient() {
+    public KubernetesClient kubernetesClient(EphemeralConfiguration ephemeralConfiguration) {
+        log.info("Ephemeral Executor Configuration Image {}, Namespace: {}, NodeSelector: {}", ephemeralConfiguration.getImage(), ephemeralConfiguration.getNamespace(), ephemeralConfiguration.getNodeSelector());
         return new DefaultKubernetesClient();
     }
 }

--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -94,6 +94,15 @@ org.terrakube.executor.ephemeral.namespace=${ExecutorEphemeralNamespace:terrakub
 org.terrakube.executor.ephemeral.image=${ExecutorEphemeralImage:azbuilder/api-server:2.22.0}
 org.terrakube.executor.ephemeral.secret=${ExecutorEphemeralSecret:terrakube-executor-secrets}
 
+###########################################
+# EPHEMERAL EXECUTOR NODE SELECTOR CONFIG #
+###########################################
+# JAVA_TOOL_OPTIONS="-Dorg.terrakube.executor.ephemeral.nodeSelector.diskType=ssd -Dorg.terrakube.executor.ephemeral.nodeSelector.nodeType=spot
+
+# EQUIVALENT CONFIGURATION
+# org.terrakube.executor.ephemeral.nodeSelector.diskType=ssd
+# org.terrakube.executor.ephemeral.nodeSelector.nodeType=spot
+
 #################
 #Storage Service#
 #################

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -94,6 +94,15 @@ org.terrakube.executor.ephemeral.namespace=${ExecutorEphemeralNamespace:terrakub
 org.terrakube.executor.ephemeral.image=${ExecutorEphemeralImage:azbuilder/executor:2.22.0}
 org.terrakube.executor.ephemeral.secret=${ExecutorEphemeralSecret:terrakube-executor-secrets}
 
+###########################################
+# EPHEMERAL EXECUTOR NODE SELECTOR CONFIG #
+###########################################
+# JAVA_TOOL_OPTIONS="-Dorg.terrakube.executor.ephemeral.nodeSelector.diskType=ssd -Dorg.terrakube.executor.ephemeral.nodeSelector.nodeType=spot"
+
+# EQUIVALENT CONFIGURATION
+# org.terrakube.executor.ephemeral.nodeSelector.diskType=ssd
+# org.terrakube.executor.ephemeral.nodeSelector.nodeType=spot
+
 #################
 #Storage Service#
 #################

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>2.22.0</revision>
+        <revision>2.23.0</revision>
         <sonar.organization>azbuilder</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.project.key>AzBuilder_azb-server</sonar.project.key>


### PR DESCRIPTION
Adding option to specify node selector when running the executor component in ephemeral mode.

To use it we need to add the following:

```yaml
api:
  env:
  - name: JAVA_TOOL_OPTIONS
    value: "-Dorg.terrakube.executor.ephemeral.nodeSelector.diskType=ssd -Dorg.terrakube.executor.ephemeral.nodeSelector.nodeType=spot"
```

The above will basically be the equivalent to:

```yaml
  nodeSelector:
    disktype: ssd
    nodeType: spot
```

We just need to add the nodeSelector properties inside the application.property `Dorg.terrakube.executor.ephemeral.nodeSelector.XXX=YYYY`  using  JAVA_TOOL_OPTIONS environment variable to add the values.

Fix #1168 