### PR TITLE
fix: Add workspace description link is displayed only if description not present for a workspace.

### DIFF
--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -770,9 +770,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                 >
                   <span className="workspace-details"> ID: {id} </span>
                 </Paragraph>
-                {workspace.data.attributes.description === "" ? (
-                  workspace.data.attributes.description
-                ) : (
+                {(workspace.data.attributes?.description === "") ? (
                   <a
                     className="workspace-button"
                     onClick={handleClickSettings}
@@ -780,6 +778,10 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                   >
                     Add workspace description
                   </a>
+                )
+                :
+                (
+                  workspace.data.attributes.description
                 )}
                 <Space
                   size={40}


### PR DESCRIPTION
Fix #1355 Workspace description

Commit: 44855a0c38cc7d67623b0d581ccbbf64b9404eed
Author: Avinashs7
Date: 01/10/2024

Display workspace description in details section, with option to add a description if none exists