### PR TITLE
feat: enhance branch matching with regex

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
@@ -200,10 +200,12 @@ public class WebhookService {
     }
 
     private boolean checkBranch(String webhookBranch, Webhook webhook) {
-        String[] branchList = webhook.getBranch().split(",");
+        // Check if the webhook branch is the default workspace branch
         if (webhookBranch.equals(webhook.getWorkspace().getBranch())) {
             return true;
         }
+
+        String[] branchList = webhook.getBranch().split(",");
         for (String branch : branchList) {
             branch = branch.trim();
             if (webhookBranch.matches(branch)) {

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
@@ -201,7 +201,9 @@ public class WebhookService {
 
     private boolean checkBranch(String webhookBranch, Webhook webhook) {
         String[] branchList = webhook.getBranch().split(",");
-
+        if (webhookBranch.equals(webhook.getWorkspace().getBranch())) {
+            return true;
+        }
         for (String branch : branchList) {
             branch = branch.trim();
             if (webhookBranch.matches(branch)) {
@@ -218,6 +220,10 @@ public class WebhookService {
             workspaceFolder = workspaceFolder.substring(1);
         }
         for (String file : files) {
+            if (file.startsWith(workspaceFolder)) {
+                log.info("Changed file {} in set workspace path {}", file, workspaceFolder);
+                return true;
+            }
             for (int i = 0; i < triggeredPath.length; i++) {
                 if (file.matches(triggeredPath[i])) {
                     log.info("Changed file {} matches set trigger pattern {}", file, triggeredPath[i]);

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
@@ -201,28 +201,14 @@ public class WebhookService {
 
     private boolean checkBranch(String webhookBranch, Webhook webhook) {
         String[] branchList = webhook.getBranch().split(",");
-        boolean isExcluded = false;
-        boolean allowAnyBranch = false;
 
         for (String branch : branchList) {
             branch = branch.trim();
-
-            if (branch.equals("*")) {
-                allowAnyBranch = true; // Only set if there are no exclusions
-            } else if (branch.startsWith("!")) {
-                // If the branch pattern starts with '!', mark it as excluded if it matches
-                String excludeBranch = branch.substring(1);
-                if (webhookBranch.equals(excludeBranch)) {
-                    isExcluded = true;
-                }
-            } else if (webhookBranch.startsWith(branch)) {
-                // Check for other prefix matches
+            if (webhookBranch.matches(branch)) {
                 return true;
             }
         }
-
-        // Return true if allowed by wildcard and not excluded
-        return allowAnyBranch && !isExcluded;
+        return false;
     }
 
     private boolean checkFileChanges(List<String> files, Webhook webhook) {
@@ -232,10 +218,6 @@ public class WebhookService {
             workspaceFolder = workspaceFolder.substring(1);
         }
         for (String file : files) {
-            if (file.startsWith(workspaceFolder)) {
-                log.info("Changed file {} in set workspace path {}", file, workspaceFolder);
-                return true;
-            }
             for (int i = 0; i < triggeredPath.length; i++) {
                 if (file.matches(triggeredPath[i])) {
                     log.info("Changed file {} matches set trigger pattern {}", file, triggeredPath[i]);


### PR DESCRIPTION
Hi @alfespa17 !

Following our discussion on this [topic](https://github.com/AzBuilder/terraform-provider-terrakube/issues/83) I'd like to propose a new way to do the matching for the branch list. The idea is as follow
- Be able to say I want to match all branch except these ones
- Keep the previous logic with startsWith branch

The only thing is that I do not automatically return `True` when the branch is the same as the workspace's default branch. I don't know if this is an issue ? 

It's just a proposal for us to be able to achieve our goals ! Lemme know if you approve it :) 

Regards