### PR TITLE
Allow to include or remove terraform backend keys in AWS

### DIFF
--- a/executor/src/main/java/org/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
@@ -54,6 +54,8 @@ public class AwsTerraformStateImpl implements TerraformState {
 
     private String endpoint;
 
+    private boolean includeBackendKeys;
+
     @NonNull
     TerrakubeClient terrakubeClient;
 
@@ -73,8 +75,13 @@ public class AwsTerraformStateImpl implements TerraformState {
             awsBackendHcl.appendln("    bucket     = \"" + bucketName + "\"");
             awsBackendHcl.appendln("    region     = \"" + region.getName() + "\"");
             awsBackendHcl.appendln("    key        = \"tfstate/" + organizationId + "/" + workspaceId + "/terraform.tfstate" + "\"");
-            awsBackendHcl.appendln("    access_key = \"" + accessKey + "\"");
-            awsBackendHcl.appendln("    secret_key = \"" + secretKey + "\"");
+            if(includeBackendKeys) {
+                log.info("Including backend information");
+                awsBackendHcl.appendln("    access_key = \"" + accessKey + "\"");
+                awsBackendHcl.appendln("    secret_key = \"" + secretKey + "\"");
+            } else {
+              log.warn("No including backend information");
+            }
 
             if(endpoint != null){
                 if(version.compareTo(new ComparableVersion("1.6.0")) < 0){

--- a/executor/src/main/java/org/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateProperties.java
+++ b/executor/src/main/java/org/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateProperties.java
@@ -19,4 +19,5 @@ public class AwsTerraformStateProperties {
     private String bucketName;
     private String region;
     private String endpoint;
+    private boolean includeBackendKeys;
 }

--- a/executor/src/main/java/org/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
+++ b/executor/src/main/java/org/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
@@ -103,6 +103,7 @@ public class TerraformStateAutoConfiguration {
                             .accessKey(awsTerraformStateProperties.getAccessKey())
                             .secretKey(awsTerraformStateProperties.getSecretKey())
                             .region(Regions.fromName(awsTerraformStateProperties.getRegion()))
+                            .includeBackendKeys(awsTerraformStateProperties.isIncludeBackendKeys())
                             .terrakubeClient(terrakubeClient)
                             .terraformStatePathService(terraformStatePathService)
                             .build();

--- a/executor/src/main/resources/application.properties
+++ b/executor/src/main/resources/application.properties
@@ -45,6 +45,7 @@ org.terrakube.executor.plugin.tfstate.aws.secretKey=${AwsTerraformStateSecretKey
 org.terrakube.executor.plugin.tfstate.aws.bucketName=${AwsTerraformStateBucketName}
 org.terrakube.executor.plugin.tfstate.aws.region=${AwsTerraformStateRegion}
 org.terrakube.executor.plugin.tfstate.aws.endpoint=${AwsEndpoint}
+org.terrakube.executor.plugin.tfstate.aws.includeBackendKeys=${AwsIncludeBackendKeys:true}
 
 ####################
 #Storage Aws Output#


### PR DESCRIPTION
This will allow to include or not the terraform backend state keys inside the internal backend override using the environment variable `AwsIncludeBackendKeys`

Fix #1411 