### PR TITLE
feat: Correct queue and run prompt for CLI

### DIFF
--- a/api/src/main/java/org/terrakube/api/repository/JobRepository.java
+++ b/api/src/main/java/org/terrakube/api/repository/JobRepository.java
@@ -13,8 +13,11 @@ public interface JobRepository extends JpaRepository<Job, Integer> {
 
     List<Job> findAllByOrganizationAndStatusNotInOrderByIdAsc(Organization organization, List<JobStatus> status);
     List<Job> findAllByStatusInOrderByIdAsc(List<JobStatus> status);
+
     Optional<List<Job>> findAllByWorkspaceAndStatusNotInOrderByIdAsc(Workspace workspace, List<JobStatus> status);
+    List<Job> findAllByWorkspaceAndStatusInOrderByIdDesc(Workspace workspace, List<JobStatus> jobStatuses);
     Optional<List<Job>> findByWorkspaceAndStatusNotInAndIdLessThan(Workspace workspace, List<JobStatus> jobStatuses, int jobId);
 
     Optional<Job> findFirstByWorkspaceAndAndStatusInOrderByIdAsc(Workspace workspace, List<JobStatus> jobStatuses);
+    Optional<Job> findFirstByWorkspaceAndStatusInOrderByIdAsc(Workspace workspace, List<JobStatus> jobStatuses);
 }

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -93,6 +93,7 @@ org.terrakube.executor.url=${AzBuilderExecutorUrl}
 org.terrakube.executor.ephemeral.namespace=${ExecutorEphemeralNamespace:terrakube}
 org.terrakube.executor.ephemeral.image=${ExecutorEphemeralImage:azbuilder/executor:2.22.0}
 org.terrakube.executor.ephemeral.secret=${ExecutorEphemeralSecret:terrakube-executor-secrets}
+org.terrakube.executor.replicas=${ExecutorReplicas:1}
 
 ###########################################
 # EPHEMERAL EXECUTOR NODE SELECTOR CONFIG #


### PR DESCRIPTION
This change takes a parameter of the number of executor replicas and uses that as the capacity for the whole Terrakube instance. This could be improved later on if more different types of agents are supported.

fix #1285 