### PR TITLE
fix: Show resources and outputs validating manageState permission correctly

### DIFF
--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -383,11 +383,12 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
   };
   
   const loadPermissionSet = () => {
+    console.log("Loading Permission Values")
     const url = `${new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin}/access-token/v1/teams/permissions/organization/${organizationId}`;
     axiosInstance.get(url).then((response) => {
+      console.log(response.data)
       setManageState(response.data.manageState);
       setManageWorkspace(response.data.manageWorkspace);
-      console.log(`Manage Permission Set: ${manageState} ${manageWorkspace}`)
     })
   };
 
@@ -408,6 +409,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
 
             if (_loadPermissionSet)
               loadPermissionSet()
+
             setWorkspace(response.data);
             console.log(response.data);
             if (response.data.included) {
@@ -430,8 +432,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                 _loadWebhook,
                 setWebhook,
                 setPushWebhookEnabled,
-                setContextState,
-                manageState,
+                setContextState
               );
             }
 
@@ -1588,8 +1589,7 @@ function setupWorkspaceIncludes(
   _loadWebhook,
   setWebhook,
   setPushWebhookEnabled,
-  setContextState,
-  manageState
+  setContextState
 ) {
   let variables = [];
   let jobs = [];
@@ -1716,15 +1716,22 @@ function setupWorkspaceIncludes(
   // reload state only if there is a new version
   console.log("Get latest state");
   if (currentStateId !== lastState?.id) {
-    loadState(
-      lastState,
-      axiosInstance,
-      setOutputs,
-      setResources,
-      sessionStorage.getItem(WORKSPACE_ARCHIVE),
-      setContextState,
-      manageState
-    );
+    var organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
+    const url = `${new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin}/access-token/v1/teams/permissions/organization/${organizationId}`;
+    axiosInstance.get(url).then((response) => {
+      console.log(`Manage Permission Set: ${response.data}`)
+      console.log(response.data)
+      loadState(
+        lastState,
+        axiosInstance,
+        setOutputs,
+        setResources,
+        sessionStorage.getItem(WORKSPACE_ARCHIVE),
+        setContextState,
+        response.data.manageState
+      );
+    })
+    
   }
   setCurrentStateId(lastState?.id);
 }
@@ -1738,10 +1745,11 @@ function loadState(
   setContextState,
   manageState
 ) {
+  console.log(`Loading State ${manageState} `)
   if (!state || !manageState) {
     return;
   }
-  console.log(`Loading State ${manageState} `)
+
   var currentState;
   var organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
 

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -341,14 +341,14 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
 
   useEffect(() => {
     setLoading(true);
-    loadWorkspace(true, true);
+    loadWorkspace(true, true, true);
     loadPermissionSet();
     setLoading(false);
     loadSSHKeys();
     loadAgentlist();
     loadOrgTemplates();
     const interval = setInterval(() => {
-      loadWorkspace(false, false);
+      loadWorkspace(false, false, false);
       loadPermissionSet();
     }, 10000);
     return () => clearInterval(interval);
@@ -387,10 +387,11 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
     axiosInstance.get(url).then((response) => {
       setManageState(response.data.manageState);
       setManageWorkspace(response.data.manageWorkspace);
+      console.log(`Manage Permission Set: ${manageState} ${manageWorkspace}`)
     })
   };
 
-  const loadWorkspace = (_loadVersions, _loadWebhook) => {
+  const loadWorkspace = (_loadVersions, _loadWebhook, _loadPermissionSet) => {
     var url = `organization/${organizationId}/workspace/${id}?include=job,variable,history,schedule,vcs,agent,organization`;
     if (_loadWebhook) url += ",webhook";
     axiosInstance
@@ -404,6 +405,9 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
           .then((response) => {
             if (_loadVersions)
               loadVersions(response.data.data.attributes.iacType);
+
+            if (_loadPermissionSet)
+              loadPermissionSet()
             setWorkspace(response.data);
             console.log(response.data);
             if (response.data.included) {
@@ -1737,7 +1741,7 @@ function loadState(
   if (!state || !manageState) {
     return;
   }
-
+  console.log(`Loading State ${manageState} `)
   var currentState;
   var organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
 


### PR DESCRIPTION
With `manageState` permission inside a team

![image](https://github.com/user-attachments/assets/250f063e-d30f-48b0-8182-88e90862a5ce)

It will correctly show the values 

![image](https://github.com/user-attachments/assets/bd455ac7-a7cf-451e-a5ba-70fe8639c0df)


Without manageState

![image](https://github.com/user-attachments/assets/0b8806bf-29a8-4406-a553-70f24df960d7)

It wont show the values in the UI and the state tab is blocked

![image](https://github.com/user-attachments/assets/5fc4da92-283a-48b4-9df7-157d842c3b6b)

Fix #1342 

