### PR TITLE
Fix run id logic for terraform remote plan

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/redirect/RedirectController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/redirect/RedirectController.java
@@ -22,10 +22,11 @@ public class RedirectController {
     }
 
     @GetMapping(path = "/{organizationName}/{workspaceName}/runs/{jobId}")
-    ResponseEntity<Void> jobIdRedirect(@PathVariable("organizationName") String organizationName, @PathVariable("workspaceName") String workspaceName, @PathVariable("jobId") int jobId) {
+    ResponseEntity<Void> jobIdRedirect(@PathVariable("organizationName") String organizationName, @PathVariable("workspaceName") String workspaceName, @PathVariable("jobId") String jobId) {
         log.info("Redirect for: {}/{}/{}", organizationName, workspaceName, jobId);
+        int jobIdFixed = Integer.parseInt(jobId.replace("run-",""));
         return ResponseEntity.status(HttpStatus.FOUND)
-                .location(URI.create(String.format("%s/organizations/%s/workspaces/%s/runs/%s", uiURL,jobRepository.findById(jobId).get().getOrganization().getId(), jobRepository.findById(jobId).get().getWorkspace().getId(), jobId)))
+                .location(URI.create(String.format("%s/organizations/%s/workspaces/%s/runs/%s", uiURL,jobRepository.findById(jobIdFixed).get().getOrganization().getId(), jobRepository.findById(jobIdFixed).get().getWorkspace().getId(), jobId)))
                 .build();
     }
 }

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -88,6 +88,12 @@ public class ScheduleJob implements org.quartz.Job {
             return;
         }
 
+        if(job.getWorkspace() == null ){
+            log.warn("Workspace does not exist anymore, deleting job context for {}", jobId);
+            removeJobContext(job, jobExecutionContext);
+            return;
+        }
+
         if (job.getWorkspace().isLocked()) {
             log.warn("Job {}, Workspace is locked. It must be unlocked before Terrakube can execute it.", jobId);
             return;

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -223,21 +223,26 @@ public class RemoteTfeController {
 
     @Transactional
     @GetMapping(produces = "application/vnd.api+json", path = "/runs/{runId}")
-    public ResponseEntity<RunsData> getRun(@PathVariable("runId") int runId, @RequestParam(name = "include", required = false) String include) {
-        return ResponseEntity.of(Optional.ofNullable(remoteTfeService.getRun(runId, include)));
+    public ResponseEntity<RunsData> getRun(@PathVariable("runId") String runId, @RequestParam(name = "include", required = false) String include) {
+        log.info("Get run {}", runId.replace("run-",""));
+        int runIdFixed = Integer.parseInt(runId.replace("run-",""));
+        return ResponseEntity.of(Optional.ofNullable(remoteTfeService.getRun(runIdFixed, include)));
     }
 
     @Transactional
     @PostMapping(produces = "application/vnd.api+json", path = "/runs/{runId}/actions/apply")
-    public ResponseEntity<RunsData> runApply(@PathVariable("runId") int runId) {
-        return ResponseEntity.ok(remoteTfeService.runApply(runId));
+    public ResponseEntity<RunsData> runApply(@PathVariable("runId") String runId) {
+        log.info("Applying run {}", runId.replace("run-",""));
+        int runIdFixed = Integer.parseInt(runId.replace("run-",""));
+        return ResponseEntity.ok(remoteTfeService.runApply(runIdFixed));
     }
 
     @Transactional
     @PostMapping(produces = "application/vnd.api+json", path = "/runs/{runId}/actions/discard")
-    public ResponseEntity<RunsData> runDiscard(@PathVariable("runId") int runId) {
-        log.info("Running discard: {}", runId);
-        return ResponseEntity.ok(remoteTfeService.runDiscard(runId));
+    public ResponseEntity<RunsData> runDiscard(@PathVariable("runId") String runId) {
+        log.info("Running discard: {}", runId.replace("run-",""));
+        int runIdFixed = Integer.parseInt(runId.replace("run-",""));
+        return ResponseEntity.ok(remoteTfeService.runDiscard(runIdFixed));
     }
 
 

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -800,7 +800,7 @@ public class RemoteTfeService {
         if(job.getWorkspace() != null) {
             RunsData runsData = new RunsData();
             RunsModel runsModel = new RunsModel();
-            runsModel.setId(String.valueOf(runId));
+            runsModel.setId("run-" + runId);
             runsModel.setType("runs");
             runsModel.setAttributes(new HashMap<>());
 


### PR DESCRIPTION
This will fix the "run-id" logic when running the following command.

```
terraform plan -out myPlan.tfplan
```

Now the file "myPlan.tfplan" will have the correct values, for example:

```
{"remote_plan_format":1,"run_id":"run-116","hostname":"terrakube-api.minikube.net"}
```

And the logs will show the id like "run-XXXX"

![image](https://github.com/user-attachments/assets/4504ebd2-aeef-419a-a013-0a9371031e91)

Partial fix for the following  #1166 

The `terraform apply myPlan.tfplan` logic still needs to be added when using remote executions