### PR TITLE
Filter text appropriate to the filter applied to the workspace 

### DIFF
--- a/ui/src/domain/Organizations/Details.jsx
+++ b/ui/src/domain/Organizations/Details.jsx
@@ -161,7 +161,6 @@ export const OrganizationDetails = ({
     console.log(searchValue || "serach empty");
     console.log(filterValue || "filter empty");
     console.log(selectedTags || "tags empty");
-
     var filteredWorkspaces = filterWorkspaces(
       workspaces,
       searchValue,
@@ -217,7 +216,6 @@ export const OrganizationDetails = ({
     const _searchValue = sessionStorage.getItem("searchValue") || "";
     const _filterValue = sessionStorage.getItem("filterValue") || "";
     const _selectedTags = sessionStorage.getItem("selectedTags") || [];
-
     setSearchValue(_searchValue);
     setFilterValue(_filterValue);
     setFilterTags(_selectedTags);
@@ -390,6 +388,7 @@ export const OrganizationDetails = ({
                     style={{ width: "100%" }}
                     placeholder="Search by tag"
                     onChange={handleChange}
+                    value={filterTags}
                     filterSort={(optionA, optionB) =>
                       (optionA?.label ?? "")
                         .toLowerCase()
@@ -407,6 +406,7 @@ export const OrganizationDetails = ({
                   <Search
                     placeholder="Search by name, description"
                     onSearch={onSearch}
+                    value={searchValue}
                     defaultValue={searchValue}
                     allowClear
                   />


### PR DESCRIPTION
Fixes #1359 Workspace view remains filtered after changing screens but no filter text is shown

## Description
- Now if workspace is filtered and moved to next page and returning will keep filter active with the proper filter applied, can be text in the search bar or filter based on tags.
- Earlier these tags or search input wasn't persistent in the view. 


Commit: 004dff9642032f9e8282c0e4a1883ca005ee6dab
Author: Avinashs7
Date: 05/10/2024