### PR TITLE
Add private extension repository support

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -208,10 +208,10 @@ public class ExecutorService {
             workspaceEnvVariables = dynamicCredentialsService.generateDynamicCredentialsGcp(job, workspaceEnvVariables);
         }
 
-        if (workspaceEnvVariables.containsKey("TERRAKUBE_PRIVATE_EXTENSION_VCS_ID_AUTH")){
-            log.warn("Found TERRAKUBE_PRIVATE_EXTENSION_VCS_ID_AUTH, adding authentication information for private extension repository");
+        if (workspaceEnvVariables.containsKey("PRIVATE_EXTENSION_VCS_ID_AUTH")){
+            log.warn("Found PRIVATE_EXTENSION_VCS_ID_AUTH, adding authentication information for private extension repository");
 
-            Optional<Vcs> vcs = vcsRepository.findById(UUID.fromString(workspaceEnvVariables.get("TERRAKUBE_PRIVATE_EXTENSION_VCS_ID_AUTH")));
+            Optional<Vcs> vcs = vcsRepository.findById(UUID.fromString(workspaceEnvVariables.get("PRIVATE_EXTENSION_VCS_ID_AUTH")));
             if(vcs.isPresent()) {
                 workspaceEnvVariables.put("TERRAKUBE_PRIVATE_EXTENSION_REPO_TYPE",vcs.get().getVcsType().toString());
                 workspaceEnvVariables.put("TERRAKUBE_PRIVATE_EXTENSION_REPO_TOKEN",vcs.get().getAccessToken());

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -138,7 +138,7 @@ public class ExecutorService {
         }
         executorContext.setTofu(iacType(job));
         executorContext.setCommitId(job.getCommitId());
-        executorContext.setFolder(job.getWorkspace().getFolder().split(",")[0]);
+        executorContext.setFolder(job.getWorkspace().getFolder() != null ? job.getWorkspace().getFolder().split(",")[0] : "/");
         executorContext.setRefresh(job.isRefresh());
         executorContext.setRefreshOnly(job.isRefreshOnly());
         executorContext.setAgentUrl(getExecutorUrl(job));

--- a/executor/src/main/java/org/terrakube/executor/service/scripts/ScriptEngineService.java
+++ b/executor/src/main/java/org/terrakube/executor/service/scripts/ScriptEngineService.java
@@ -105,8 +105,9 @@ public class ScriptEngineService {
     private void createToolsDirectory(File terraformWorkingDir, TerraformJob terraformJob) throws IOException {
         FileUtils.deleteDirectory(getToolsRepository(terraformWorkingDir));
         FileUtils.forceMkdir(getToolsRepository(terraformWorkingDir));
-        String privateRepositoryType = terraformJob.getEnvironmentVariables().get("TERRAKUBE_PRIVATE_EXTENSION_REPO_TYPE");
-        String privateRepositoryToken = terraformJob.getEnvironmentVariables().get("TERRAKUBE_PRIVATE_EXTENSION_REPO_TOKEN");
+        String privateRepositoryType = "PUBLIC";
+        privateRepositoryType = terraformJob.getEnvironmentVariables().containsKey("TERRAKUBE_PRIVATE_EXTENSION_REPO_TYPE") ? terraformJob.getEnvironmentVariables().get("TERRAKUBE_PRIVATE_EXTENSION_REPO_TYPE") : privateRepositoryType;
+        String privateRepositoryToken = terraformJob.getEnvironmentVariables().containsKey("TERRAKUBE_PRIVATE_EXTENSION_REPO_TOKEN") ? terraformJob.getEnvironmentVariables().get("TERRAKUBE_PRIVATE_EXTENSION_REPO_TOKEN") : null;
         try {
             CredentialsProvider credentialsProvider;
             log.info("Private Extension vcsType: {}", privateRepositoryType);

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspace.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspace.java
@@ -1,5 +1,6 @@
 package org.terrakube.executor.service.workspace;
 
+import org.eclipse.jgit.transport.CredentialsProvider;
 import org.terrakube.executor.service.mode.TerraformJob;
 
 import java.io.File;
@@ -7,4 +8,5 @@ import java.io.File;
 public interface SetupWorkspace {
 
     File prepareWorkspace(TerraformJob terraformJob);
+    CredentialsProvider setupCredentials(String vcsType, String accessToken);
 }

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspace.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspace.java
@@ -8,5 +8,4 @@ import java.io.File;
 public interface SetupWorkspace {
 
     File prepareWorkspace(TerraformJob terraformJob);
-    CredentialsProvider setupCredentials(String vcsType, String accessToken);
 }

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -323,7 +323,8 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
         return sshFile.getParentFile();
     }
 
-    private CredentialsProvider setupCredentials(String vcsType, String accessToken) {
+    @Override
+    public CredentialsProvider setupCredentials(String vcsType, String accessToken) {
         CredentialsProvider credentialsProvider = null;
         log.info("vcsType: {}", vcsType);
         switch (vcsType) {

--- a/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -323,7 +323,6 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
         return sshFile.getParentFile();
     }
 
-    @Override
     public CredentialsProvider setupCredentials(String vcsType, String accessToken) {
         CredentialsProvider credentialsProvider = null;
         log.info("vcsType: {}", vcsType);


### PR DESCRIPTION
Adding support to use a private extension repository, to use it we just need to add the following environment variable at the organization level.

PRIVATE_EXTENSION_VCS_ID_AUTH

> The above will require the vcs id to use when authentication to the private extension repository

![image](https://github.com/user-attachments/assets/e3ee4757-f38b-4596-bca9-5374d44c7561)

For example when using the helm chart we can set the private extension repository like the following:

```yaml
executor:
  properties:
    toolsRepository: "https://myprivate.com/secret/my-private-repository.git"
    toolsBranch: "main"
```

Fix #928 