### PR TITLE
feat: Add manageState permission

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/security/state/StateService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/state/StateService.java
@@ -1,0 +1,33 @@
+package org.terrakube.api.plugin.security.state;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Service;
+import org.terrakube.api.repository.TeamRepository;
+import org.terrakube.api.rs.team.Team;
+
+@Service
+public class StateService {
+   @Autowired
+   private TeamRepository teamRepository;
+
+   public boolean hasManageStatePermission(Authentication authentication, String orgnizationId) {
+      Object groupNames = ((JwtAuthenticationToken) authentication).getTokenAttributes().get("groups");
+      if (groupNames == null) {
+         return false;
+      }
+      @SuppressWarnings("unchecked")
+      List<Team> teams = teamRepository.findAllByOrganizationIdAndNameIn(UUID.fromString(orgnizationId), (List<String>) groupNames);
+      for (Team team : teams) {
+         if (team.isManageState()) {
+            return true;
+         }
+      }
+      
+      return false;
+   } 
+}

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -67,7 +67,7 @@ public class RemoteTfeController {
         HttpHeaders responseHeaders = new HttpHeaders();
         responseHeaders.set("TFP-API-Version", "2.5");
         responseHeaders.set("TFP-AppName", "Terrakube");
-        ResponseEntity response = new ResponseEntity<>(responseHeaders, HttpStatus.NOT_FOUND);
+        ResponseEntity<String> response = new ResponseEntity<>(responseHeaders, HttpStatus.NOT_FOUND);
         return response;
     }
 
@@ -159,7 +159,7 @@ public class RemoteTfeController {
         log.info("Lock {}", workspaceId);
         if (remoteTfeService.isWorkspaceLocked(workspaceId)) {
             WorkspaceData workspaceData = new WorkspaceData();
-            workspaceData.setErrors(new ArrayList());
+            workspaceData.setErrors(new ArrayList<WorkspaceError>());
             WorkspaceError workspaceError = new WorkspaceError();
             workspaceError.setStatus("409");
             workspaceError.setTitle("conflict");

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -312,12 +312,12 @@ public class RemoteTfeService {
             defaultAttributes.put("can-lock", isManageWorkspace);
             defaultAttributes.put("can-manage-run-tasks", isManageWorkspace);
             defaultAttributes.put("can-manage-tags", isManageWorkspace);
-            defaultAttributes.put("can-queue-apply", isManageWorkspace);
+            defaultAttributes.put("can-queue-apply", true);
             defaultAttributes.put("can-queue-destroy", isManageWorkspace);
-            defaultAttributes.put("can-queue-run", isManageWorkspace);
-            defaultAttributes.put("can-read-settings", isManageWorkspace);
+            defaultAttributes.put("can-queue-run", true);
+            defaultAttributes.put("can-read-settings", true);
             defaultAttributes.put("can-read-state-versions", isManageWorkspace);
-            defaultAttributes.put("can-read-variable", isManageWorkspace);
+            defaultAttributes.put("can-read-variable", true);
             defaultAttributes.put("can-unlock", isManageWorkspace);
             defaultAttributes.put("can-update", isManageWorkspace);
             defaultAttributes.put("can-update-variable", isManageWorkspace);

--- a/api/src/main/java/org/terrakube/api/plugin/token/team/TeamTokenController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/team/TeamTokenController.java
@@ -1,20 +1,28 @@
 package org.terrakube.api.plugin.token.team;
 
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.terrakube.api.repository.TeamRepository;
+import org.terrakube.api.rs.token.group.Group;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.*;
-import org.terrakube.api.rs.token.group.Group;
-
-import java.security.Principal;
-import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 @RestController
@@ -23,9 +31,11 @@ import java.util.List;
 public class TeamTokenController {
 
     TeamTokenService teamTokenService;
+    TeamRepository teamRepository;
 
     @PostMapping
-    public ResponseEntity<TeamToken> createToken(@RequestBody GroupTokenRequest groupTokenRequest,  Principal principal) {
+    public ResponseEntity<TeamToken> createToken(@RequestBody GroupTokenRequest groupTokenRequest,
+            Principal principal) {
         TeamToken teamToken = new TeamToken();
         teamToken.setToken(teamTokenService.createTeamToken(
                 groupTokenRequest.getGroup(),
@@ -37,25 +47,46 @@ public class TeamTokenController {
     }
 
     @GetMapping("/current-teams")
-    public ResponseEntity<CurrentGroupsResponse> SearchTeams(Principal principal){
+    public ResponseEntity<CurrentGroupsResponse> SearchTeams(Principal principal) {
         JwtAuthenticationToken principalJwt = ((JwtAuthenticationToken) principal);
         CurrentGroupsResponse groupList = new CurrentGroupsResponse();
-        groupList.setGroups(new ArrayList());
-        teamTokenService.getCurrentGroups(principalJwt).forEach(group->{
+        groupList.setGroups(new ArrayList<String>());
+        teamTokenService.getCurrentGroups(principalJwt).forEach(group -> {
             groupList.getGroups().add(group);
         });
         return new ResponseEntity<>(groupList, HttpStatus.ACCEPTED);
     }
 
+    @GetMapping(path = "/permissions/organization/{organizationId}")
+    public ResponseEntity<PermissionSet> getPermissions(Principal principal,
+            @PathVariable("organizationId") String organizationId) {
+        JwtAuthenticationToken principalJwt = ((JwtAuthenticationToken) principal);
+        PermissionSet permissions = new PermissionSet();
+        List<String> groups = teamTokenService.getCurrentGroups(principalJwt);
+        teamRepository.findAllByOrganizationIdAndNameIn(UUID.fromString(organizationId), groups).forEach(group -> {
+            permissions.setManageState(permissions.manageState || group.isManageState());
+            permissions.setManageWorkspace(permissions.manageWorkspace || group.isManageWorkspace());
+            permissions.setManageModule(permissions.manageModule || group.isManageModule());
+            permissions.setManageProvider(permissions.manageProvider || group.isManageProvider());
+            permissions.setManageTemplate(permissions.manageTemplate || group.isManageTemplate());
+            permissions.setManageVcs(permissions.manageVcs || group.isManageVcs());
+        });
+        return new ResponseEntity<>(permissions, HttpStatus.ACCEPTED);
+    }
+
     @Transactional
     @DeleteMapping(path = "/{groupTokenId}")
-    public ResponseEntity<String> deleteToken(@PathVariable("groupTokenId") String groupTokenId){
-        if (teamTokenService.deleteToken(groupTokenId)) return ResponseEntity.accepted().build(); else return ResponseEntity.badRequest().build();
+    public ResponseEntity<String> deleteToken(@PathVariable("groupTokenId") String groupTokenId) {
+        if (teamTokenService.deleteToken(groupTokenId))
+            return ResponseEntity.accepted().build();
+        else
+            return ResponseEntity.badRequest().build();
     }
 
     @GetMapping
-    public ResponseEntity<List<Group>> searchToken(Principal principal){
-        return new ResponseEntity<>(teamTokenService.searchToken(((JwtAuthenticationToken) principal)), HttpStatus.ACCEPTED);
+    public ResponseEntity<List<Group>> searchToken(Principal principal) {
+        return new ResponseEntity<>(teamTokenService.searchToken(((JwtAuthenticationToken) principal)),
+                HttpStatus.ACCEPTED);
     }
 
     @Getter
@@ -72,7 +103,7 @@ public class TeamTokenController {
 
     @Getter
     @Setter
-    private static class GroupTokenRequest{
+    private static class GroupTokenRequest {
         private String group;
         private String description;
         private int days = 0;
@@ -80,4 +111,14 @@ public class TeamTokenController {
         private int hours = 0;
     }
 
+    @Getter
+    @Setter
+    private class PermissionSet {
+        private boolean manageState;
+        private boolean manageWorkspace;
+        private boolean manageModule;
+        private boolean manageProvider;
+        private boolean manageVcs;
+        private boolean manageTemplate;
+    }
 }

--- a/api/src/main/java/org/terrakube/api/repository/TeamRepository.java
+++ b/api/src/main/java/org/terrakube/api/repository/TeamRepository.java
@@ -1,0 +1,11 @@
+package org.terrakube.api.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.terrakube.api.rs.team.Team;
+
+public interface TeamRepository extends JpaRepository<Team, UUID> {
+    List<Team> findAllByOrganizationIdAndNameIn(UUID organizationId, List<String> names);
+}

--- a/api/src/main/java/org/terrakube/api/rs/team/Team.java
+++ b/api/src/main/java/org/terrakube/api/rs/team/Team.java
@@ -1,17 +1,26 @@
 package org.terrakube.api.rs.team;
 
-import com.yahoo.elide.annotation.*;
-import lombok.Getter;
-import lombok.Setter;
+import java.sql.Types;
+import java.util.UUID;
+
 import org.hibernate.annotations.JdbcTypeCode;
 import org.terrakube.api.rs.IdConverter;
 import org.terrakube.api.rs.Organization;
-import org.hibernate.annotations.Type;
 
-import jakarta.persistence.*;
+import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.DeletePermission;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.UpdatePermission;
 
-import java.sql.Types;
-import java.util.UUID;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.Setter;
 
 @CreatePermission(expression = "user is a superuser")
 @UpdatePermission(expression = "user is a superuser")
@@ -30,6 +39,9 @@ public class Team {
 
     @Column(name = "name")
     private String name;
+
+    @Column(name = "manage_state")
+    private boolean manageState;
 
     @Column(name = "manage_workspace")
     private boolean manageWorkspace;

--- a/api/src/main/java/org/terrakube/api/rs/token/group/Group.java
+++ b/api/src/main/java/org/terrakube/api/rs/token/group/Group.java
@@ -1,17 +1,22 @@
 package org.terrakube.api.rs.token.group;
 
+import java.sql.Types;
+import java.util.UUID;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.terrakube.api.plugin.security.audit.GenericAuditFields;
+import org.terrakube.api.rs.IdConverter;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.annotations.Type;
-import org.terrakube.api.plugin.security.audit.GenericAuditFields;
-
-import jakarta.persistence.*;
-import org.terrakube.api.rs.IdConverter;
-
-import java.sql.Types;
-import java.util.UUID;
 
 @NoArgsConstructor
 @Getter

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -63,4 +63,5 @@
     <include file="/db/changelog/local/changelog-2.22.1-module-github-token-id.xml"/>
     <include file="/db/changelog/local/changelog-2.22.2-webhook-triggers.xml"/>
     <include file="/db/changelog/local/changelog-2.23.0-job-reference-size.xml"/>
+    <include file="/db/changelog/local/changelog-2.23.0-team-manage-state.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.23.0-team-manage-state.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.23.0-team-manage-state.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-23-0-2" author="Stanley Zhang (stanley.zhang@ityin.net)">
+        <addColumn tableName="team">
+            <column name="manage_state" type="boolean" defaultValue="false"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/dynamic-credential-setup/azure/main.tf
+++ b/dynamic-credential-setup/azure/main.tf
@@ -7,7 +7,7 @@ resource "random_string" "random" {
 }
 
 resource "azuread_application_registration" "terrakube_application" {
-  display_name     = "terrakube-dynamic-creds-${random_string.random.result}"
+  display_name = "terrakube-dynamic-creds-${random_string.random.result}"
 }
 
 resource "azuread_service_principal" "terrakube_service_principal" {

--- a/dynamic-credential-setup/gcp/main.tf
+++ b/dynamic-credential-setup/gcp/main.tf
@@ -4,16 +4,16 @@ resource "google_project_service" "services" {
 }
 
 resource "random_string" "random" {
-  length           = 3
-  special          = false
-  lower = true
-  upper = false
+  length  = 3
+  special = false
+  lower   = true
+  upper   = false
   numeric = false
 }
 
 locals {
-  workload_identity_pool_id = format("terrakube-pool%s",random_string.random.result)
-  workload_identity_pool_provider_id = format("terrakube-provider-%s",random_string.random.result)
+  workload_identity_pool_id          = format("terrakube-pool%s", random_string.random.result)
+  workload_identity_pool_provider_id = format("terrakube-provider-%s", random_string.random.result)
 }
 
 resource "google_iam_workload_identity_pool" "terrakube_pool" {
@@ -35,7 +35,7 @@ resource "google_iam_workload_identity_pool_provider" "terrakube_provider" {
   }
   attribute_condition = "assertion.sub.startsWith(\"organization:${var.terrakube_organization_name}:workspace:${var.terrakube_workspace_name}\")"
 
-  depends_on = [ google_iam_workload_identity_pool.terrakube_pool ]
+  depends_on = [google_iam_workload_identity_pool.terrakube_pool]
 }
 
 resource "google_service_account" "terrakube_service_account" {
@@ -63,7 +63,7 @@ resource "terrakube_workspace_cli" "dynamic_credentials_workspace" {
   iac_type        = "terraform"
   iac_version     = "1.5.7"
 
-  depends_on = [ data.terrakube_organization.org ]
+  depends_on = [data.terrakube_organization.org]
 }
 
 

--- a/dynamic-credential-setup/gcp/provider.tf
+++ b/dynamic-credential-setup/gcp/provider.tf
@@ -13,5 +13,5 @@ provider "google" {
 
 provider "terrakube" {
   endpoint = "https://${var.terrakube_hostname}"
-  token = var.terrakube_token
+  token    = var.terrakube_token
 }

--- a/ui/src/domain/Settings/EditTeam.jsx
+++ b/ui/src/domain/Settings/EditTeam.jsx
@@ -58,6 +58,7 @@ export const EditTeam = ({ mode, setMode, teamId, loadTeams }) => {
     axiosInstance.get(`organization/${orgid}/team/${id}`).then((response) => {
       setTeamName(response.data.data.attributes.name);
       form.setFieldsValue({
+        manageState: response.data.data.attributes.manageState,
         manageProvider: response.data.data.attributes.manageProvider,
         manageModule: response.data.data.attributes.manageModule,
         manageWorkspace: response.data.data.attributes.manageWorkspace,
@@ -76,6 +77,7 @@ export const EditTeam = ({ mode, setMode, teamId, loadTeams }) => {
         type: "team",
         attributes: {
           name: values.name,
+          manageState: values.manageState,
           manageWorkspace: values.manageWorkspace,
           manageModule: values.manageModule,
           manageProvider: values.manageProvider,
@@ -112,6 +114,7 @@ export const EditTeam = ({ mode, setMode, teamId, loadTeams }) => {
         type: "team",
         id: teamId,
         attributes: {
+          manageState: values.manageState,
           manageWorkspace: values.manageWorkspace,
           manageModule: values.manageModule,
           manageProvider: values.manageProvider,
@@ -255,6 +258,18 @@ export const EditTeam = ({ mode, setMode, teamId, loadTeams }) => {
             <FormItem>
               <h2 style={{ marginTop: "10px" }}>Organization Access</h2>
             </FormItem>
+            <Form.Item
+              name="manageState"
+              valuePropName="checked"
+              label="Manage State"
+              tooltip={{
+                title:
+                  "Allow members to manage Terraform/OpenTofu state, include downloading, uploading and view state content of a workspace.",
+                icon: <InfoCircleOutlined />,
+              }}
+            >
+              <Switch />
+            </Form.Item>
             <Form.Item
               name="manageWorkspace"
               valuePropName="checked"

--- a/ui/src/domain/Workspaces/DownloadState.jsx
+++ b/ui/src/domain/Workspaces/DownloadState.jsx
@@ -7,7 +7,7 @@ import { toPng, toSvg, toJpeg } from "html-to-image";
 import axiosInstance from "../../config/axiosConfig";
 import{BsFiletypeSvg,BsFiletypeJson,BsFiletypePng} from "react-icons/bs";
 
-export const DownloadState = ({stateUrl}) => {
+export const DownloadState = ({stateUrl, manageState}) => {
   function downloadImage(dataUrl, fileName) {
     const a = document.createElement("a");
     a.setAttribute("download", fileName);
@@ -134,7 +134,7 @@ export const DownloadState = ({stateUrl}) => {
   };
 
   return (
-    <Dropdown.Button menu={menuProps} onClick={handleButtonClick}>
+    <Dropdown.Button menu={menuProps} onClick={handleButtonClick} disabled={!manageState}>
       Download
     </Dropdown.Button>
   );

--- a/ui/src/domain/Workspaces/Schedules.jsx
+++ b/ui/src/domain/Workspaces/Schedules.jsx
@@ -66,13 +66,14 @@ const VARIABLES_COLUMS = (organizationId, workspaceId, onEdit) => [
   {
     title: "Actions",
     key: "action",
-    render: (_, record) => {
+    render: (_, record, manageWorkspace) => {
       return (
         <div>
           <Button
             type="link"
             icon={<EditOutlined />}
             onClick={() => onEdit(record)}
+            disabled={!manageWorkspace}
           >
             Edit
           </Button>
@@ -90,7 +91,7 @@ const VARIABLES_COLUMS = (organizationId, workspaceId, onEdit) => [
             cancelText="No"
           >
             {" "}
-            <Button danger type="link" icon={<DeleteOutlined />}>
+            <Button danger type="link" icon={<DeleteOutlined />} manageWorkspace={!manageWorkspace}>
               Delete
             </Button>
           </Popconfirm>
@@ -105,7 +106,7 @@ const validateMessages = {
   pattern: "${label} is not valid cron expression!",
 };
 
-export const Schedules = ({ schedules }) => {
+export const Schedules = ({ schedules, manageWorkspace }) => {
   const workspaceId = sessionStorage.getItem(WORKSPACE_ARCHIVE);
   const organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
   const [form] = Form.useForm();
@@ -232,6 +233,7 @@ export const Schedules = ({ schedules }) => {
           form.resetFields();
           setVisible(true);
         }}
+        disabled={!manageWorkspace}
       >
         Add schedule
       </Button>
@@ -276,7 +278,7 @@ export const Schedules = ({ schedules }) => {
               ) : (
                 <Select>
                   {templates.map((item) => (
-                    <Select.Option value={item.id}>
+                    <Select.Option value={item.id} key={item.id}>
                       {item.attributes.name}
                     </Select.Option>
                   ))}

--- a/ui/src/domain/Workspaces/Tags.jsx
+++ b/ui/src/domain/Workspaces/Tags.jsx
@@ -2,7 +2,7 @@ import { React, useEffect, useState } from "react";
 import { Select } from "antd";
 import axiosInstance from "../../config/axiosConfig";
 
-export const Tags = ({ organizationId, workspaceId }) => {
+export const Tags = ({ organizationId, workspaceId, manageWorkspace }) => {
   const [tags, setTags] = useState([]);
   const [newTags, setNewTags] = useState([]);
   const [currentTags, setCurrentTags] = useState([]);
@@ -139,6 +139,7 @@ export const Tags = ({ organizationId, workspaceId }) => {
         return { label: tag.attributes.name, value: tag.id };
       })}
       placeholder="Add a tag"
+      disabled={!manageWorkspace}
     />
   );
 };

--- a/ui/src/domain/Workspaces/Variables.jsx
+++ b/ui/src/domain/Workspaces/Variables.jsx
@@ -18,7 +18,7 @@ import axiosInstance from "../../config/axiosConfig";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { DeleteOutlined, EditOutlined } from "@ant-design/icons";
 
-const VARIABLES_COLUMS = (organizationId, workspaceId, onEdit) => [
+const VARIABLES_COLUMS = (organizationId, workspaceId, onEdit, manageWorkspace) => [
   {
     title: "Key",
     dataIndex: "key",
@@ -28,8 +28,8 @@ const VARIABLES_COLUMS = (organizationId, workspaceId, onEdit) => [
       return (
         <div>
           {record.key} &nbsp;&nbsp;&nbsp;&nbsp;{" "}
-          <Tag visible={record.hcl}>HCL</Tag>{" "}
-          <Tag visible={record.sensitive}>Sensitive</Tag>
+          {record.hcl && <Tag>HCL</Tag>}{" "}
+          {record.sensitive && <Tag>Sensitive</Tag>}
         </div>
       );
     },
@@ -57,6 +57,7 @@ const VARIABLES_COLUMS = (organizationId, workspaceId, onEdit) => [
             type="link"
             icon={<EditOutlined />}
             onClick={() => onEdit(record)}
+            disabled={!manageWorkspace}
           >
             Edit
           </Button>
@@ -75,7 +76,7 @@ const VARIABLES_COLUMS = (organizationId, workspaceId, onEdit) => [
             cancelText="No"
           >
             {" "}
-            <Button danger type="link" icon={<DeleteOutlined />}>
+            <Button danger type="link" icon={<DeleteOutlined />} disabled={!manageWorkspace}>
               Delete
             </Button>
           </Popconfirm>
@@ -89,7 +90,7 @@ const validateMessages = {
   required: "${label} is required!",
 };
 
-export const Variables = ({ vars, env }) => {
+export const Variables = ({ vars, env, manageWorkspace }) => {
   const workspaceId = sessionStorage.getItem(WORKSPACE_ARCHIVE);
   const organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
   const [form] = Form.useForm();
@@ -207,7 +208,7 @@ export const Variables = ({ vars, env }) => {
       </div>
       <Table
         dataSource={vars}
-        columns={VARIABLES_COLUMS(organizationId, workspaceId, onEdit)}
+        columns={VARIABLES_COLUMS(organizationId, workspaceId, onEdit, manageWorkspace)}
         rowKey="key"
       />
       <Button
@@ -219,6 +220,7 @@ export const Variables = ({ vars, env }) => {
           form.resetFields();
           setVisible(true);
         }}
+        disabled={!manageWorkspace}
       >
         Add variable
       </Button>
@@ -229,7 +231,7 @@ export const Variables = ({ vars, env }) => {
         </div>
         <Table
           dataSource={env}
-          columns={VARIABLES_COLUMS(organizationId, workspaceId, onEdit)}
+          columns={VARIABLES_COLUMS(organizationId, workspaceId, onEdit, manageWorkspace)}
           rowKey="key"
         />
         <Button
@@ -241,6 +243,7 @@ export const Variables = ({ vars, env }) => {
             form.resetFields();
             setVisible(true);
           }}
+          disabled={!manageWorkspace}
         >
           Add variable
         </Button>


### PR DESCRIPTION
This change adds a separate role for managing Terraform state and also disables the corresponding UI items for users who can't mange workspace or state.

Additional changes:

1. Users who doesn't have the permission to manage state can run Terraform plan and apply but can't manipulate state with command such as `terraform state rm|pull|push`

fix #1245

![Screenshot 2024-09-22 at 7 18 05 PM](https://github.com/user-attachments/assets/8f40cd4c-36a3-446a-82b5-a20eefc9a8d7)
![Screenshot 2024-09-22 at 7 28 25 PM](https://github.com/user-attachments/assets/7a005159-1467-45bf-b8c5-7b823ea9d96a)
 