### PR TITLE
feat: Allow users w/o manage perm to trigger run

### DIFF
--- a/api/src/main/java/org/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/org/terrakube/api/rs/job/Job.java
@@ -1,22 +1,36 @@
 package org.terrakube.api.rs.job;
 
-import com.yahoo.elide.annotation.*;
-import lombok.Getter;
-import lombok.Setter;
+import java.util.List;
+
 import org.terrakube.api.plugin.security.audit.GenericAuditFields;
 import org.terrakube.api.rs.Organization;
 import org.terrakube.api.rs.hooks.job.JobManageHook;
 import org.terrakube.api.rs.job.step.Step;
 import org.terrakube.api.rs.workspace.Workspace;
 
-import jakarta.persistence.*;
+import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.Exclude;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.LifeCycleHookBinding;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.annotation.UpdatePermission;
 
-import java.util.List;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.Setter;
 
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.CREATE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = JobManageHook.class)
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.UPDATE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = JobManageHook.class)
 @ReadPermission(expression = "team view job")
-@CreatePermission(expression = "team manage job")
+@CreatePermission(expression = "team view job")
 @UpdatePermission(expression = "team manage job OR user is a super service")
 @Include(rootLevel = false)
 @Getter

--- a/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
@@ -111,6 +111,7 @@ public class Workspace extends GenericAuditFields {
     private List<Schedule> schedule;
 
     @OneToMany(mappedBy = "workspace")
+    @UpdatePermission(expression = "team view workspace")
     private List<Job> job;
 
     @Exclude


### PR DESCRIPTION
Allow users without manage workspace permission to trigger runs from UI. This enhances the security posture so that users who uses the workspace don't necessarily have the permission to update any settings of the workspace.