### PR TITLE
fix: error output overlaps with standard output

### DIFF
--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<commons-text.version>1.12.0</commons-text.version>
-		<terraform-spring-boot-starter.version>0.15.0</terraform-spring-boot-starter.version>
+		<terraform-spring-boot-starter.version>0.16.0</terraform-spring-boot-starter.version>
 		<terrakube-client-starter.version>0.15.1</terrakube-client-starter.version>
 		<commons-io.version>2.17.0</commons-io.version>
 		<commons-codec>1.17.1</commons-codec>

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -226,6 +226,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             boolean scriptBeforeSuccess;
             boolean scriptAfterSuccess;
 
+            terraformClient.setRedirectErrorStream(true);
             executeTerraformInit(
                     terraformJob,
                     terraformWorkingDir,

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -96,19 +96,12 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                     .lineNumber(new AtomicInteger(0))
                     .build();
 
-            Consumer<String> planOutputError = LogsConsumer.builder()
-                    .jobId(Integer.valueOf(terraformJob.getJobId()))
-                    .terraformOutput(jobErrorOutput)
-                    .stepId(terraformJob.getStepId())
-                    .lineNumber(new AtomicInteger(0))
-                    .processLogs(logsService)
-                    .build();
-
+            terraformClient.setRedirectErrorStream(true);
             executeTerraformInit(
                     terraformJob,
                     terraformWorkingDir,
                     planOutput,
-                    planOutputError);
+                    null);
 
             scriptBeforeSuccessPlan = executePreOperationScripts(terraformJob, terraformWorkingDir, planOutput);
 
@@ -120,12 +113,12 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                     exitCode = terraformClient.planDestroyDetailExitCode(
                             getTerraformProcessData(terraformJob, terraformWorkingDir),
                             planOutput,
-                            planOutputError).get();
+                            null).get();
                 } else {
                     exitCode = terraformClient.planDetailExitCode(
                             getTerraformProcessData(terraformJob, terraformWorkingDir),
                             planOutput,
-                            planOutputError).get();
+                            null).get();
                 }
 
             if(exitCode != 1) {
@@ -169,25 +162,18 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                     .processLogs(logsService)
                     .build();
 
-            Consumer<String> applyErrorOutput = LogsConsumer.builder()
-                    .jobId(Integer.valueOf(terraformJob.getJobId()))
-                    .terraformOutput(terraformErrorOutput)
-                    .stepId(terraformJob.getStepId())
-                    .processLogs(logsService)
-                    .lineNumber(new AtomicInteger(0))
-                    .build();
-
             HashMap<String, String> terraformParameters = getWorkspaceParameters(terraformJob.getVariables());
 
             boolean execution = false;
             boolean scriptBeforeSuccess;
             boolean scriptAfterSuccess;
 
+            terraformClient.setRedirectErrorStream(true);
             executeTerraformInit(
                     terraformJob,
                     terraformWorkingDir,
                     applyOutput,
-                    applyErrorOutput);
+                    null);
 
             scriptBeforeSuccess = executePreOperationScripts(terraformJob, terraformWorkingDir, applyOutput);
 
@@ -201,7 +187,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                 execution = terraformClient.apply(
                         terraformProcessData,
                         applyOutput,
-                        applyErrorOutput).get();
+                        null).get();
 
                 handleTerraformStateChange(terraformJob, terraformWorkingDir);
 
@@ -236,14 +222,6 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                     .lineNumber(new AtomicInteger(0))
                     .build();
 
-            Consumer<String> errorOutputDestroy = LogsConsumer.builder()
-                    .lineNumber(new AtomicInteger(0))
-                    .jobId(Integer.valueOf(terraformJob.getJobId()))
-                    .terraformOutput(jobErrorOutput)
-                    .stepId(terraformJob.getStepId())
-                    .processLogs(logsService)
-                    .build();
-
             boolean execution = false;
             boolean scriptBeforeSuccess;
             boolean scriptAfterSuccess;
@@ -252,7 +230,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                     terraformJob,
                     terraformWorkingDir,
                     outputDestroy,
-                    errorOutputDestroy);
+                    null);
 
             scriptBeforeSuccess = executePreOperationScripts(terraformJob, terraformWorkingDir, outputDestroy);
 
@@ -262,7 +240,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                 execution = terraformClient.destroy(
                         getTerraformProcessData(terraformJob, terraformWorkingDir),
                         outputDestroy,
-                        errorOutputDestroy).get();
+                        null).get();
 
                 handleTerraformStateChange(terraformJob, terraformWorkingDir);
             }


### PR DESCRIPTION
This change fixes the display overlaps between error and standard output by redirect error output to standard, in which case Terraform will display the errors at the end of the standard output.

fixes #1394 