### PR TITLE
fix: Change lock logic for local execution in CLI driven workflow

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -484,6 +484,12 @@ public class RemoteTfeService {
         return getWorkspace(organizationName, workspace.getName(), otherAttributes, currentUser);
     }
 
+    public boolean isWorkspaceLocked(String workspaceId) {
+        Optional<Workspace> workspace = workspaceRepository.findById(UUID.fromString(workspaceId));
+        log.info("Checking Lock for Workspace: {} is locked {}", workspaceId, workspace.get().isLocked());
+        return workspace.get().isLocked();
+    }
+
     StateData createWorkspaceState(String workspaceId, StateData stateData) {
         log.info("Creating new workspace state for {}", workspaceId);
         Workspace workspace = workspaceRepository.getReferenceById(UUID.fromString(workspaceId));

--- a/api/src/main/java/org/terrakube/api/plugin/state/model/workspace/WorkspaceData.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/model/workspace/WorkspaceData.java
@@ -1,12 +1,17 @@
 package org.terrakube.api.plugin.state.model.workspace;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
 @Setter
 @ToString
 public class WorkspaceData  {
     WorkspaceModel data;
+    List<WorkspaceError> errors;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/state/model/workspace/WorkspaceError.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/model/workspace/WorkspaceError.java
@@ -1,0 +1,14 @@
+package org.terrakube.api.plugin.state.model.workspace;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class WorkspaceError {
+    String status;
+    String title;
+    String detail;
+}

--- a/api/src/main/java/org/terrakube/api/plugin/state/model/workspace/WorkspaceModel.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/model/workspace/WorkspaceModel.java
@@ -1,5 +1,6 @@
 package org.terrakube.api.plugin.state.model.workspace;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -7,6 +8,7 @@ import lombok.ToString;
 import org.terrakube.api.plugin.state.model.generic.Resource;
 import java.util.Map;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
 @Setter
 @ToString

--- a/api/src/test/java/org/terrakube/api/TfcApiTests.java
+++ b/api/src/test/java/org/terrakube/api/TfcApiTests.java
@@ -218,6 +218,16 @@ class TfcApiTests extends ServerApplicationTests {
                 .log()
                 .all()
                 .statusCode(HttpStatus.OK.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .post("/remote/tfe/v2/workspaces/5ed411ca-7ab8-4d2f-b591-02d0d5788afc/actions/lock")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.CONFLICT.value());
     }
 
     @Test


### PR DESCRIPTION
This will fix the logic to run a terraform plan using the CLI driven workflow when the workspaces is locked like the following configuration.

![image](https://github.com/user-attachments/assets/0e57e650-2e8e-41ff-9623-c1b04f0ab46c)

Now when running the terraform command it will show the difference like the below:

```shell
user@pop-os:~/git/simple-terraform$ terraform plan

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create

Terraform will perform the following actions:

  # null_resource.next will be created
  + resource "null_resource" "next" {
      + id = (known after apply)
    }

  # null_resource.next2 will be created
  + resource "null_resource" "next2" {
      + id = (known after apply)
    }

  # null_resource.next3 will be created
  + resource "null_resource" "next3" {
      + id = (known after apply)
    }

  # null_resource.next4 will be created
  + resource "null_resource" "next4" {
      + id = (known after apply)
    }

  # null_resource.previous will be created
  + resource "null_resource" "previous" {
      + id = (known after apply)
    }

  # time_sleep.wait_30_seconds will be created
  + resource "time_sleep" "wait_30_seconds" {
      + create_duration  = "2m"
      + destroy_duration = "45s"
      + id               = (known after apply)
    }

  # module.time_module.random_integer.time will be created
  + resource "random_integer" "time" {
      + id     = (known after apply)
      + max    = 5
      + min    = 1
      + result = (known after apply)
    }

Plan: 7 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + creation_time = "2m"
  + fake_data     = {
      + data     = "Hello World"
      + resource = {
          + resource1 = "fake"
        }
    }

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform
apply" now.
user@pop-os:~/git/simple-terraform$ terraform plan
╷
│ Error: Error acquiring the state lock
│ 
│ Error message: workspace already locked (lock ID: "simple/locked-local")
│ Lock Info:
│   ID:        b624d3b4-c763-fe4c-8c7e-2bac7ff6220b
│   Path:      
│   Operation: OperationTypePlan
│   Who:       user@pop-os
│   Version:   1.5.7
│   Created:   2024-09-04 19:10:17.557721232 +0000 UTC
│   Info:      
│ 
│ 
│ Terraform acquires a state lock to protect the state from being written
│ by multiple users at the same time. Please resolve the issue above and try
│ again. For most commands, you can disable locking with the "-lock=false"
│ flag, but this is not recommended.

```

The endpoint to lock the workspace should return http code 409 and the following content when trying to lock a workspace that is already "locked"

```json
{
    "errors": [
        {
            "status": "409",
            "title": "conflict",
            "detail": "Unable to lock workspace. The workspace is already locked."
        }
    ]
}
```

Fix #1248 