### PR TITLE
fix: issue when executor is downloading the state file using terraform_remote_state

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/security/state/StateService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/state/StateService.java
@@ -16,18 +16,21 @@ public class StateService {
    private TeamRepository teamRepository;
 
    public boolean hasManageStatePermission(Authentication authentication, String orgnizationId) {
-      Object groupNames = ((JwtAuthenticationToken) authentication).getTokenAttributes().get("groups");
-      if (groupNames == null) {
+      if (((JwtAuthenticationToken) authentication).getTokenAttributes().get("iss").equals("TerrakubeInternal")) {
+         return true;
+      } else {
+         Object groupNames = ((JwtAuthenticationToken) authentication).getTokenAttributes().get("groups");
+         if (groupNames == null) {
+            return false;
+         }
+         @SuppressWarnings("unchecked")
+         List<Team> teams = teamRepository.findAllByOrganizationIdAndNameIn(UUID.fromString(orgnizationId), (List<String>) groupNames);
+         for (Team team : teams) {
+            if (team.isManageState()) {
+               return true;
+            }
+         }
          return false;
       }
-      @SuppressWarnings("unchecked")
-      List<Team> teams = teamRepository.findAllByOrganizationIdAndNameIn(UUID.fromString(orgnizationId), (List<String>) groupNames);
-      for (Team team : teams) {
-         if (team.isManageState()) {
-            return true;
-         }
-      }
-      
-      return false;
-   } 
+   }
 }


### PR DESCRIPTION
Fix issue in version 2.23.1 when using `terraform_remote_state` datasource, now the executor component is able to download the state file correctly when using `terraform_remote_state`

Adding test cases to correctly validate if the state can be downloaded by the executor or a normal user.

```
user@pop-os:~/git/simple-terraform/shared-state$ terraform apply

Running apply in HCP Terraform. Output will stream here. Pressing Ctrl-C
will cancel the remote apply if it's still pending. If the apply started it
will stop streaming the logs, but will not stop the apply running remotely.

Preparing the remote apply...

To view this run in a browser, visit:
https://terrakube-api.minikube.net/app/simple/reference-shared/runs/run-5

Waiting for 0 queued run(s) to finish before starting...
Waiting for 0 queued run(s) to finish before starting... (30s elapsed)

***************************************
Running Terraform PLAN
***************************************
data.terraform_remote_state.remote_creation_time: Reading...
data.terraform_remote_state.remote_creation_time: Read complete after 2s

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # null_resource.next will be created
  + resource "null_resource" "next" {
      + id = (known after apply)
    }

  # null_resource.previous will be created
  + resource "null_resource" "previous" {
      + id = (known after apply)
    }

  # time_sleep.wait_30_seconds will be created
  + resource "time_sleep" "wait_30_seconds" {
      + create_duration = "2m"
      + id              = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.


Do you want to perform these actions in workspace "reference-shared"?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

null_resource.previous: Creating...
null_resource.previous: Creation complete after 0s [id=8847489657941947752]
time_sleep.wait_30_seconds: Creating...
time_sleep.wait_30_seconds: Still creating... [10s elapsed]
time_sleep.wait_30_seconds: Still creating... [20s elapsed]
time_sleep.wait_30_seconds: Still creating... [30s elapsed]
time_sleep.wait_30_seconds: Still creating... [40s elapsed]
time_sleep.wait_30_seconds: Still creating... [50s elapsed]
time_sleep.wait_30_seconds: Still creating... [1m0s elapsed]
time_sleep.wait_30_seconds: Still creating... [1m10s elapsed]
time_sleep.wait_30_seconds: Still creating... [1m20s elapsed]
time_sleep.wait_30_seconds: Still creating... [1m30s elapsed]
time_sleep.wait_30_seconds: Still creating... [1m40s elapsed]
time_sleep.wait_30_seconds: Still creating... [1m50s elapsed]
time_sleep.wait_30_seconds: Still creating... [2m0s elapsed]
time_sleep.wait_30_seconds: Creation complete after 2m0s [id=2024-10-03T16:00:17Z]
null_resource.next: Creating...
null_resource.next: Creation complete after 0s [id=8072788383020742687]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

```

Fix #1360 