### PR TITLE
fix: correctly cancel long running jobs

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/inactive/InactiveJobs.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/inactive/InactiveJobs.java
@@ -75,7 +75,6 @@ public class InactiveJobs implements org.quartz.Job {
                     log.error(e.getMessage());
                 }
                 log.warn("Closing Job");
-                return;
             }
         }
     }

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/inactive/InactiveJobs.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/inactive/InactiveJobs.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.Date;
 
 import static org.terrakube.api.plugin.scheduler.ScheduleJobService.PREFIX_JOB_CONTEXT;
-import static org.terrakube.api.rs.vcs.VcsType.GITHUB;
 
 @Service
 @Slf4j

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/inactive/InactiveJobs.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/inactive/InactiveJobs.java
@@ -1,0 +1,85 @@
+package org.terrakube.api.plugin.scheduler.inactive;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.time.DateUtils;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobKey;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
+import org.terrakube.api.repository.JobRepository;
+import org.terrakube.api.repository.StepRepository;
+import org.terrakube.api.rs.job.Job;
+import org.terrakube.api.rs.job.JobStatus;
+import org.terrakube.api.rs.job.JobVia;
+import org.terrakube.api.rs.job.step.Step;
+
+import java.util.Arrays;
+import java.util.Date;
+
+import static org.terrakube.api.plugin.scheduler.ScheduleJobService.PREFIX_JOB_CONTEXT;
+import static org.terrakube.api.rs.vcs.VcsType.GITHUB;
+
+@Service
+@Slf4j
+@AllArgsConstructor
+public class InactiveJobs implements org.quartz.Job {
+
+    JobRepository jobRepository;
+    RedisTemplate redisTemplate;
+    GitHubWebhookService gitHubWebhookService;
+    StepRepository stepRepository;
+
+    @Transactional
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+        for (Job job : jobRepository.findAllByStatusInOrderByIdAsc(Arrays.asList(
+                JobStatus.pending,
+                JobStatus.running,
+                JobStatus.queue,
+                JobStatus.waitingApproval))) {
+            Date currentTime = new Date(System.currentTimeMillis());
+            Date jobExpirationDate = DateUtils.addHours(job.getCreatedDate(), 6);
+            log.info("Inactive Job {} should be completed before {}, current time {}", job.getId(), jobExpirationDate, currentTime);
+            if (currentTime.after(jobExpirationDate)) {
+                try {
+                    log.warn("Deleting Job Context {} from Quartz", PREFIX_JOB_CONTEXT + job.getId());
+                    log.error("Job has been running for more than 6 hours, cancelling running job");
+                    job.setStatus(JobStatus.failed);
+                    jobRepository.save(job);
+                    redisTemplate.delete(String.valueOf(job.getId()));
+                    log.warn("Cancelling pending steps");
+                    for (Step step : stepRepository.findByJobId(job.getId())) {
+                        if (step.getStatus().equals(JobStatus.pending) || step.getStatus().equals(JobStatus.running)) {
+                            step.setStatus(JobStatus.failed);
+                            stepRepository.save(step);
+                        }
+                    }
+                    if (job.getVia().equals(JobVia.CLI.name()) || job.getVia().equals(JobVia.UI.name()) ) {
+                        log.info("No information to update for job", job.getId());
+                        return;
+                    } else {
+
+                        switch (job.getWorkspace().getVcs().getVcsType()) {
+                            case GITHUB:
+                                log.info("Updating VCS information for GITHUB", job.getId());
+                                gitHubWebhookService.sendCommitStatus(job, JobStatus.unknown);
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                    jobExecutionContext.getScheduler().deleteJob(new JobKey(PREFIX_JOB_CONTEXT + job.getId()));
+                } catch (Exception e) {
+                    log.error(e.getMessage());
+                }
+                log.warn("Closing Job");
+                return;
+            }
+        }
+    }
+
+}

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/inactive/InactiveJobs.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/inactive/InactiveJobs.java
@@ -46,8 +46,7 @@ public class InactiveJobs implements org.quartz.Job {
             log.info("Inactive Job {} should be completed before {}, current time {}", job.getId(), jobExpirationDate, currentTime);
             if (currentTime.after(jobExpirationDate)) {
                 try {
-                    log.warn("Deleting Job Context {} from Quartz", PREFIX_JOB_CONTEXT + job.getId());
-                    log.error("Job has been running for more than 6 hours, cancelling running job");
+                    log.error("Job has been running for more than 6 hours, cancelling running job {}", job.getId());
                     job.setStatus(JobStatus.failed);
                     jobRepository.save(job);
                     redisTemplate.delete(String.valueOf(job.getId()));

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/inactive/InactiveJobsService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/inactive/InactiveJobsService.java
@@ -1,0 +1,88 @@
+package org.terrakube.api.plugin.scheduler.inactive;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import java.text.ParseException;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@AllArgsConstructor
+public class InactiveJobsService {
+
+    private static final String PREFIX_INACTIVE_JOBS = "TerrakubeV2_InactiveJobs";
+
+    private Scheduler scheduler;
+
+    @Transactional
+    @PostConstruct
+    public void initInactiveJobs() {
+        try {
+            log.info("Setup job to cancelled inactive jobs");
+            runInactiveJobs();
+            JobDetail jobDetail = scheduler.getJobDetail(new JobKey(PREFIX_INACTIVE_JOBS));
+            log.info("jobDetail is null {}", jobDetail == null);
+            if(jobDetail == null){
+                setupInactiveJob("0 * * ? * *");
+            } else {
+                log.info("Delete Old Quartz Job for inactive jobs");
+                scheduler.deleteJob(new JobKey(PREFIX_INACTIVE_JOBS));
+                setupInactiveJob("0 * * ? * *");
+            }
+        } catch (Exception ex) {
+            log.error(ex.getMessage());
+        }
+
+    }
+
+    public void runInactiveJobs() throws SchedulerException {
+        JobDataMap jobDataMap = new JobDataMap();
+        jobDataMap.put("InactiveJobs", "InactiveJobsV1");
+
+        JobDetail jobDetail = JobBuilder.newJob().ofType(InactiveJobs.class)
+                .storeDurably()
+                .setJobData(jobDataMap)
+                .withIdentity(PREFIX_INACTIVE_JOBS + "_" + UUID.randomUUID())
+                .withDescription("InactiveJobsStartup")
+                .build();
+
+        Trigger trigger = TriggerBuilder.newTrigger()
+                .startNow()
+                .forJob(jobDetail)
+                .withIdentity(PREFIX_INACTIVE_JOBS + "_" + UUID.randomUUID())
+                .withDescription("InactiveJobsStartup")
+                .startNow()
+                .build();
+
+        log.info("Create Schedule for inactive jobs: {}", jobDetail.getKey());
+        scheduler.scheduleJob(jobDetail, trigger);
+    }
+
+    public void setupInactiveJob(String quartzSchedule) throws ParseException, SchedulerException {
+        JobDataMap jobDataMap = new JobDataMap();
+        jobDataMap.put("InactiveJobs", "InactiveJobsV1");
+
+        JobDetail jobDetail = JobBuilder.newJob().ofType(InactiveJobs.class)
+                .storeDurably()
+                .setJobData(jobDataMap)
+                .withIdentity(PREFIX_INACTIVE_JOBS)
+                .withDescription("InactiveJobsV1")
+                .build();
+
+        Trigger trigger = TriggerBuilder.newTrigger()
+                .startNow()
+                .forJob(jobDetail)
+                .withIdentity(PREFIX_INACTIVE_JOBS)
+                .withDescription("InactiveJobsV1")
+                .withSchedule(CronScheduleBuilder.cronSchedule(new CronExpression(quartzSchedule)))
+                .build();
+
+        log.info("Create Schedule Job Trigger for inactive jobs {}", jobDetail.getKey());
+        scheduler.scheduleJob(jobDetail, trigger);
+    }
+}

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/inactive/InactiveJobsService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/inactive/InactiveJobsService.java
@@ -28,11 +28,11 @@ public class InactiveJobsService {
             JobDetail jobDetail = scheduler.getJobDetail(new JobKey(PREFIX_INACTIVE_JOBS));
             log.info("jobDetail is null {}", jobDetail == null);
             if(jobDetail == null){
-                setupInactiveJob("0 * * ? * *");
+                setupInactiveJob("0 */5 * ? * *");
             } else {
                 log.info("Delete Old Quartz Job for inactive jobs");
                 scheduler.deleteJob(new JobKey(PREFIX_INACTIVE_JOBS));
-                setupInactiveJob("0 * * ? * *");
+                setupInactiveJob("0 */5 * ? * *");
             }
         } catch (Exception ex) {
             log.error(ex.getMessage());

--- a/api/src/main/java/org/terrakube/api/repository/JobRepository.java
+++ b/api/src/main/java/org/terrakube/api/repository/JobRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 public interface JobRepository extends JpaRepository<Job, Integer> {
 
     List<Job> findAllByOrganizationAndStatusNotInOrderByIdAsc(Organization organization, List<JobStatus> status);
-
+    List<Job> findAllByStatusInOrderByIdAsc(List<JobStatus> status);
     Optional<List<Job>> findAllByWorkspaceAndStatusNotInOrderByIdAsc(Workspace workspace, List<JobStatus> status);
     Optional<List<Job>> findByWorkspaceAndStatusNotInAndIdLessThan(Workspace workspace, List<JobStatus> jobStatuses, int jobId);
 


### PR DESCRIPTION
This will execute and setup a quartz job when the API is starting to correctly cancel jobs that has been running for more that 6 hours, the quartz job to check inactive jobs will be executed every 5 minutes.

The logs will show something like the following:

```shell
2024-09-13T21:47:47.914Z  INFO 1 --- [           main] o.t.a.p.s.inactive.InactiveJobsService   : Setup job to cancelled inactive jobs
2024-09-13T21:47:47.916Z  INFO 1 --- [           main] o.t.a.p.s.inactive.InactiveJobsService   : Create Schedule for inactive jobs: DEFAULT.TerrakubeV2_InactiveJobs_ae638dea-dff2-459f-a9f7-549283fca505
2024-09-13T21:47:47.964Z  INFO 1 --- [           main] o.t.a.p.s.inactive.InactiveJobsService   : jobDetail is null false
2024-09-13T21:47:47.964Z  INFO 1 --- [           main] o.t.a.p.s.inactive.InactiveJobsService   : Delete Old Quartz Job for inactive jobs
2024-09-13T21:47:48.054Z  INFO 1 --- [           main] o.t.a.p.s.inactive.InactiveJobsService   : Create Schedule Job Trigger for inactive jobs DEFAULT.TerrakubeV2_InactiveJobs
```