### PR TITLE
hotfix:set manageState value to false in existing teams

### DIFF
--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -64,4 +64,5 @@
     <include file="/db/changelog/local/changelog-2.22.2-webhook-triggers.xml"/>
     <include file="/db/changelog/local/changelog-2.23.0-job-reference-size.xml"/>
     <include file="/db/changelog/local/changelog-2.23.0-team-manage-state.xml"/>
+    <include file="/db/changelog/local/changelog-2.23.1-team-manage-state-hotfix.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.23.1-team-manage-state-hotfix.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.23.1-team-manage-state-hotfix.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-23-1" author="alfespa17@gmail.com">
+        <update tableName="team">
+            <column name="manage_state" valueBoolean="false"/>
+        </update>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
This will update the `manageState` value to "false" in `teams` table

Fix #1344