### PR TITLE
filter tag and search value remain until the filter is removed.

### DIFF
--- a/ui/src/domain/Organizations/Details.jsx
+++ b/ui/src/domain/Organizations/Details.jsx
@@ -137,10 +137,11 @@ export const OrganizationDetails = ({
   };
 
   const onSearch = (value) => {
-    setSearchValue(value);
     applyFilters(value, filterValue, filterTags);
   };
-
+  const updateSearchValue=(e)=>{
+    setSearchValue(e.target.value);
+  }
   const getTagName = (tagId) => {
     return tags.data.find((tag) => tag.id === tagId)?.attributes?.name;
   };
@@ -390,6 +391,7 @@ export const OrganizationDetails = ({
                     style={{ width: "100%" }}
                     placeholder="Search by tag"
                     onChange={handleChange}
+                    value={filterTags}
                     filterSort={(optionA, optionB) =>
                       (optionA?.label ?? "")
                         .toLowerCase()
@@ -407,7 +409,9 @@ export const OrganizationDetails = ({
                   <Search
                     placeholder="Search by name, description"
                     onSearch={onSearch}
-                    defaultValue={searchValue}
+                    onChange={updateSearchValue}
+                    value={searchValue}
+                    // defaultValue={searchValue}
                     allowClear
                   />
                 </Col>


### PR DESCRIPTION
Fixes #1359 Workspace view remains filtered after changing screens but no filter text is shown

## Description
- Now if workspace is filtered and moved to next page and returning will keep filter active with the proper filter applied, can be text in the search bar or filter based on tags.
- Earlier these tags or search input wasn't persistent in the view. 


Commit: 6fa23e15cdb5a3e9f7d4e073bda2effc0a7a3cc3
Author: Avinashs7
Date: 07/10/2024