### PR TITLE
fix: remove 'run-' prefix from jobId in redirect URL

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/redirect/RedirectController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/redirect/RedirectController.java
@@ -26,7 +26,7 @@ public class RedirectController {
         log.info("Redirect for: {}/{}/{}", organizationName, workspaceName, jobId);
         int jobIdFixed = Integer.parseInt(jobId.replace("run-",""));
         return ResponseEntity.status(HttpStatus.FOUND)
-                .location(URI.create(String.format("%s/organizations/%s/workspaces/%s/runs/%s", uiURL,jobRepository.findById(jobIdFixed).get().getOrganization().getId(), jobRepository.findById(jobIdFixed).get().getWorkspace().getId(), jobId)))
+                .location(URI.create(String.format("%s/organizations/%s/workspaces/%s/runs/%s", uiURL,jobRepository.findById(jobIdFixed).get().getOrganization().getId(), jobRepository.findById(jobIdFixed).get().getWorkspace().getId(), jobIdFixed)))
                 .build();
     }
 }


### PR DESCRIPTION
Hello @alfespa17, @jcanizalez;

### What does this PR do?
This PR addresses an issue where the redirect URL for job runs was incorrectly including the 'run-' prefix in the jobId, resulting in an invalid redirect.

For example: 
![image](https://github.com/user-attachments/assets/3f5552ce-019b-46b7-be4a-57dd2222e94f)

### What has been changed?
- The 'run-' prefix is now removed from the jobId when forming the redirect URL.
- The updated URL correctly points to `/organizations/{organizationId}/workspaces/{workspaceId}/runs/{jobId}` without the 'run-' prefix.

### Why is this needed?
This fix ensures that the redirect URL for job runs is properly formed, preventing errors when navigating to specific job run pages.

Could you please review this PR when you're available?