### PR TITLE
feat: Improve CLI driven workflow execution time

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJobService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJobService.java
@@ -1,19 +1,32 @@
 package org.terrakube.api.plugin.scheduler;
 
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+
+import org.quartz.CronExpression;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.terrakube.api.repository.StepRepository;
 import org.terrakube.api.repository.WorkspaceRepository;
 import org.terrakube.api.rs.job.Job;
 import org.terrakube.api.rs.job.JobStatus;
 import org.terrakube.api.rs.job.step.Step;
-import org.quartz.*;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.terrakube.api.rs.workspace.Workspace;
 
-import java.text.ParseException;
-import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @AllArgsConstructor
 @Slf4j
@@ -22,7 +35,7 @@ public class ScheduleJobService {
 
     public static final String PREFIX_JOB = "TerrakubeV2_Trigger_";
     public static final String PREFIX_JOB_CONTEXT = "TerrakubeV2_Job_";
-    public static final String CRON_SCHEDULE = "0 * * ? * *"; //CHECK EVERY MINUTES
+    public static final int JOB_CONTEXT_INTERVAL = 30;
 
     Scheduler scheduler;
 
@@ -67,11 +80,11 @@ public class ScheduleJobService {
                 .build();
 
         Trigger trigger = TriggerBuilder.newTrigger()
-                .startNow()
                 .forJob(jobDetail)
                 .withIdentity(PREFIX_JOB_CONTEXT + job.getId())
                 .withDescription(String.valueOf(job.getId()))
-                .withSchedule(CronScheduleBuilder.cronSchedule(new CronExpression(CRON_SCHEDULE)))
+                .withSchedule(SimpleScheduleBuilder.simpleSchedule().withIntervalInSeconds(JOB_CONTEXT_INTERVAL).repeatForever())
+                .startAt(Date.from(Instant.now().plusSeconds(JOB_CONTEXT_INTERVAL)))
                 .build();
 
         log.info("Create Job Context {}", jobDetail.getKey());
@@ -79,6 +92,7 @@ public class ScheduleJobService {
         Workspace workspace = job.getWorkspace();
         workspaceRepository.save(workspace);
         scheduler.scheduleJob(jobDetail, trigger);
+        scheduler.triggerJob(jobDetail.getKey());
     }
 
     public void createJobContextNow(Job job) throws SchedulerException {
@@ -97,14 +111,14 @@ public class ScheduleJobService {
                 .build();
 
         Trigger trigger = TriggerBuilder.newTrigger()
-                .startNow()
                 .forJob(jobDetail)
                 .withIdentity(PREFIX_JOB_CONTEXT + job.getId() + "_" + random)
                 .withDescription(String.valueOf(job.getId()))
                 .startNow()
                 .build();
 
-        log.info("Running Job Context Now: {}, Identity: {}", job.getId(), PREFIX_JOB_CONTEXT + job.getId() + "_" + random);
+        log.info("Running Job Context Now: {}, Identity: {}", job.getId(),
+                PREFIX_JOB_CONTEXT + job.getId() + "_" + random);
         scheduler.scheduleJob(jobDetail, trigger);
     }
 
@@ -117,8 +131,8 @@ public class ScheduleJobService {
     public void deleteJobContext(int jobId) throws ParseException, SchedulerException {
         log.info("Delete Job Context {}", jobId);
         scheduler.deleteJob(new JobKey(PREFIX_JOB_CONTEXT + jobId));
-        for(Step step: stepRepository.findByJobId(jobId)){
-            if(step.getStatus().equals(JobStatus.pending) || step.getStatus().equals(JobStatus.running)){
+        for (Step step : stepRepository.findByJobId(jobId)) {
+            if (step.getStatus().equals(JobStatus.pending) || step.getStatus().equals(JobStatus.running)) {
                 step.setStatus(JobStatus.cancelled);
                 stepRepository.save(step);
             }

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -833,7 +833,7 @@ public class RemoteTfeService {
 
         job = jobRepository.save(job);
         log.info("Job Created");
-        scheduleJobService.createJobContextNow(job);
+        scheduleJobService.createJobContext(job);
         log.info("Job Context Created");
         return getRun(job.getId(), null);
     }

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -833,7 +833,7 @@ public class RemoteTfeService {
 
         job = jobRepository.save(job);
         log.info("Job Created");
-        scheduleJobService.createJobContext(job);
+        scheduleJobService.createJobContextNow(job);
         log.info("Job Context Created");
         return getRun(job.getId(), null);
     }


### PR DESCRIPTION
People are quite sensitive to the amount of time they have to wait for Terraform runs kicked off from CLI, this change triggers such runs straight after it's created.

Additional changes:

1. Format
2. Remove excessive `startNow` call from `createJobContextNow`