### PR TITLE
Change size globalvar/workspace key value

### DIFF
--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -57,4 +57,5 @@
     <include file="/db/changelog/local/changelog-2.22.0-actions.xml"/>
     <include file="/db/changelog/local/changelog-2.21.0-has-changes.xml"/>
     <include file="/db/changelog/local/changelog-2.22.0-global-vars-size.xml"/>
+    <include file="/db/changelog/local/changelog-2.22.0-global-var-key-size.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.22.0-global-var-key-size.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.22.0-global-var-key-size.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="41" author="alfespa17@gmail.com">
+        <modifyDataType
+                columnName="variable_key"
+                newDataType="varchar(1024)"
+                tableName="globalvar"/>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.22.0-global-var-key-size.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.22.0-global-var-key-size.xml
@@ -9,5 +9,9 @@
                 columnName="variable_key"
                 newDataType="varchar(1024)"
                 tableName="globalvar"/>
+        <modifyDataType
+                columnName="variable_key"
+                newDataType="varchar(1024)"
+                tableName="variable"/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Allow to create global variable with a big name like the below example:

![image](https://github.com/user-attachments/assets/b9b283d0-faa9-47a2-acad-645eb9f2ae52)


Fix #1208 