### PR TITLE
fix: rate limited by github api

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/json/TofuJsonController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/json/TofuJsonController.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.io.IOUtils;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @AllArgsConstructor
@@ -19,20 +21,33 @@ import java.nio.charset.Charset;
 @RequestMapping("/tofu")
 public class TofuJsonController {
 
+    private static final String TOFU_REDIS_KEY = "tofuReleasesResponse";
     TofuJsonProperties tofuJsonProperties;
+    RedisTemplate redisTemplate;
 
     @GetMapping(value= "/index.json", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<String> createToken() throws IOException {
+    public ResponseEntity<String> getTofuReleases() throws IOException {
         String tofuIndex = "";
-        if(tofuJsonProperties.getReleasesUrl() != null && !tofuJsonProperties.getReleasesUrl().isEmpty()) {
-            log.info("Using tofu releases URL {}", tofuJsonProperties.getReleasesUrl());
-            tofuIndex = IOUtils.toString(URI.create(tofuJsonProperties.getReleasesUrl()), Charset.defaultCharset().toString());
+        if(redisTemplate.hasKey(TOFU_REDIS_KEY)) {
+            log.info("Getting tofu releases from redis....");
+            String tofuRedis = (String) redisTemplate.opsForValue().get(TOFU_REDIS_KEY);
+            return new ResponseEntity<>(tofuRedis, HttpStatus.OK);
         } else {
-            String defaultUrl="https://api.github.com/repos/opentofu/opentofu/releases";
-            log.warn("Using tofu releases URL {}", defaultUrl);
-            tofuIndex = IOUtils.toString(URI.create(defaultUrl), Charset.defaultCharset().toString());
+            log.info("Getting tofu releases from default endpoint....");
+            if(tofuJsonProperties.getReleasesUrl() != null && !tofuJsonProperties.getReleasesUrl().isEmpty()) {
+                log.info("Using tofu releases URL {}", tofuJsonProperties.getReleasesUrl());
+                tofuIndex = IOUtils.toString(URI.create(tofuJsonProperties.getReleasesUrl()), Charset.defaultCharset().toString());
+            } else {
+                String defaultUrl="https://api.github.com/repos/opentofu/opentofu/releases";
+                log.warn("Using tofu releases URL {}", defaultUrl);
+                tofuIndex = IOUtils.toString(URI.create(defaultUrl), Charset.defaultCharset().toString());
+            }
+            log.warn("Saving tofu releases to redis...");
+            redisTemplate.opsForValue().set(TOFU_REDIS_KEY, tofuIndex);
+            redisTemplate.expire(TOFU_REDIS_KEY, 30, TimeUnit.MINUTES);
+            return new ResponseEntity<>(tofuIndex, HttpStatus.OK);
         }
-        return new ResponseEntity<>(tofuIndex, HttpStatus.OK);
+
     }
 }
 

--- a/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
@@ -61,6 +61,7 @@ public class DexWebSecurityAdapter {
                                                         .requestMatchers("/remote/tfe/v2/plans/*/logs").permitAll()
                                                         .requestMatchers("/remote/tfe/v2/applies/*/logs").permitAll()
                                                         .requestMatchers("/app/*/*/runs/*").permitAll()
+                                                        .requestMatchers("/tofu/index.json").permitAll()
                                                         .anyRequest().authenticated();
                                 })
                                 .oauth2ResourceServer(oauth2 -> {

--- a/executor/src/main/resources/application.properties
+++ b/executor/src/main/resources/application.properties
@@ -6,7 +6,7 @@ server.port=8090
 org.terrakube.terraform.flags.enableColor=true
 org.terrakube.terraform.flags.jsonOutput=false
 org.terrakube.terraform.flags.terraformReleasesUrl=${CustomTerraformReleasesUrl}
-org.terrakube.terraform.flags.tofuReleasesUrl=${CustomTofuReleasesUrl:https://api.github.com/repos/opentofu/opentofu/releases}
+org.terrakube.terraform.flags.tofuReleasesUrl=${AzBuilderApiUrl}/tofu/index.json
 
 ###########################
 #General Settings Executor#


### PR DESCRIPTION
This change the logic to read the `https://api.github.com/repos/opentofu/opentofu/releases` endpoint, terrakube will only check the releases endpoint every 30 minutes and save the response to REDIS to be reuse the information in other api calls.

Fix #1239 