### PR TITLE
feat: separate webhook configuration out

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManagerResolver;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -26,53 +27,72 @@ import java.util.List;
 @EnableMethodSecurity(prePostEnabled = true, securedEnabled = true, jsr250Enabled = true)
 public class DexWebSecurityAdapter {
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http, @Value("${org.terrakube.token.issuer-uri}") String issuerUri, @Value("${org.terrakube.token.pat}") String patJwtSecret, @Value("${org.terrakube.token.internal}") String internalJwtSecret, PatRepository patRepository, TeamTokenRepository teamTokenRepository) throws Exception {
-        http.cors().and().csrf().ignoringRequestMatchers("/remote/tfe/v2/configuration-versions/*", "/tfstate/v1/archive/*/terraform.tfstate", "/tfstate/v1/archive/*/terraform.json.tfstate","/webhook/v1/**").and().authorizeRequests(authz -> {
-                            authz
-                                    .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                                    .requestMatchers("/actuator/**").permitAll()
-                                    .requestMatchers("/error").permitAll()
-                                    .requestMatchers("/callback/v1/**").permitAll()
-                                    .requestMatchers("/webhook/v1/**").permitAll()
-                                    .requestMatchers("/.well-known/terraform.json").permitAll()
-                                    .requestMatchers("/.well-known/openid-configuration").permitAll()
-                                    .requestMatchers("/.well-known/jwks").permitAll()
-                                    .requestMatchers("/remote/tfe/v2/ping").permitAll()
-                                    .requestMatchers(HttpMethod.PUT, "/remote/tfe/v2/configuration-versions/*").permitAll()
-                                    .requestMatchers(HttpMethod.PUT,"/tfstate/v1/archive/*/terraform.tfstate").permitAll()
-                                    .requestMatchers(HttpMethod.PUT,"/tfstate/v1/archive/*/terraform.json.tfstate").permitAll()
-                                    .requestMatchers("/remote/tfe/v2/plans/*/logs").permitAll()
-                                    .requestMatchers("/remote/tfe/v2/applies/*/logs").permitAll()
-                                    .requestMatchers("/app/*/*/runs/*").permitAll()
-                                    .anyRequest().authenticated();
-                        }
-                )
-                .oauth2ResourceServer(oauth2 -> {
-                    AuthenticationManagerResolver<HttpServletRequest> authenticationManagerResolver = DexAuthenticationManagerResolver
-                            .builder()
-                            .dexIssuerUri(issuerUri)
-                            .patJwtSecret(patJwtSecret)
-                            .internalJwtSecret(internalJwtSecret)
-                            .patRepository(patRepository)
-                            .teamTokenRepository(teamTokenRepository)
-                            .build();
-                    oauth2.authenticationManagerResolver(authenticationManagerResolver);
-                });
+        @Bean
+        public SecurityFilterChain filterChain(HttpSecurity http,
+                        @Value("${org.terrakube.token.issuer-uri}") String issuerUri,
+                        @Value("${org.terrakube.token.pat}") String patJwtSecret,
+                        @Value("${org.terrakube.token.internal}") String internalJwtSecret, PatRepository patRepository,
+                        TeamTokenRepository teamTokenRepository) throws Exception {
+                http.cors(Customizer.withDefaults())
+                                .csrf(crsf -> crsf.ignoringRequestMatchers("/remote/tfe/v2/configuration-versions/*",
+                                                "/tfstate/v1/archive/*/terraform.tfstate",
+                                                "/tfstate/v1/archive/*/terraform.json.tfstate", "/webhook/v1/**"))
+                                .authorizeHttpRequests(authz -> {
+                                        authz
+                                                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                                                        .requestMatchers("/actuator/**").permitAll()
+                                                        .requestMatchers("/error").permitAll()
+                                                        .requestMatchers("/callback/v1/**").permitAll()
+                                                        .requestMatchers("/webhook/v1/**").permitAll()
+                                                        .requestMatchers("/.well-known/terraform.json").permitAll()
+                                                        .requestMatchers("/.well-known/openid-configuration")
+                                                        .permitAll()
+                                                        .requestMatchers("/.well-known/jwks").permitAll()
+                                                        .requestMatchers("/remote/tfe/v2/ping").permitAll()
+                                                        .requestMatchers(HttpMethod.PUT,
+                                                                        "/remote/tfe/v2/configuration-versions/*")
+                                                        .permitAll()
+                                                        .requestMatchers(HttpMethod.PUT,
+                                                                        "/tfstate/v1/archive/*/terraform.tfstate")
+                                                        .permitAll()
+                                                        .requestMatchers(HttpMethod.PUT,
+                                                                        "/tfstate/v1/archive/*/terraform.json.tfstate")
+                                                        .permitAll()
+                                                        .requestMatchers("/remote/tfe/v2/plans/*/logs").permitAll()
+                                                        .requestMatchers("/remote/tfe/v2/applies/*/logs").permitAll()
+                                                        .requestMatchers("/app/*/*/runs/*").permitAll()
+                                                        .anyRequest().authenticated();
+                                })
+                                .oauth2ResourceServer(oauth2 -> {
+                                        AuthenticationManagerResolver<HttpServletRequest> authenticationManagerResolver = DexAuthenticationManagerResolver
+                                                        .builder()
+                                                        .dexIssuerUri(issuerUri)
+                                                        .patJwtSecret(patJwtSecret)
+                                                        .internalJwtSecret(internalJwtSecret)
+                                                        .patRepository(patRepository)
+                                                        .teamTokenRepository(teamTokenRepository)
+                                                        .build();
+                                        oauth2.authenticationManagerResolver(authenticationManagerResolver);
+                                });
 
-        return http.build();
-    }
+                return http.build();
+        }
 
-    @Bean
-    CorsConfigurationSource corsConfigurationSource(@Value("${org.terrakube.ui.url:http://localhost:3000}") String uiURL) {
-        log.info("Loading CORS {}", uiURL);
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of(uiURL.split(",")));
-        configuration.setAllowCredentials(true);
-        configuration.setAllowedHeaders(Arrays.asList("Access-Control-Allow-Headers", "Access-Control-Allow-Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers", "Origin", "Cache-Control", "Content-Type", "Authorization", "X-TFC-Token","X-TFC-Url" ));
-        configuration.setAllowedMethods(Arrays.asList("DELETE", "GET", "POST", "PATCH", "PUT", "OPTIONS"));
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
-    }
+        @Bean
+        CorsConfigurationSource corsConfigurationSource(
+                        @Value("${org.terrakube.ui.url:http://localhost:3000}") String uiURL) {
+                log.info("Loading CORS {}", uiURL);
+                CorsConfiguration configuration = new CorsConfiguration();
+                configuration.setAllowedOrigins(List.of(uiURL.split(",")));
+                configuration.setAllowCredentials(true);
+                configuration.setAllowedHeaders(
+                                Arrays.asList("Access-Control-Allow-Headers", "Access-Control-Allow-Origin",
+                                                "Access-Control-Request-Method", "Access-Control-Request-Headers",
+                                                "Origin", "Cache-Control",
+                                                "Content-Type", "Accept", "Authorization", "X-TFC-Token", "X-TFC-Url"));
+                configuration.setAllowedMethods(Arrays.asList("DELETE", "GET", "POST", "PATCH", "PUT", "OPTIONS"));
+                UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+                source.registerCorsConfiguration("/**", configuration);
+                return source;
+        }
 }

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
@@ -1,157 +1,227 @@
 package org.terrakube.api.plugin.vcs;
 
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
-import org.terrakube.api.repository.JobRepository;
-import org.terrakube.api.repository.TemplateRepository;
-import org.terrakube.api.repository.WebhookRepository;
-import org.terrakube.api.repository.WorkspaceRepository;
-import org.terrakube.api.rs.Organization;
-import org.terrakube.api.rs.job.Job;
-import org.terrakube.api.rs.job.JobStatus;
-import org.terrakube.api.rs.template.Template;
-import org.terrakube.api.rs.vcs.Vcs;
-import org.terrakube.api.rs.webhook.Webhook;
-import org.terrakube.api.rs.webhook.WebhookType;
-import org.terrakube.api.rs.workspace.Workspace;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.terrakube.api.plugin.scheduler.ScheduleJobService;
 import org.terrakube.api.plugin.vcs.provider.bitbucket.BitBucketWebhookService;
 import org.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
 import org.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.terrakube.api.repository.JobRepository;
+import org.terrakube.api.repository.WebhookRepository;
+import org.terrakube.api.rs.job.Job;
+import org.terrakube.api.rs.job.JobStatus;
+import org.terrakube.api.rs.vcs.Vcs;
+import org.terrakube.api.rs.webhook.Webhook;
+import org.terrakube.api.rs.webhook.WebhookEvent;
+import org.terrakube.api.rs.workspace.Workspace;
 
-import java.nio.charset.StandardCharsets;
-import java.util.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @AllArgsConstructor
 @Slf4j
 @Service
 public class WebhookService {
 
-    TemplateRepository templateRepository;
     WebhookRepository webhookRepository;
-    WorkspaceRepository workspaceRepository;
     GitHubWebhookService gitHubWebhookService;
     GitLabWebhookService gitLabWebhookService;
-    BitBucketWebhookService BitBucketWebhookService;
+    BitBucketWebhookService bitBucketWebhookService;
     JobRepository jobRepository;
     ScheduleJobService scheduleJobService;
-
+    ObjectMapper objectMapper;
 
     @Transactional
-    public String processWebhook(String webhookId, String jsonPayload,Map<String, String> headers) {
+    public String processWebhook(String webhookId, String jsonPayload, Map<String, String> headers) {
         String result = "";
         Webhook webhook = webhookRepository.getReferenceById(UUID.fromString(webhookId));
-        if(webhook == null){
-            log.error("Webhook not found {}", webhookId);
+        if (webhook == null) {
+            log.error("Webhook with ID {} for workspace {} not found", webhookId, webhook.getWorkspace().getName());
             return result;
         }
-        webhook.setType(WebhookType.WORKSPACE);
-        switch (webhook.getType()) {
-            case WORKSPACE:
-                // The webhook instance has a reference to the workspace
-                Workspace workspace = workspaceRepository.getReferenceById(UUID.fromString(webhook.getReferenceId()));
-                Vcs vcs = workspace.getVcs();
+        Workspace workspace = webhook.getWorkspace();
+        Vcs vcs = workspace.getVcs();
 
-                // if the VCS is empty we cannot process the webhook
-                if(vcs == null) {
-                    log.error("VCS not found for workspace {}", workspace.getId());
-                    return result;
-                }
-                else{
-                    WebhookResult webhookResult = new WebhookResult();
-                    String base64WorkspaceId = Base64.getEncoder().encodeToString(workspace.getId().toString().getBytes(StandardCharsets.UTF_8));
-                    switch (vcs.getVcsType()) {
-                        case GITHUB:
-                             webhookResult = gitHubWebhookService.processWebhook(jsonPayload, headers,base64WorkspaceId);
-                            break;
-                        case GITLAB:
-                             webhookResult = gitLabWebhookService.processWebhook(jsonPayload, headers,base64WorkspaceId);
-                            break;
-                        case BITBUCKET:
-                            webhookResult = BitBucketWebhookService.processWebhook(jsonPayload, headers,base64WorkspaceId);
-                            break;
-                        default:
-                            break;
-                    }
+        // if the VCS is empty we cannot process the webhook
+        if (vcs == null) {
+            log.error("VCS not found for workspace {} with id {}", workspace.getName(), workspace.getId());
+            return result;
+        }
 
-                    log.info("webhook result {}", webhookResult);
-
-                    // if the webhook is a valid request we can create a new job
-                    if(webhookResult.isValid()){
-                        // Verify the branch matches a comma separated list
-                        boolean found = false;
-                        String[] branchList = workspace.getBranch().split(",");
-                        String webhookBranch = webhookResult.getBranch();
-                        for (String branch: branchList){
-                            if (webhookBranch.startsWith(branch)) {
-                                found = true;
-                                break;
-                            }
-                        }
-                        if(found && checkFileChanges(webhookResult.getFileChanges(), workspace.getFolder()))
-                        {
-                           ObjectMapper objectMapper = new ObjectMapper();
-                            try {
-                                // The template id is stored in the webhook template mapping, basicall its a map with event and templateId
-                                JsonNode rootNode = objectMapper.readTree(webhook.getTemplateMapping());
-                                log.info("webhook event {}", webhookResult.getEvent());
-                                log.info(rootNode.toString());
-                                String templateId = rootNode.path(webhookResult.getEvent()).asText();
-                                log.info("Template ID is: " + templateId);
-                                if(templateId.isEmpty()){
-                                    log.error("Template not found for event {}", webhookResult.getEvent());
-                                    return result;
-                                }
-                                Job job = new Job();
-                                job.setRefresh(true);
-                                job.setPlanChanges(true);
-                                job.setRefreshOnly(false);
-                                job.setOverrideBranch(webhookBranch);
-                                job.setOrganization(workspace.getOrganization());
-                                job.setWorkspace(workspace);
-                                job.setTemplateReference(templateId);
-                                job.setCreatedBy(webhookResult.getCreatedBy());
-                                job.setUpdatedBy(webhookResult.getCreatedBy());
-                                Date triggerDate = new Date(System.currentTimeMillis());
-                                job.setCreatedDate(triggerDate);
-                                job.setUpdatedDate(triggerDate);
-                                job.setVia(webhookResult.getVia());
-                                job.setCommitId(webhookResult.getCommit());
-                                Job savedJob = jobRepository.save(job);
-                                sendCommitStatus(savedJob);
-                                scheduleJobService.createJobContext(savedJob);
-                            } catch (Exception e) {
-                                log.error("Error creating the job", e);
-                            }
-                        }
-                    }
-                }
+        WebhookResult webhookResult = new WebhookResult();
+        String base64WorkspaceId = Base64.getEncoder()
+                .encodeToString(workspace.getId().toString().getBytes(StandardCharsets.UTF_8));
+        switch (vcs.getVcsType()) {
+            case GITHUB:
+                webhookResult = gitHubWebhookService.processWebhook(jsonPayload, headers,
+                        base64WorkspaceId);
                 break;
-            case MODULE:
-            // In future we can use this to validate the module for a new version or update the code asynchronously
+            case GITLAB:
+                webhookResult = gitLabWebhookService.processWebhook(jsonPayload, headers,
+                        base64WorkspaceId);
+                break;
+            case BITBUCKET:
+                webhookResult = bitBucketWebhookService.processWebhook(jsonPayload, headers,
+                        base64WorkspaceId);
                 break;
             default:
                 break;
         }
+
+        log.info("webhook result {}", webhookResult);
+
+        if (!webhookResult.isValid())
+            return result;
+
+        String webhookBranch = webhookResult.getBranch();
+
+        // Return if branch in the event doesn't match any set branches or if the file
+        // changes doesn't match the set path
+        if (!checkBranch(webhookBranch, webhook) || !checkFileChanges(webhookResult.getFileChanges(), webhook)) {
+            return result;
+        }
+
+        try {
+            // The template id is stored in the webhook template mapping, basicall its a map
+            log.info("webhook event {}", webhookResult.getEvent());
+            if (webhook.getTemplateId() == null || webhook.getTemplateId().isEmpty()) {
+                String workspaceTemplate = workspace.getDefaultTemplate();
+                if (workspaceTemplate == null || workspaceTemplate.isEmpty()) {
+                    log.error(
+                            "No template found for the configured webhook event {}, nor default template configured for workspace {}",
+                            webhookResult.getEvent(), workspace.getName());
+                    return result;
+                }
+                webhook.setTemplateId(workspaceTemplate);
+                webhook = webhookRepository.save(webhook);
+                log.warn("Template not found for event {}, using workspace default template with id {}",
+                        webhookResult.getEvent(), workspaceTemplate);
+            }
+            Job job = new Job();
+            job.setRefresh(true);
+            job.setPlanChanges(true);
+            job.setRefreshOnly(false);
+            job.setOverrideBranch(webhookBranch);
+            job.setOrganization(workspace.getOrganization());
+            job.setWorkspace(workspace);
+            job.setTemplateReference(webhook.getTemplateId());
+            job.setCreatedBy(webhookResult.getCreatedBy());
+            job.setUpdatedBy(webhookResult.getCreatedBy());
+            Date triggerDate = new Date(System.currentTimeMillis());
+            job.setCreatedDate(triggerDate);
+            job.setUpdatedDate(triggerDate);
+            job.setVia(webhookResult.getVia());
+            job.setCommitId(webhookResult.getCommit());
+            Job savedJob = jobRepository.save(job);
+            sendCommitStatus(savedJob);
+            scheduleJobService.createJobContext(savedJob);
+        } catch (Exception e) {
+            log.error("Error creating the job", e);
+        }
         return result;
     }
 
-    private boolean checkFileChanges(List<String> files, String workspaceFolder){
-        String[] triggeredPath = workspaceFolder.split(",");
-        for (String file: files){
-            if(file.startsWith(triggeredPath[0].substring(1))){
-                log.info("Changed file {} in set workspace path {}", file, triggeredPath[0]);
+    @Transactional
+    public void createWorkspaceWebhook(Webhook webhook) {
+        Workspace workspace = webhook.getWorkspace();
+        if (workspace.getVcs() == null) {
+            log.warn("There is no VCS defined for workspace {}, skipping webhook creation", workspace.getName());
+            throw new IllegalArgumentException("No VCS defined for workspace");
+        }
+
+        if (webhook.getEvent() == null || webhook.getEvent().toString().isEmpty())
+            webhook.setEvent(WebhookEvent.PUSH);
+
+        String webhookRemoteId = "";
+        if (webhook.getTemplateId() == null)
+            webhook.setTemplateId(workspace.getDefaultTemplate());
+
+        Vcs vcs = workspace.getVcs();
+        switch (vcs.getVcsType()) {
+            case GITHUB:
+                webhookRemoteId = gitHubWebhookService.createWebhook(workspace, webhook.getId().toString());
+                break;
+            case GITLAB:
+                webhookRemoteId = gitLabWebhookService.createWebhook(workspace, webhook.getId().toString());
+                break;
+            case BITBUCKET:
+                webhookRemoteId = bitBucketWebhookService.createWebhook(workspace, webhook.getId().toString());
+                break;
+            default:
+                break;
+        }
+
+        if (webhookRemoteId.isEmpty()) {
+            log.error("Error creating the webhook");
+            throw new IllegalArgumentException("Error creating the webhook");
+        }
+
+        webhook.setRemoteHookId(webhookRemoteId);
+    }
+
+    @Transactional
+    public void deleteWorkspaceWebhook(Webhook webhook) {
+        Workspace workspace = webhook.getWorkspace();
+        if (workspace.getVcs() == null) {
+            log.warn("There is no VCS defined for workspace {}, skipping webhook creation", workspace.getName());
+            return;
+        }
+        if (webhook.getRemoteHookId() == null || webhook.getRemoteHookId().isEmpty()) {
+            log.warn("No remote hook id found for webhook {} on workspace {}, skipping webhook deletion",
+                    webhook.getId(), workspace.getName());
+            return;
+        }
+
+        Vcs vcs = workspace.getVcs();
+        switch (vcs.getVcsType()) {
+            case GITHUB:
+                gitHubWebhookService.deleteWebhook(workspace, webhook.getRemoteHookId());
+                break;
+            case GITLAB:
+                gitLabWebhookService.deleteWebhook(workspace, webhook.getRemoteHookId());
+                break;
+            case BITBUCKET:
+                bitBucketWebhookService.deleteWebhook(workspace, webhook.getRemoteHookId());
+                break;
+            default:
+                break;
+        }
+    }
+
+    private boolean checkBranch(String webhookBranch, Webhook webhook) {
+        // Check if the webhook branch is the default workspace branch
+        if (webhookBranch.equals(webhook.getWorkspace().getBranch())) {
+            return true;
+        }
+        String[] branchList = webhook.getBranch().split(",");
+        for (String branch : branchList) {
+            if (webhookBranch.startsWith(branch)) {
                 return true;
             }
-            for (int i = 1; i< triggeredPath.length; i++){  
-                if(file.matches(triggeredPath[i])){
+        }
+
+        return false;
+    }
+
+    private boolean checkFileChanges(List<String> files, Webhook webhook) {
+        String[] triggeredPath = webhook.getPath().split(",");
+        String workspaceFolder = webhook.getWorkspace().getFolder();
+        for (String file : files) {
+            if (file.startsWith(workspaceFolder)) {
+                log.info("Changed file {} in set workspace path {}", file, workspaceFolder);
+                return true;
+            }
+            for (int i = 0; i < triggeredPath.length; i++) {
+                if (file.matches(triggeredPath[i])) {
                     log.info("Changed file {} matches set trigger pattern {}", file, triggeredPath[i]);
                     return true;
                 }
@@ -161,80 +231,13 @@ public class WebhookService {
         return false;
     }
 
-
- @Transactional
- public void createWorkspaceWebhook(Workspace workspace) {
-    String webhookRemoteId = "";
-
-  if(workspace.getVcs() != null){
-      Organization organization = workspace.getOrganization();
-      log.info("Checking templates for : {}", organization.getName());
-    List<Template> templates = templateRepository.findByOrganization(workspace.getOrganization()).get();
-    log.info("Templates: {}", templates.size());
-    String templateId = "";
-    if(workspace.getDefaultTemplate() != null && workspace.getDefaultTemplate().length() > 0){
-        templateId = workspace.getDefaultTemplate();
-    } else {
-        for (Template template : templates) {
-            // search for the template "Plan and apply"
-            if ("Plan and apply".equals(template.getName())) {
-                templateId = template.getId().toString();
+    private void sendCommitStatus(Job job) {
+        switch (job.getWorkspace().getVcs().getVcsType()) {
+            case GITHUB:
+                gitHubWebhookService.sendCommitStatus(job, JobStatus.pending);
                 break;
-            }
-        }
-
-        if (templateId.isEmpty()) {
-            log.warn("Template 'Plan and apply' not found , getting first template");
-            templateId = templates.get(0).getId().toString();
+            default:
+                break;
         }
     }
-
-    // Template id is a json with the mapping of the event and the template id. 
-    // In a future release we can trigger a different template for each event
-    String templateMapping ="{\"push\":\"" + templateId +"\"}";
-    log.info("templateMapping {}", templateMapping);
-    // save the webhook
-    Webhook webhook = new Webhook();
-    webhook.setType(WebhookType.WORKSPACE);
-    webhook.setReferenceId(workspace.getId().toString());
-    webhook.setTemplateMapping(templateMapping);
-    Webhook savedWebhook = webhookRepository.save(webhook);
-
-    //
-    Vcs vcs = workspace.getVcs();
-    switch (vcs.getVcsType()) {
-        case GITHUB:
-            webhookRemoteId = gitHubWebhookService.createWebhook(workspace,savedWebhook.getId().toString());
-            break;
-        case GITLAB:
-            webhookRemoteId = gitLabWebhookService.createWebhook(workspace,savedWebhook.getId().toString());
-            break;
-        case BITBUCKET:
-            webhookRemoteId = BitBucketWebhookService.createWebhook(workspace,savedWebhook.getId().toString());
-            break;
-        default:
-            break;
-    }
-
-    if(webhookRemoteId.isEmpty()){
-        log.error("Error creating the webhook");
-        return;
-    }
-
-    savedWebhook.setRemoteHookId(webhookRemoteId);
-    // Save the updated webhook
-    webhookRepository.save(savedWebhook);
-  }
- }
- 
- 
- private void sendCommitStatus(Job job) {
-    switch (job.getWorkspace().getVcs().getVcsType()) {
-        case GITHUB:
-            gitHubWebhookService.sendCommitStatus(job, JobStatus.pending);
-            break;
-        default:
-            break;
-    }
- }
 }

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookServiceBase.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookServiceBase.java
@@ -82,9 +82,13 @@ public class WebhookServiceBase {
     }
 
     protected ResponseEntity<String> makeApiRequest(HttpHeaders headers, String body, String apiUrl) {
+        return makeApiRequest(headers, body, apiUrl, HttpMethod.POST);
+    }
+
+    protected ResponseEntity<String> makeApiRequest(HttpHeaders headers, String body, String apiUrl, HttpMethod method) {
         RestTemplate restTemplate = new RestTemplate();
         HttpEntity<String> entity = new HttpEntity<>(body, headers);
-        return restTemplate.exchange(apiUrl, HttpMethod.POST, entity, String.class);
+        return restTemplate.exchange(apiUrl, method, entity, String.class);
     }
 
     protected WebhookResult handleWebhook(String jsonPayload, Map<String, String> headers, String token,

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
@@ -2,6 +2,7 @@ package org.terrakube.api.plugin.vcs.provider.bitbucket;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -22,7 +23,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.*;
 
-
 @Service
 @Slf4j
 public class BitBucketWebhookService extends WebhookServiceBase {
@@ -36,14 +36,14 @@ public class BitBucketWebhookService extends WebhookServiceBase {
 
     public BitBucketWebhookService(WorkspaceRepository workspaceRepository, ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
-        this.workspaceRepository =workspaceRepository;
+        this.workspaceRepository = workspaceRepository;
     }
 
     public WebhookResult processWebhook(String jsonPayload, Map<String, String> headers, String token) {
         return handleWebhook(jsonPayload, headers, token, "x-hub-signature", "Bitbucket", this::handleEvent);
     }
 
-    private WebhookResult handleEvent(String jsonPayload, WebhookResult result, Map<String, String> headers){
+    private WebhookResult handleEvent(String jsonPayload, WebhookResult result, Map<String, String> headers) {
         // Extract event
         String event = headers.get("x-event-key");
         if (event != null) {
@@ -68,12 +68,18 @@ public class BitBucketWebhookService extends WebhookServiceBase {
                 String author = authorNode.asText();
                 result.setCreatedBy(author);
 
-                BitbucketTokenModel bitbucketTokenModel = new ObjectMapper().readValue(jsonPayload, BitbucketTokenModel.class);
-                if(bitbucketTokenModel.getPush().getChanges().size() == 1) {
-                    log.info("Bitbucket commit: {}", bitbucketTokenModel.getPush().getChanges().get(0).getNewCommit().getTarget().getHash());
-                    log.info("Bitbucket diff file: {}", bitbucketTokenModel.getPush().getChanges().get(0).getLinks().getDiff().getHref());
-                    result.setCommit(bitbucketTokenModel.getPush().getChanges().get(0).getNewCommit().getTarget().getHash());
-                    result.setFileChanges(getFileChanges(bitbucketTokenModel.getPush().getChanges().get(0).getLinks().getDiff().getHref(), result.getWorkspaceId()));
+                BitbucketTokenModel bitbucketTokenModel = new ObjectMapper().readValue(jsonPayload,
+                        BitbucketTokenModel.class);
+                if (bitbucketTokenModel.getPush().getChanges().size() == 1) {
+                    log.info("Bitbucket commit: {}",
+                            bitbucketTokenModel.getPush().getChanges().get(0).getNewCommit().getTarget().getHash());
+                    log.info("Bitbucket diff file: {}",
+                            bitbucketTokenModel.getPush().getChanges().get(0).getLinks().getDiff().getHref());
+                    result.setCommit(
+                            bitbucketTokenModel.getPush().getChanges().get(0).getNewCommit().getTarget().getHash());
+                    result.setFileChanges(getFileChanges(
+                            bitbucketTokenModel.getPush().getChanges().get(0).getLinks().getDiff().getHref(),
+                            result.getWorkspaceId()));
                 } else {
                     log.error("Bitbucket webhook with more than 1 changes is not supported");
                 }
@@ -90,9 +96,11 @@ public class BitBucketWebhookService extends WebhookServiceBase {
         List<String> fileChanges = new ArrayList<>();
 
         try {
-            String accessToken = "Bearer " + workspaceRepository.findById(UUID.fromString(workspaceId)).get().getVcs().getAccessToken();
+            String accessToken = "Bearer "
+                    + workspaceRepository.findById(UUID.fromString(workspaceId)).get().getVcs().getAccessToken();
             URL urlBitbucketApi = new URL(diffFile);
-            log.info("Base URL: {}", String.format("%s://%s", urlBitbucketApi.getProtocol(), urlBitbucketApi.getHost()));
+            log.info("Base URL: {}",
+                    String.format("%s://%s", urlBitbucketApi.getProtocol(), urlBitbucketApi.getHost()));
             log.info("URI: {}", urlBitbucketApi.getPath());
             WebClient webClient = WebClient.builder()
                     .baseUrl(String.format("%s://%s", urlBitbucketApi.getProtocol(), urlBitbucketApi.getHost()))
@@ -106,8 +114,8 @@ public class BitBucketWebhookService extends WebhookServiceBase {
                     .timeout(Duration.ofSeconds(10))
                     .block();
 
-            new BufferedReader(new StringReader(diffContent)).lines().forEach(line ->{
-                if(line.startsWith("diff --git ")){
+            new BufferedReader(new StringReader(diffContent)).lines().forEach(line -> {
+                if (line.startsWith("diff --git ")) {
                     log.warn("Checking change: {}", line);
                     // Example
                     // diff --git a/work1/main.tf b/work1/main.tf
@@ -124,16 +132,11 @@ public class BitBucketWebhookService extends WebhookServiceBase {
     }
 
     public String createWebhook(Workspace workspace, String webhookId) {
-        String url = "";
+        String id = "";
         String secret = Base64.getEncoder()
                 .encodeToString(workspace.getId().toString().getBytes(StandardCharsets.UTF_8));
         String ownerAndRepo = extractOwnerAndRepo(workspace.getSource());
         String webhookUrl = String.format("https://%s/webhook/v1/%s", hostname, webhookId);
-
-        // Create the headers
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Accept", "application/json");
-        headers.set("Authorization", "Bearer " + workspace.getVcs().getAccessToken());
 
         // Create the body, in this version we only support push event but in future we
         // can make this more dynamic
@@ -142,23 +145,48 @@ public class BitBucketWebhookService extends WebhookServiceBase {
 
         String apiUrl = workspace.getVcs().getApiUrl() + "/repositories/" + ownerAndRepo + "/hooks";
 
-        ResponseEntity<String> response = makeApiRequest(headers, body, apiUrl);
+        ResponseEntity<String> response = callBitBucketApi(workspace.getVcs().getAccessToken(), body, apiUrl,
+                HttpMethod.POST);
 
         // Extract the id from the response
-        if (response.getStatusCodeValue() == 201) {
+        if (response.getStatusCode().value() == 201) {
             ObjectMapper objectMapper = new ObjectMapper();
             try {
                 JsonNode rootNode = objectMapper.readTree(response.getBody());
-                url = rootNode.path("links").path("self").path("href").asText();
+                id = rootNode.path("uuid").asText();
             } catch (Exception e) {
                 log.error("Error parsing JSON response", e);
             }
 
-            log.info("Hook created successfully {}" + url);
+            log.info("GitHub Hook created successfully for workspace {}/{} with id {}",
+                    workspace.getOrganization().getName(), workspace.getName(), id);
         } else {
             log.error("Error creating the webhook" + response.getBody());
         }
 
-        return url;
+        return id;
+    }
+
+    public void deleteWebhook(Workspace workspace, String webhookRemoteId) {
+        String ownerAndRepo = extractOwnerAndRepo(workspace.getSource());
+        String apiUrl = workspace.getVcs().getApiUrl() + "/repositories/" + ownerAndRepo + "/hooks/" + webhookRemoteId;
+
+        ResponseEntity<String> response = callBitBucketApi(workspace.getVcs().getAccessToken(), "", apiUrl,
+                HttpMethod.DELETE);
+        if (response.getStatusCode().value() == 204) {
+            log.info("Webhook with remote hook id {} on repository {} deleted successfully", webhookRemoteId,
+                    ownerAndRepo);
+        } else {
+            log.warn("Failed to delete webhook with remote hook id {} on repository {}, message {}", webhookRemoteId,
+                    ownerAndRepo, response.getBody());
+        }
+    }
+
+    private ResponseEntity<String> callBitBucketApi(String token, String body, String apiUrl, HttpMethod httpMethod) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", "application/json");
+        headers.set("Authorization", "Bearer " + token);
+
+        return makeApiRequest(headers, body, apiUrl, httpMethod);
     }
 }

--- a/api/src/main/java/org/terrakube/api/repository/WebhookRepository.java
+++ b/api/src/main/java/org/terrakube/api/repository/WebhookRepository.java
@@ -1,12 +1,9 @@
 package org.terrakube.api.repository;
 
-import org.terrakube.api.rs.webhook.Webhook;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
 import java.util.UUID;
 
-public interface WebhookRepository extends JpaRepository<Webhook, UUID> {
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.terrakube.api.rs.webhook.Webhook;
 
-    Optional<Webhook> findByReferenceId(String referenceId);
+public interface WebhookRepository extends JpaRepository<Webhook, UUID> {
 }

--- a/api/src/main/java/org/terrakube/api/rs/Organization.java
+++ b/api/src/main/java/org/terrakube/api/rs/Organization.java
@@ -1,10 +1,11 @@
 package org.terrakube.api.rs;
 
-import com.yahoo.elide.annotation.*;
-import lombok.Getter;
-import lombok.Setter;
+import java.sql.Types;
+import java.util.List;
+import java.util.UUID;
+
 import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.SQLRestriction;
 import org.terrakube.api.rs.agent.Agent;
 import org.terrakube.api.rs.globalvar.Globalvar;
 import org.terrakube.api.rs.hooks.organization.OrganizationManageHook;
@@ -12,18 +13,28 @@ import org.terrakube.api.rs.job.Job;
 import org.terrakube.api.rs.module.Module;
 import org.terrakube.api.rs.provider.Provider;
 import org.terrakube.api.rs.ssh.Ssh;
-import org.terrakube.api.rs.team.Team;
 import org.terrakube.api.rs.tag.Tag;
+import org.terrakube.api.rs.team.Team;
 import org.terrakube.api.rs.template.Template;
 import org.terrakube.api.rs.vcs.Vcs;
 import org.terrakube.api.rs.workspace.Workspace;
-import org.hibernate.annotations.Type;
 
-import jakarta.persistence.*;
+import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.DeletePermission;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.LifeCycleHookBinding;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.annotation.UpdatePermission;
 
-import java.sql.Types;
-import java.util.List;
-import java.util.UUID;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.Setter;
 
 @ReadPermission(expression = "user belongs organization")
 @CreatePermission(expression = "user is a superuser")
@@ -35,7 +46,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @Entity(name = "organization")
-@Where(clause = "disabled = false")
+@SQLRestriction(value = "disabled = false")
 public class Organization {
 
     @Id

--- a/api/src/main/java/org/terrakube/api/rs/hooks/webhook/WebhookManageHook.java
+++ b/api/src/main/java/org/terrakube/api/rs/hooks/webhook/WebhookManageHook.java
@@ -1,0 +1,62 @@
+package org.terrakube.api.rs.hooks.webhook;
+
+import java.util.Optional;
+
+import org.apache.hc.core5.http.HttpStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.terrakube.api.plugin.vcs.WebhookService;
+import org.terrakube.api.rs.webhook.Webhook;
+
+import com.yahoo.elide.annotation.LifeCycleHookBinding.Operation;
+import com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase;
+import com.yahoo.elide.core.lifecycle.LifeCycleHook;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class WebhookManageHook implements LifeCycleHook<Webhook> {
+    @Autowired
+    WebhookService webhookService;
+
+    @Override
+    public void execute(Operation operation, TransactionPhase phase, Webhook elideEntity, RequestScope requestScope,
+            Optional<ChangeSpec> changes) {
+        switch (operation) {
+            case CREATE:
+                switch (phase) {
+                    case PRECOMMIT:
+                        try {
+                            webhookService.createWorkspaceWebhook(elideEntity);
+                        } catch (Exception e) {
+                            throw new WebhookManagementException(HttpStatus.SC_FAILED_DEPENDENCY,
+                                    "Failed to create webhook: " + e.getMessage());
+                        }
+                        break;
+
+                    default:
+                        break;
+                }
+                break;
+            case DELETE:
+                switch (phase) {
+                    case POSTCOMMIT:
+                        try {
+                            webhookService.deleteWorkspaceWebhook(elideEntity);
+                        } catch (Exception e) {
+                            throw new WebhookManagementException(HttpStatus.SC_FAILED_DEPENDENCY,
+                                    "Failed to delete webhook: " + e.getMessage());
+                        }
+                        break;
+
+                    default:
+                        break;
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+}

--- a/api/src/main/java/org/terrakube/api/rs/hooks/webhook/WebhookManagementException.java
+++ b/api/src/main/java/org/terrakube/api/rs/hooks/webhook/WebhookManagementException.java
@@ -1,0 +1,10 @@
+package org.terrakube.api.rs.hooks.webhook;
+
+import com.yahoo.elide.core.exceptions.HttpStatusException;
+
+
+public class WebhookManagementException extends HttpStatusException {
+    protected WebhookManagementException(int failedDependency, String message) {
+        super(failedDependency, message);
+    }
+}

--- a/api/src/main/java/org/terrakube/api/rs/webhook/Webhook.java
+++ b/api/src/main/java/org/terrakube/api/rs/webhook/Webhook.java
@@ -1,40 +1,55 @@
 package org.terrakube.api.rs.webhook;
 
-import com.yahoo.elide.annotation.Include;
-import lombok.Getter;
-import lombok.Setter;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.annotations.Type;
-
-import jakarta.persistence.*;
-import org.terrakube.api.rs.IdConverter;
-
 import java.sql.Types;
 import java.util.UUID;
 
-@Include(rootLevel = false)
+import org.hibernate.annotations.JdbcTypeCode;
+import org.terrakube.api.plugin.security.audit.GenericAuditFields;
+import org.terrakube.api.rs.IdConverter;
+import org.terrakube.api.rs.hooks.webhook.WebhookManageHook;
+import org.terrakube.api.rs.workspace.Workspace;
+
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.LifeCycleHookBinding;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import lombok.Getter;
+import lombok.Setter;
+
+@Include
 @Getter
 @Setter
+@LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.CREATE, phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT, hook = WebhookManageHook.class)
+@LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.DELETE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = WebhookManageHook.class)
 @Entity(name = "webhook")
-public class Webhook {
+public class Webhook extends GenericAuditFields{
 
     @Id
     @JdbcTypeCode(Types.VARCHAR)
     @Convert(converter = IdConverter.class)
-    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
-
-    @Column(name="type")
-    @Enumerated(EnumType.STRING)
-    private WebhookType type;
-
-    @Column(name="template_mapping")
-    private String templateMapping;
-
-    @Column(name="reference_id")
-    private String referenceId;
 
     @Column(name="remote_hook_id")
     private String remoteHookId;
+    
+    private String branch;
+    
+    private String path;
+    
+    @Column(name="template_id")
+    private String templateId;
+
+    @Enumerated(EnumType.STRING)
+    private WebhookEvent event = WebhookEvent.PUSH;
+    
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    private Workspace workspace;
 }
 

--- a/api/src/main/java/org/terrakube/api/rs/webhook/WebhookEvent.java
+++ b/api/src/main/java/org/terrakube/api/rs/webhook/WebhookEvent.java
@@ -1,0 +1,5 @@
+package org.terrakube.api.rs.webhook;
+
+public enum WebhookEvent {
+    PUSH
+}

--- a/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
@@ -1,43 +1,58 @@
 package org.terrakube.api.rs.workspace;
 
-import com.yahoo.elide.annotation.*;
-import lombok.Getter;
-import lombok.Setter;
+import java.sql.Types;
+import java.util.List;
+import java.util.UUID;
+
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.SQLRestriction;
 import org.terrakube.api.plugin.security.audit.GenericAuditFields;
 import org.terrakube.api.rs.IdConverter;
 import org.terrakube.api.rs.Organization;
 import org.terrakube.api.rs.agent.Agent;
 import org.terrakube.api.rs.hooks.workspace.WorkspaceManageHook;
+import org.terrakube.api.rs.job.Job;
 import org.terrakube.api.rs.ssh.Ssh;
 import org.terrakube.api.rs.vcs.Vcs;
+import org.terrakube.api.rs.webhook.Webhook;
 import org.terrakube.api.rs.workspace.content.Content;
-import org.terrakube.api.rs.workspace.parameters.Variable;
-import org.terrakube.api.rs.job.Job;
 import org.terrakube.api.rs.workspace.history.History;
-import org.terrakube.api.rs.workspace.tag.WorkspaceTag;
+import org.terrakube.api.rs.workspace.parameters.Variable;
 import org.terrakube.api.rs.workspace.schedule.Schedule;
-import org.hibernate.annotations.Type;
-import org.hibernate.annotations.Where;
+import org.terrakube.api.rs.workspace.tag.WorkspaceTag;
 
-import jakarta.persistence.*;
+import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.DeletePermission;
+import com.yahoo.elide.annotation.Exclude;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.LifeCycleHookBinding;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.annotation.UpdatePermission;
 
-import java.sql.Types;
-import java.util.List;
-import java.util.UUID;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import lombok.Getter;
+import lombok.Setter;
 
 @ReadPermission(expression = "team view workspace")
 @CreatePermission(expression = "team manage workspace")
 @UpdatePermission(expression = "team manage workspace")
 @DeletePermission(expression = "team manage workspace")
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.UPDATE, phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT, hook = WorkspaceManageHook.class)
-@LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.CREATE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = WorkspaceManageHook.class)
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.CREATE, phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT, hook = WorkspaceManageHook.class)
 @Include
 @Getter
 @Setter
 @Entity(name = "workspace")
-@Where(clause = "deleted = false")
+@SQLRestriction(value = "deleted = false")
 public class Workspace extends GenericAuditFields {
 
     @Id
@@ -114,4 +129,6 @@ public class Workspace extends GenericAuditFields {
     @OneToOne
     private Agent agent;
     
+    @OneToMany(mappedBy = "workspace", fetch = FetchType.LAZY)
+    private List<Webhook> webhook;
 }

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -188,4 +188,6 @@ org.terrakube.dynamic.credentials.ttl=${DynamicCredentialTtl:30}
 org.terrakube.dynamic.credentials.public-key-path=${DynamicCredentialPublicKeyPath:}
 org.terrakube.dynamic.credentials.private-key-path=${DynamicCredentialPrivateKeyPath:}
 
-# logging.level.org.springframework.security=DEBUG
+# logging.level.org.springframework=DEBUG
+# logging.level.org.terrakube=DEBUG
+# logging.level.com.yahoo.elide=DEBUG

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -58,4 +58,5 @@
     <include file="/db/changelog/local/changelog-2.21.0-has-changes.xml"/>
     <include file="/db/changelog/local/changelog-2.22.0-global-vars-size.xml"/>
     <include file="/db/changelog/local/changelog-2.22.0-global-var-key-size.xml"/>
+    <include file="/db/changelog/local/changelog-2.22.2-webhook-triggers.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.22.2-webhook-triggers.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.22.2-webhook-triggers.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-22-2-1" author="Stanley Zhang (stanley.zhang@ityin.net)">
+        <addColumn tableName="webhook">
+            <column name="branch" type="varchar(512)" />
+            <column name="path" type="varchar(512)" />
+            <column name="event" type="varchar(72)" />
+            <column name="template_id" type="varchar(36)" />
+            <column name="created_date" type="datetime" />
+            <column name="updated_date" type="datetime" />
+            <column name="created_by" type="varchar(128)"/> 
+            <column name="updated_by" type="varchar(128)"/> 
+        </addColumn>
+        <dropColumn tableName="webhook">
+            <column name="template_mapping" />
+            <column name="type" />
+        </dropColumn>
+
+        <renameColumn tableName="webhook" oldColumnName="reference_id" newColumnName="workspace_id"
+            columnDataType="varchar(36)" />
+
+        <addForeignKeyConstraint baseTableName="webhook" baseColumnNames="template_id"
+            constraintName="fk_webhook_template_id" referencedTableName="template"
+            referencedColumnNames="id" onDelete="SET NULL" />
+        <addForeignKeyConstraint baseTableName="webhook" baseColumnNames="workspace_id"
+            constraintName="fk_webhook_workspace_id" referencedTableName="workspace"
+            referencedColumnNames="id" onDelete="CASCADE" />
+    </changeSet>
+</databaseChangeLog>

--- a/ui/src/domain/Workspaces/Create.jsx
+++ b/ui/src/domain/Workspaces/Create.jsx
@@ -1,34 +1,37 @@
-import { React, useState, useEffect } from "react";
 import {
+  DownOutlined,
+  InfoCircleOutlined,
+  GithubOutlined,
+  GitlabOutlined,
+} from "@ant-design/icons";
+import {
+  Breadcrumb,
+  Button,
+  Card,
+  Checkbox,
+  Dropdown,
   Form,
   Input,
-  Button,
-  Breadcrumb,
   Layout,
-  Steps,
-  Card,
-  Space,
-  Select,
-  message,
-  Dropdown,
   List,
+  Select,
+  Space,
+  Switch,
+  Steps,
+  message,
 } from "antd";
+import { React, useEffect, useState, version } from "react";
+import { IconContext } from "react-icons";
+import { BiBookBookmark, BiTerminal, BiUpload } from "react-icons/bi";
+import { SiAzuredevops, SiBitbucket, SiGit } from "react-icons/si";
+import { Link, useNavigate } from "react-router-dom";
+import { v7 as uuid } from "uuid";
 import {
   ORGANIZATION_ARCHIVE,
   ORGANIZATION_NAME,
 } from "../../config/actionTypes";
 import axiosInstance from "../../config/axiosConfig";
-import { BiTerminal, BiBookBookmark, BiUpload } from "react-icons/bi";
 import { compareVersions } from "./Workspaces";
-import { IconContext } from "react-icons";
-import {
-  GithubOutlined,
-  GitlabOutlined,
-  DownOutlined,
-} from "@ant-design/icons";
-import { SiBitbucket, SiAzuredevops } from "react-icons/si";
-import { SiGit } from "react-icons/si";
-import { useNavigate, Link } from "react-router-dom";
 const { Content } = Layout;
 const { Step } = Steps;
 const validateMessages = {
@@ -50,6 +53,10 @@ export const CreateWorkspace = () => {
   const [vcsId, setVcsId] = useState("");
   const [current, setCurrent] = useState(0);
   const [step3Hidden, setStep4Hidden] = useState(true);
+  const [isWebhooKEnabled, setWebhookEnabled] = useState(true);
+  const [defaultBranch, setDefaultBranch] = useState("");
+  const [defaultPath, setDefaultPath] = useState("");
+  const [defaultTemplate, setDefaultTemplate] = useState("");
   const [step2Hidden, setStep3Hidden] = useState(true);
   const [sshKeysVisible, setSSHKeysVisible] = useState(false);
   const [versionControlFlow, setVersionControlFlow] = useState(true);
@@ -166,6 +173,25 @@ export const CreateWorkspace = () => {
     setVCSButtonsVisible(true);
   };
 
+  const handleWebhookClick = (e) => {
+    setWebhookEnabled(!isWebhooKEnabled);
+  }
+
+  const handleBranchChange = (e) => {
+    setDefaultBranch(e.target.value);
+  }
+  const handlePathChange = (e) => {
+    setDefaultPath(e.target.value);
+  }
+  const handleTemplateChange = (e) => {
+    orgTemplates.forEach((template) => {
+      if (template.id === e) {
+        setDefaultTemplate(template.attributes.name);
+        return;
+      }
+    });
+  }
+
   const renderVCSLogo = (vcs) => {
     switch (vcs) {
       case "GITLAB":
@@ -242,9 +268,8 @@ export const CreateWorkspace = () => {
   };
 
   const loadVersions = (iacType) => {
-    const versionsApi = `${
-      new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin
-    }/${iacType.id}/index.json`;
+    const versionsApi = `${new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin
+      }/${iacType.id}/index.json`;
     axiosInstance.get(versionsApi).then((resp) => {
       console.log(resp);
       const tfVersions = [];
@@ -264,84 +289,94 @@ export const CreateWorkspace = () => {
   };
 
   const onFinish = (values) => {
+    const workspace_lid = uuid();
     let body = {
-      data: {
-        type: "workspace",
-        attributes: {
-          source: values.source,
-          folder: values.folder,
-          name: values.name,
-          terraformVersion: values.terraformVersion,
-          branch: values.branch,
-          iacType: iacType.id,
-        },
-      },
+      "atomic:operations": [
+        {
+          op: "add",
+          href: `/organization/${organizationId}/workspace`,
+          data: {
+            type: "workspace",
+            lid: workspace_lid,
+            attributes: {
+              source: values.source,
+              folder: values.folder,
+              name: values.name,
+              terraformVersion: values.terraformVersion,
+              branch: values.branch,
+              iacType: iacType.id,
+            },
+            relationships: {}
+          },
+        }],
     };
 
     if (vcsId !== "") {
-      body = {
+      body["atomic:operations"][0].data.relationships["vcs"] = {
         data: {
-          type: "workspace",
-          attributes: {
-            source: values.source,
-            folder: values.folder,
-            name: values.name,
-            terraformVersion: values.terraformVersion,
-            branch: values.branch,
-            iacType: iacType.id,
-            defaultTemplate: values.defaultTemplate,
-          },
-          relationships: {
-            vcs: {
-              data: {
-                type: "vcs",
-                id: vcsId,
-              },
-            },
-          },
-        },
-      };
-    }
-    if (values.sshKey) {
-      body = {
-        data: {
-          type: "workspace",
-          attributes: {
-            source: values.source,
-            folder: values.folder,
-            name: values.name,
-            terraformVersion: values.terraformVersion,
-            branch: values.branch,
-            iacType: iacType.id,
-          },
-          relationships: {
-            ssh: {
-              data: {
-                type: "ssh",
-                id: values.sshKey,
-              },
-            },
-          },
+          type: "vcs",
+          id: vcsId,
         },
       };
     }
 
+    if (values.sshKey) {
+      body["atomic:operations"][0].data.relationships["ssh"] = {
+        data: {
+          type: "ssh",
+          id: values.sshKey,
+        },
+      }
+    }
+
+    if (isWebhooKEnabled) {
+      const webhook_lid = uuid();
+      body["atomic:operations"].push({
+        op: "add",
+        href: `/organization/${organizationId}/workspace/${workspace_lid}/webhook`,
+        data: {
+          type: "webhook",
+          lid: webhook_lid,
+          attributes: {
+            branch: values.webhookBranch,
+            path: values.webhookPath,
+            templateId: values.webhookTemplate,
+          },
+          relationships: {
+            workspace: {
+              data: {
+                type: "workspace",
+                id: workspace_lid,
+              }
+            }
+          }
+        }
+      })
+    }
+
     axiosInstance
-      .post(`organization/${organizationId}/workspace`, body, {
+      .post(`/operations`, body, {
         headers: {
-          "Content-Type": "application/vnd.api+json",
+          "Content-Type": "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic\"",
+          "Accept": "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic\"",
         },
       })
       .then((response) => {
         console.log(response.status);
-        if (response.status === 201) {
-          console.log("/workspaces/" + response.data.data.id);
-          navigate("/workspaces/" + response.data.data.id);
+        if (response.status === 200) {
+          console.log(`/organizations/${organizationId}/workspaces/${response.data["atomic:results"][0].data.id}`);
+          navigate(`/organizations/${organizationId}/workspaces/${response.data["atomic:results"][0].data.id}`);
         }
       })
       .catch((error) => {
         if (error.response) {
-          if (error.response.status === 403) {
+          if (error.response.status === 424) {
+            message.error(
+              <span>
+                An error occurred while creating the webhook, please check whether your VCS connection has the right permission.
+              </span>
+            );
+          } else if (error.response.status === 403) {
             message.error(
               <span>
                 You are not authorized to create workspaces. <br /> Please
@@ -676,13 +711,13 @@ export const CreateWorkspace = () => {
 
               <Form.Item
                 name="branch"
-                label="VCS branches"
+                label="VCS branch"
                 placeholder="(default branch)"
-                extra=" The branches from which the runs are allowed to kick off, separated by comma. The first one is used as the default for runs kicked off from UI. All braches are compared as prefixes against the branch name in a git push."
+                extra="The branch from which the runs are kicked off, this is used for runs issued from the UI."
                 rules={[{ required: true }]}
                 hidden={!versionControlFlow}
               >
-                <Input />
+                <Input onChange={handleBranchChange} />
               </Form.Item>
               <Form.Item
                 name="folder"
@@ -692,7 +727,24 @@ export const CreateWorkspace = () => {
                 rules={[{ required: true }]}
                 hidden={!versionControlFlow}
               >
-                <Input />
+                <Input onChange={handlePathChange} />
+              </Form.Item>
+              <Form.Item
+                name="defaultTemplate"
+                label="Default template (VCS Push)"
+                tooltip="Template that will be executed by default when doing a git push to the repository."
+                rules={[{ required: true }]}
+                hidden={!versionControlFlow}
+              >
+                <Select onChange={handleTemplateChange} placeholder="Select Template" style={{ width: 250 }}>
+                  {orgTemplates.map(function (template, index) {
+                    return (
+                      <Option key={template?.id}>
+                        {template?.attributes?.name}
+                      </Option>
+                    );
+                  })}
+                </Select>
               </Form.Item>
               <Form.Item
                 name="terraformVersion"
@@ -711,23 +763,6 @@ export const CreateWorkspace = () => {
                 </Select>
               </Form.Item>
               <Form.Item
-                name="defaultTemplate"
-                label="Default template (VCS Push)"
-                tooltip="Template that will be executed by default when doing a git push to the repository."
-                rules={[{ required: false }]}
-                hidden={!versionControlFlow}
-              >
-                <Select placeholder="Select Template" style={{ width: 250 }}>
-                  {orgTemplates.map(function (template, index) {
-                    return (
-                      <Option key={template?.id}>
-                        {template?.attributes?.name}
-                      </Option>
-                    );
-                  })}
-                </Select>
-              </Form.Item>
-              <Form.Item
                 hidden={!sshKeysVisible}
                 name="sshKey"
                 label="SSH Key"
@@ -740,6 +775,54 @@ export const CreateWorkspace = () => {
                     return (
                       <Option key={sshKey?.id}>
                         {sshKey?.attributes?.name}
+                      </Option>
+                    );
+                  })}
+                </Select>
+              </Form.Item>
+              <Form.Item
+                hidden={!versionControlFlow}
+                label="Enable Push Webhook?"
+                tooltip={{
+                  title: "Whether to trigger a run when a push event is received from the selected VCS provider.",
+                  icon: <InfoCircleOutlined />,
+                }}
+              >
+                <Switch onChange={handleWebhookClick} defaultChecked={true} />
+              </Form.Item>
+              <Form.Item
+                hidden={!isWebhooKEnabled || !versionControlFlow}
+                name="webhookBranch"
+                label="Webhook Branch"
+                tooltip="A list of branch prefixes that will trigger a run."
+                extra="A list of brach prefixes besides the default VCS branch that will trigger a run, for example 'feat,fix'. Values are separated by comma."
+                rules={[{ required: false }]}
+              >
+                <Input placeholder={defaultBranch} />
+              </Form.Item>
+              <Form.Item
+                hidden={!isWebhooKEnabled || !versionControlFlow}
+                name="webhookPath"
+                label="Webhook Path"
+                tooltip="A list of regex to match against the paths in the source that will trigger a run."
+                extra="A list of regex to match against the paths besides the 'Terraform Working Directory' that will trigger a run, for example 'modules/.*.tf'. Values are separated by comma."
+                rules={[{ required: false }]}
+              >
+                <Input placeholder={defaultPath} />
+              </Form.Item>
+              <Form.Item
+                hidden={!isWebhooKEnabled || !versionControlFlow}
+                name="webhookTemplate"
+                label="Webhook Template"
+                tooltip="The template that will be executed when a push event is received from the selected VCS provider."
+                extra="The template that will be executed when a push event is received from the selected VCS provider."
+                rules={[{ required: false }]}
+              >
+                <Select placeholder={defaultTemplate} style={{ width: 250 }}>
+                  {orgTemplates.map(function (template, index) {
+                    return (
+                      <Option key={template?.id}>
+                        {template?.attributes?.name}
                       </Option>
                     );
                   })}

--- a/ui/src/domain/Workspaces/Create.jsx
+++ b/ui/src/domain/Workspaces/Create.jsx
@@ -305,6 +305,7 @@ export const CreateWorkspace = () => {
               terraformVersion: values.terraformVersion,
               branch: values.branch,
               iacType: iacType.id,
+              defaultTemplate: values.defaultTemplate,
             },
             relationships: {}
           },

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -1,67 +1,68 @@
-import { React, useEffect, useState } from "react";
-import axiosInstance from "../../config/axiosConfig";
-import { useNavigate, useParams, Link } from "react-router-dom";
-import {
-  ORGANIZATION_ARCHIVE,
-  WORKSPACE_ARCHIVE,
-  ORGANIZATION_NAME,
-} from "../../config/actionTypes";
-import {
-  Button,
-  Layout,
-  Breadcrumb,
-  Tabs,
-  List,
-  Space,
-  Avatar,
-  Tag,
-  Form,
-  Input,
-  Select,
-  message,
-  Spin,
-  Switch,
-  Typography,
-  Popconfirm,
-  Row,
-  Col,
-  Divider,
-  Table,
-} from "antd";
-import { compareVersions } from "./Workspaces";
-import { CreateJob } from "../Jobs/Create";
-import { DetailsJob } from "../Jobs/Details";
-import { Variables } from "../Workspaces/Variables";
-import { States } from "../Workspaces/States";
-import { Schedules } from "../Workspaces/Schedules";
-import { CLIDriven } from "../Workspaces/CLIDriven";
-import { Tags } from "../Workspaces/Tags";
-import { ResourceDrawer } from "../Workspaces/ResourceDrawer";
-import ActionLoader from "../../ActionLoader.jsx";
 import {
   CheckCircleOutlined,
   ClockCircleOutlined,
-  SyncOutlined,
-  ExclamationCircleOutlined,
-  StopOutlined,
-  InfoCircleOutlined,
   DeleteOutlined,
-  UserOutlined,
-  ThunderboltOutlined,
-  PlayCircleOutlined,
-  LockOutlined,
-  ProfileOutlined,
-  UnlockOutlined,
-  GitlabOutlined,
+  ExclamationCircleOutlined,
   GithubOutlined,
+  GitlabOutlined,
+  InfoCircleOutlined,
+  LockOutlined,
+  PlayCircleOutlined,
+  ProfileOutlined,
+  StopOutlined,
+  SyncOutlined,
+  ThunderboltOutlined,
+  UnlockOutlined,
+  UserOutlined,
 } from "@ant-design/icons";
-import { SiTerraform, SiBitbucket, SiAzuredevops } from "react-icons/si";
-import { HiOutlineExternalLink } from "react-icons/hi";
+import {
+  Avatar,
+  Breadcrumb,
+  Button,
+  Col,
+  Divider,
+  Form,
+  Input,
+  Layout,
+  List,
+  message,
+  Popconfirm,
+  Row,
+  Select,
+  Space,
+  Spin,
+  Switch,
+  Table,
+  Tabs,
+  Tag,
+  Typography
+} from "antd";
+import { React, useEffect, useState } from "react";
 import { IconContext } from "react-icons";
-import { FiGitCommit } from "react-icons/fi";
 import { BiTerminal } from "react-icons/bi";
-import "./Workspaces.css";
+import { FiGitCommit } from "react-icons/fi";
+import { HiOutlineExternalLink } from "react-icons/hi";
+import { SiAzuredevops, SiBitbucket, SiTerraform } from "react-icons/si";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { v7 as uuid } from "uuid";
+import ActionLoader from "../../ActionLoader.jsx";
+import {
+  ORGANIZATION_ARCHIVE,
+  ORGANIZATION_NAME,
+  WORKSPACE_ARCHIVE,
+} from "../../config/actionTypes";
+import axiosInstance from "../../config/axiosConfig";
+import { CreateJob } from "../Jobs/Create";
+import { DetailsJob } from "../Jobs/Details";
+import { CLIDriven } from "../Workspaces/CLIDriven";
+import { ResourceDrawer } from "../Workspaces/ResourceDrawer";
+import { Schedules } from "../Workspaces/Schedules";
+import { States } from "../Workspaces/States";
+import { Tags } from "../Workspaces/Tags";
+import { Variables } from "../Workspaces/Variables";
 import { getServiceIcon } from "./Icons.js";
+import { compareVersions } from "./Workspaces";
+import "./Workspaces.css";
 const { Option } = Select;
 const { Paragraph } = Typography;
 const include = {
@@ -71,6 +72,7 @@ const include = {
   SCHEDULE: "schedule",
   VCS: "vcs",
   AGENT: "agent",
+  WEBHOOK: "webhook",
 };
 const { DateTime } = require("luxon");
 const { Content } = Layout;
@@ -134,7 +136,13 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
   const [currentStateId, setCurrentStateId] = useState(0);
   const [selectedIac, setSelectedIac] = useState("");
   const [actions, setActions] = useState([]);
+  const [webhook, setWebhook] = useState({});
+  const [pushWebhookEnabled, setPushWebhookEnabled] = useState(true);
+  const [defaultBranch, setDefaultBranch] = useState("");
+  const [defaultPath, setDefaultPath] = useState("");
+  const [defaultTemplate, setDefaultTemplate] = useState("");
   const [contextState, setContextState] = useState({});
+  const pushWebhookName = "PUSH";
   const handleClick = (jobid) => {
     changeJob(jobid);
     navigate(
@@ -331,13 +339,13 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
 
   useEffect(() => {
     setLoading(true);
-    loadWorkspace(true);
+    loadWorkspace(true, true);
     setLoading(false);
     loadSSHKeys();
     loadAgentlist();
     loadOrgTemplates();
     const interval = setInterval(() => {
-      loadWorkspace(false);
+      loadWorkspace(false, false);
     }, 10000);
     return () => clearInterval(interval);
   }, [id]);
@@ -350,9 +358,8 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
   };
 
   const loadVersions = (iacType) => {
-    const versionsApi = `${
-      new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin
-    }/${iacType}/index.json`;
+    const versionsApi = `${new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin
+      }/${iacType}/index.json`;
     axiosInstance.get(versionsApi).then((resp) => {
       console.log(resp);
       const tfVersions = [];
@@ -371,14 +378,16 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
     });
   };
 
-  const loadWorkspace = (_loadVersions) => {
+  const loadWorkspace = (_loadVersions, _loadWebhook) => {
+    var url = `organization/${organizationId}/workspace/${id}?include=job,variable,history,schedule,vcs,agent,organization`;
+    if (_loadWebhook) url += ",webhook";
     axiosInstance
       .get(`organization/${organizationId}/template`)
       .then((template) => {
         setTemplates(template.data.data);
         axiosInstance
           .get(
-            `organization/${organizationId}/workspace/${id}?include=job,variable,history,schedule,vcs,agent,organization`
+            `organization/${organizationId}/workspace/${id}?include=job,variable,history,schedule,vcs,agent,organization,webhook`
           )
           .then((response) => {
             if (_loadVersions)
@@ -402,6 +411,9 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                 setResources,
                 setOutputs,
                 setAgent,
+                _loadWebhook,
+                setWebhook,
+                setPushWebhookEnabled,
                 setContextState
               );
             }
@@ -423,6 +435,25 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
           });
       });
   };
+
+  const handlePushWebhookClick = () => {
+    setPushWebhookEnabled(!pushWebhookEnabled);
+  }
+
+  const handleBranchChange = (e) => {
+    setDefaultBranch(e.target.value);
+  }
+  const handlePathChange = (e) => {
+    setDefaultPath(e.target.value);
+  }
+  const handleTemplateChange = (e) => {
+    orgTemplates.forEach((template) => {
+      if (template.id === e) {
+        setDefaultTemplate(template.attributes.name);
+        return;
+      }
+    });
+  }
 
   const handleClickSettings = () => {
     switchKey("6");
@@ -452,48 +483,103 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
           message.success("Workspace " + newstatus + " successfully");
         } else {
           var newstatus = locked ? "unlock" : "lock";
-          message.error("Workspace " + newstatus + " failed");
+          message.errr("Workspace " + newstatus + " failed");
         }
       });
   };
 
   const onFinish = (values) => {
     setWaiting(true);
+    const pushWebhookId = webhook[pushWebhookName]?.id;
+    const pushWebhookExists = pushWebhookId && pushWebhookId != "";
     const body = {
-      data: {
-        type: "workspace",
-        id: id,
-        attributes: {
-          name: values.name,
-          description: values.description,
-          folder: values.folder,
-          locked: values.locked,
-          executionMode: values.executionMode,
-          moduleSshKey: values.moduleSshKey,
-          terraformVersion: values.terraformVersion,
-          iacType: values.iacType,
-          branch: values.branch,
-          defaultTemplate: values.defaultTemplate,
+      "atomic:operations": [{
+        op: "update",
+        href: `/organization/${organizationId}/workspace/${id}`,
+        data: {
+          type: "workspace",
+          id: id,
+          attributes: {
+            name: values.name,
+            description: values.description,
+            folder: values.folder,
+            locked: values.locked,
+            executionMode: values.executionMode,
+            moduleSshKey: values.moduleSshKey,
+            terraformVersion: values.terraformVersion,
+            iacType: values.iacType,
+            branch: values.branch,
+            defaultTemplate: values.defaultTemplate,
+          },
         },
-      },
-    };
+      }]
+    }
+    if (pushWebhookEnabled) {
+      const newPushWebhookId = pushWebhookExists ? "" : uuid();
+      body["atomic:operations"].push({
+        op: pushWebhookExists ? "update" : "add",
+        href: pushWebhookExists ? `/organization/${organizationId}/workspace/${id}/webhook/${pushWebhookId}` : `/organization/${organizationId}/workspace/${id}/webhook`,
+        data: {
+          type: "webhook",
+          id: pushWebhookExists ? pushWebhookId : newPushWebhookId,
+          attributes: {
+            id: pushWebhookExists ? pushWebhookId : newPushWebhookId,
+            branch: values.pushWebhookBranch,
+            path: values.pushWebhookPath,
+            event: pushWebhookName,
+            templateId: values.pushWebhookTemplate,
+          },
+        }
+      })
+    }
+    if (!pushWebhookEnabled && pushWebhookExists) {
+      body["atomic:operations"].push({
+        op: "remove",
+        href: `/organization/${organizationId}/workspace/${id}/webhook/${pushWebhookId}`,
+      });
+    }
+
     console.log(body);
 
-    axiosInstance
-      .patch(`organization/${organizationId}/workspace/${id}`, body, {
-        headers: {
-          "Content-Type": "application/vnd.api+json",
-        },
-      })
-      .then((response) => {
-        console.log(response);
-        if (response.status === 204) {
-          message.success("Workspace updated successfully");
-        } else {
-          message.error("Workspace update failed");
+    try {
+      axiosInstance
+        .post("/operations",
+          body, atomicHeader
+        )
+        .then((response) => {
+          console.log(response);
+          if (response.status === 200) {
+            const pushWebhookData = response.data["atomic:results"][1]?.data;
+            if (pushWebhookEnabled && pushWebhookData) {
+              var updatedWebhook = {};
+              updatedWebhook[pushWebhookData.attributes.event] = {
+                id: pushWebhookData.id,
+                type: pushWebhookData.type,
+                ...pushWebhookData.attributes,
+              };
+              setWebhook(updatedWebhook);
+            }
+            if (!pushWebhookEnabled && pushWebhookExists) {
+              var updatedWebhook = webhook;
+              updatedWebhook[pushWebhookName] = null;
+              setWebhook(updatedWebhook);
+            }
+            message.success("workspace updated successfully");
+          } else {
+            message.error("workspace update failed");
+          }
+          setWaiting(false);
+        });
+    } catch (error) {
+      console.error("error updating workspace:", error);
+      message.error("workspace update failed");
+      if (error.response) {
+        if (error.response.status === 424) {
+          message.error("failed to create push webhook, please check if the set vcs connection has the correct permissions on the linked repository.");
         }
         setWaiting(false);
-      });
+      }
+    }
 
     var bodyAgent;
     console.log(`Using Agent: ${values.executorAgent}`);
@@ -513,13 +599,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
     axiosInstance
       .patch(
         `/organization/${organizationId}/workspace/${id}/relationships/agent`,
-        bodyAgent,
-        {
-          headers: {
-            "Content-Type": "application/vnd.api+json",
-          },
-        }
-      )
+        bodyAgent, genericHeader)
       .then((response) => {
         console.log("Update Workspace agent successfully");
         console.log(response);
@@ -530,6 +610,53 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
         }
       });
   };
+
+  const genericHeader = {
+    headers: {
+      "Content-Type": "application/vnd.api+json",
+    },
+  };
+  const atomicHeader = {
+    headers: {
+      "content-type": "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic\"",
+      "accept": "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic\"",
+    },
+  };
+
+  const deleteWebhook = () => {
+    const webhooks = Object.entries(webhook);
+    if (webhooks.length == 0) return;
+    var body = {
+      "atomic:operations": []
+    };
+    webhooks.map(([_, hook]) => {
+      body["atomic:operations"].push({
+        op: "remove",
+        href: `/organization/${organizationId}/workspace/${id}/webhook/${hook.id}`,
+      });
+    });
+    try {
+      axiosInstance.post(
+        "/operations",
+        body, atomicHeader
+      )
+        .then((response) => {
+          if (response.status == 200) {
+            message.success("Webhook deleted successfully");
+          } else {
+            message.error("Webhook deletion failed");
+          }
+        });
+    } catch (error) {
+      console.error("Error deleting webhook:", error);
+      message.error("Webhook deletion failed");
+      if (error.response) {
+        if (error.response.status === 424) {
+          message.error("Failed to delete webhook, please check if the set VCS connection has the correct permissions on the linked repository.");
+        }
+      }
+    }
+  }
 
   const renderVCSLogo = (vcs) => {
     switch (vcs) {
@@ -572,11 +699,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
       },
     };
     axiosInstance
-      .patch(`organization/${organizationId}/workspace/${id}`, body, {
-        headers: {
-          "Content-Type": "application/vnd.api+json",
-        },
-      })
+      .patch(`organization/${organizationId}/workspace/${id}`, body, genericHeader)
       .then((response) => {
         console.log(response);
         if (response.status === 204) {
@@ -587,6 +710,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
           message.error("Workspace deletion failed");
         }
       });
+    deleteWebhook();
   };
 
   return (
@@ -778,8 +902,8 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                   <Row>
                     <Col span={19} style={{ paddingRight: "20px" }}>
                       {workspace.data.attributes.source === "empty" &&
-                      workspace.data.attributes.branch === "remote-content" &&
-                      workspace.data.relationships.history.data.length < 1 ? (
+                        workspace.data.attributes.branch === "remote-content" &&
+                        workspace.data.relationships.history.data.length < 1 ? (
                         <CLIDriven
                           organizationName={organizationNameLocal}
                           workspaceName={workspaceName}
@@ -799,9 +923,9 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                               dataSource={
                                 jobs.length > 0
                                   ? jobs
-                                      .sort((a, b) => a.id - b.id)
-                                      .reverse()
-                                      .slice(0, 1)
+                                    .sort((a, b) => a.id - b.id)
+                                    .reverse()
+                                    .slice(0, 1)
                                   : []
                               }
                               renderItem={(item) => (
@@ -845,7 +969,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                                                 <Tag
                                                   icon={
                                                     item.status ==
-                                                    "completed" ? (
+                                                      "completed" ? (
                                                       <CheckCircleOutlined />
                                                     ) : item.status ==
                                                       "running" ? (
@@ -938,7 +1062,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                         <br />
                         <span className="App-text">
                           {workspace.data.attributes.branch !==
-                          "remote-content" ? (
+                            "remote-content" ? (
                             <>
                               {" "}
                               {renderVCSLogo(vcsProvider)}{" "}
@@ -1105,6 +1229,9 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                             workspace.data.relationships.agent.data?.id == null
                               ? "default"
                               : workspace.data.relationships.agent.data?.id,
+                          pushWebhookBranch: webhook[pushWebhookName]?.branch,
+                          pushWebhookPath: webhook[pushWebhookName]?.path,
+                          pushWebhookTemplate: webhook[pushWebhookName]?.templateId,
                         }}
                         layout="vertical"
                         name="form-settings"
@@ -1176,13 +1303,16 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                             ) +
                             " will execute within. This defaults to the root of your repository and is typically set to a subdirectory matching the environment when multiple environments exist within the same repository."
                           }
+                          onChange={handlePathChange}
                         >
                           <Input />
                         </Form.Item>
                         <Form.Item
                           name="branch"
-                          label="Branch list separated by comma used in VCS worklfow. The first is used as the default branch for runs kicked off from UI."
-                          extra="Don't update the value when using CLI Driven workflows. In the VCS driven workflow, the first branch is used for any runs from UI. All values in the list are compared as prefixes for runs kicked off from VCS webhooks."
+                          label="Default Branch"
+                          tooltip="The branch from which the runs are kicked off, this is used for runs issued from the UI."
+                          extra="Don't update the value when using CLI Driven workflows. This is only used in VCS driven workflow."
+                          onChange={handleBranchChange}
                         >
                           <Input />
                         </Form.Item>
@@ -1244,6 +1374,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                           extra="Default template when doing a git push to the repository"
                         >
                           <Select
+                            onChange={handleTemplateChange}
                             defaultValue={
                               workspace.data.attributes.defaultTemplate
                             }
@@ -1302,6 +1433,54 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                             <Option key="default">default</Option>
                           </Select>
                         </Form.Item>
+                        <Form.Item
+                          label="Enable Push Webhook?"
+                          hidden={vcsProvider == ""}
+                          tooltip={{
+                            title: "Whether to enable push webhook",
+                            icon: <InfoCircleOutlined />,
+                          }}
+                        >
+                          <Switch onChange={handlePushWebhookClick} defaultValue={pushWebhookEnabled} />
+                        </Form.Item>
+                        <Form.Item
+                          hidden={!pushWebhookEnabled}
+                          name="pushWebhookBranch"
+                          label="Webhook Branch"
+                          tooltip="A list of branch prefixes that will trigger a run."
+                          extra="A list of brach prefixes besides the default VCS branch that will trigger a run, for example 'feat,fix'. Values are separated by comma."
+                          rules={[{ required: false }]}
+                        >
+                          <Input placeholder={defaultBranch} />
+                        </Form.Item>
+                        <Form.Item
+                          hidden={!pushWebhookEnabled}
+                          name="pushWebhookPath"
+                          label="Webhook Path"
+                          tooltip="A list of regex to match against the paths in the source that will trigger a run."
+                          extra="A list of regex to match against the paths besides the 'Terraform Working Directory' that will trigger a run, for example 'modules/.*.tf'. Values are separated by comma."
+                          rules={[{ required: false }]}
+                        >
+                          <Input placeholder={defaultPath} />
+                        </Form.Item>
+                        <Form.Item
+                          hidden={!pushWebhookEnabled}
+                          name="pushWebhookTemplate"
+                          label="Webhook Template"
+                          tooltip="The template that will be executed when a push event is received from the selected VCS provider."
+                          extra="The template that will be executed when a push event is received from the selected VCS provider."
+                          rules={[{ required: false }]}
+                        >
+                          <Select placeholder={defaultTemplate} style={{ width: 250 }}>
+                            {orgTemplates.map(function (template, index) {
+                              return (
+                                <Option key={template?.id}>
+                                  {template?.attributes?.name}
+                                </Option>
+                              );
+                            })}
+                          </Select>
+                        </Form.Item>
                         <Form.Item>
                           <Button type="primary" htmlType="submit">
                             Save settings
@@ -1311,7 +1490,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                     </Spin>
                     <h1>Delete Workspace</h1>
                     <div className="App-Text">
-                      Deleting the workspace will permanently delete the
+                      Deleting thill permanently delete the
                       information. Please be certain that you understand this.
                       This action cannot be undone.
                     </div>
@@ -1379,10 +1558,14 @@ function setupWorkspaceIncludes(
   setResources,
   setOutputs,
   setAgent,
+  _loadWebhook,
+  setWebhook,
+  setPushWebhookEnabled,
   setContextState
 ) {
   let variables = [];
   let jobs = [];
+  let webhooks = {};
   let envVariables = [];
   let history = [];
   let schedule = [];
@@ -1475,6 +1658,13 @@ function setupWorkspaceIncludes(
           });
         }
         break;
+      case include.WEBHOOK:
+        webhooks[element.attributes.event] = {
+          id: element.id,
+          type: element.type,
+          ...element.attributes,
+        };
+        break;
     }
   });
 
@@ -1483,6 +1673,10 @@ function setupWorkspaceIncludes(
   setJobs(jobs);
   setHistory(history);
   setSchedule(schedule);
+  if (_loadWebhook) {
+    setWebhook(webhooks);
+    setPushWebhookEnabled(webhooks["PUSH"] ? true : false);
+  }
 
   console.log(
     `Parsing state for workspace ${localStorage.getItem(WORKSPACE_ARCHIVE)} `
@@ -1527,8 +1721,7 @@ function loadState(
     if (result.outputs.length < 1 && result.resources.length < 1) {
       axiosInstance
         .get(
-          `${
-            new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin
+          `${new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin
           }/tfstate/v1/organization/${organizationId}/workspace/${workspaceId}/state/terraform.tfstate`
         )
         .then((currentStateData) => {


### PR DESCRIPTION
This change updates the webhook functionality and adds three fields in the UI: branch, path and template so that the webhook can be triggered on a set path, branch and execute the configured template.

Additional changes:

1. Replace the deprecated functions/methods in `DexWebSecurityAdapter.java` while `Accept` is added to the allowed header for Elide JSON atomic operations.
2. Replace the deprecated `Where` annotation in `Workspace.java` with the new `SQLRestriction`

This is enhancement to #703 