### PR TITLE
fix: REDIS connection using ssl in API

### DIFF
--- a/api/src/main/java/org/terrakube/api/rs/module/GitTagsCache.java
+++ b/api/src/main/java/org/terrakube/api/rs/module/GitTagsCache.java
@@ -107,6 +107,11 @@ public class GitTagsCache {
                             jedisPool = new JedisPool(jedisPoolConfig, hostname, Integer.valueOf(port),
                                     Integer.valueOf(timeout), Integer.valueOf(timeout), username, password, 0, null,
                                     true, sslSocketFactory, null, null);
+                        } else if (useSSL && username == null) {
+                            log.warn("Connecting Redis using hostname, port, password and sslSocketFactory");
+                            jedisPool = new JedisPool(jedisPoolConfig, hostname, Integer.valueOf(port),
+                                    Integer.valueOf(timeout), Integer.valueOf(timeout), password, 0, null,
+                                    true, sslSocketFactory, null, null);
                         } else if (username != null) {
                             log.warn("Connecting Redis using hostname, port, username, password with SSL enabled",
                                     username);


### PR DESCRIPTION
This PR will fix the issue when the API is connecting to a REDIS with SSL enabled.

```yaml
## API properties
api:
  version: "2.23.2"
  defaultRedis: false
  env:
  - name: TerrakubeRedisSSL
    value: "true"
  - name: TerrakubeRedisTruststorePath
    value: /layers/paketo-buildpacks_bellsoft-liberica/jre/lib/security/cacerts 
  - name: TerrakubeRedisTruststorePassword
    value: changeit
  properties:
    redisHostname: "MYREDISHOSTNAME.redis.cache.windows.net"
    redisPassword: "mysuperpassword"
```

Logs:

```shell
2024-10-08T21:13:42.610Z  INFO 1 --- [           main] o.t.a.p.s.StreamingConfiguration         : Redis Configuration=> User: username is null, Hostname: MYREDISHOSTNAME.redis.cache.windows.net, Port: 6380, Ssl: true
2024-10-08T21:13:42.618Z  INFO 1 --- [           main] o.t.a.p.s.StreamingConfiguration         : Redis connection is not using username parameter
2024-10-08T21:13:42.618Z  INFO 1 --- [           main] o.t.a.p.s.StreamingConfiguration         : Setup Redis connection using SSL
```

It will use the default CA certs that are included inside the container located in `/layers/paketo-buildpacks_bellsoft-liberica/jre/lib/security/cacerts`

> The above was tested using a Azure REDIS cache and connecting using the "primary access key" without a username

This require to manually update the REDIS port that is hardcoded inside the helm chart.

https://github.com/AzBuilder/terrakube-helm-chart/blob/efd3585024cd7236cabfd389ed090d3d2add721f/charts/terrakube/templates/secrets-api.yaml#L20

I will change that in another PR.