### PR TITLE
feat: Migrate Terrakube Executor to AWS sdk v2

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -1188,7 +1188,7 @@ public class RemoteTfeService {
         if (job.getStep() != null && !job.getStep().isEmpty())
             for (Step step : job.getStep()) {
                 if (step.getStepNumber() == 100) {
-                    log.info("Checking logs stepId for apply: {}", step.getId());
+                    log.debug("Checking logs stepId for apply: {}", step.getId());
 
                     try {
                         @SuppressWarnings("unchecked")

--- a/api/src/main/java/org/terrakube/api/plugin/storage/aws/AwsStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/aws/AwsStorageTypeServiceImpl.java
@@ -139,7 +139,7 @@ public class AwsStorageTypeServiceImpl implements StorageTypeService {
                     .contentType("application/gzip")
                     .build();
 
-            s3client.putObject(putObjectRequest, RequestBody.fromInputStream(inputStream, IoUtils.toByteArray(inputStream).length));
+            s3client.putObject(putObjectRequest, RequestBody.fromBytes(IoUtils.toByteArray(inputStream)));
         } catch (IOException e) {
             log.error(e.getMessage());
         }

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -27,7 +27,7 @@
 		<groovy.version>4.0.23</groovy.version>
 		<ivy.version>2.5.2</ivy.version>
 		<jcolor.version>5.5.1</jcolor.version>
-		<aws-sdk.version>1.12.776</aws-sdk.version>
+		<aws-sdk.version>2.28.27</aws-sdk.version>
 		<google-storage.version>1.17.0</google-storage.version>
 		<slf4j.version>2.0.16</slf4j.version>
 		<gcp-libraries-bom.version>26.49.0</gcp-libraries-bom.version>
@@ -142,8 +142,8 @@
 			<version>${jcolor.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-s3</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>s3</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.google.cloud</groupId>
@@ -174,8 +174,8 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>com.amazonaws</groupId>
-				<artifactId>aws-java-sdk-bom</artifactId>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>bom</artifactId>
 				<version>${aws-sdk.version}</version>
 				<type>pom</type>
 				<scope>import</scope>

--- a/executor/src/main/java/org/terrakube/executor/plugin/tfoutput/aws/AwsTerraformOutputProperties.java
+++ b/executor/src/main/java/org/terrakube/executor/plugin/tfoutput/aws/AwsTerraformOutputProperties.java
@@ -19,4 +19,5 @@ public class AwsTerraformOutputProperties {
     private String bucketName;
     private String region;
     private String endpoint;
+    private boolean enableRoleAuthentication;
 }

--- a/executor/src/main/java/org/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
@@ -133,7 +133,6 @@ public class AwsTerraformStateImpl implements TerraformState {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucketName)
                     .key(blobKey)
-                    .contentType("application/octet-stream")
                     .build();
 
             s3client.putObject(putObjectRequest, RequestBody.fromFile(tfPlanContent));
@@ -160,7 +159,7 @@ public class AwsTerraformStateImpl implements TerraformState {
                         log.info("Downloading state from {}", stateUrl);
                         log.info("Buket location: {}", "tfstate/" + new URL(stateUrl).getPath().split("/tfstate/")[1]);
 
-                        byte[] data = downloadObjectFromBucket(bucketName, new URL(stateUrl).getPath().split("/tfstate/")[1]);
+                        byte[] data = downloadObjectFromBucket(bucketName, "tfstate/" + new URL(stateUrl).getPath().split("/tfstate/")[1]);
 
                         FileUtils.copyToFile(
                                 new ByteArrayInputStream(data),

--- a/executor/src/main/java/org/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
@@ -133,6 +133,7 @@ public class AwsTerraformStateImpl implements TerraformState {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucketName)
                     .key(blobKey)
+                    .contentType("application/octet-stream")
                     .build();
 
             s3client.putObject(putObjectRequest, RequestBody.fromFile(tfPlanContent));

--- a/executor/src/main/java/org/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateProperties.java
+++ b/executor/src/main/java/org/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateProperties.java
@@ -20,4 +20,5 @@ public class AwsTerraformStateProperties {
     private String region;
     private String endpoint;
     private boolean includeBackendKeys;
+    private boolean enableRoleAuthentication;
 }

--- a/executor/src/main/resources/application.properties
+++ b/executor/src/main/resources/application.properties
@@ -46,6 +46,7 @@ org.terrakube.executor.plugin.tfstate.aws.bucketName=${AwsTerraformStateBucketNa
 org.terrakube.executor.plugin.tfstate.aws.region=${AwsTerraformStateRegion}
 org.terrakube.executor.plugin.tfstate.aws.endpoint=${AwsEndpoint}
 org.terrakube.executor.plugin.tfstate.aws.includeBackendKeys=${AwsIncludeBackendKeys:true}
+org.terrakube.executor.plugin.tfstate.aws.enableRoleAuthentication=${AwsEnableRoleAuth:false}
 
 ####################
 #Storage Aws Output#
@@ -55,6 +56,7 @@ org.terrakube.executor.plugin.tfoutput.aws.secretKey=${AwsTerraformOutputSecretK
 org.terrakube.executor.plugin.tfoutput.aws.bucketName=${AwsTerraformOutputBucketName}
 org.terrakube.executor.plugin.tfoutput.aws.region=${AwsTerraformOutputRegion}
 org.terrakube.executor.plugin.tfoutput.aws.endpoint=${AwsEndpoint}
+org.terrakube.executor.plugin.tfoutput.aws.enableRoleAuthentication=${AwsEnableRoleAuth:false}
 
 ####################
 #Storage Gcp Output#


### PR DESCRIPTION
Fix #1204 

- Migrating to AWS SDK version 2
- Allow to use DefaultCredentialsProvider.create() when environment variable "AwsEnableRoleAuth=true"

