### PR TITLE
feat: Adding lock description warning in workspace details

### DIFF
--- a/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
@@ -85,6 +85,9 @@ public class Workspace extends GenericAuditFields {
     @Column(name = "default_template")
     private String defaultTemplate;
 
+    @Column(name = "lock_description")
+    private String lockDescription;
+
     @Column(name = "iac_type")
     private String iacType = "terraform";
 

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -65,4 +65,5 @@
     <include file="/db/changelog/local/changelog-2.23.0-job-reference-size.xml"/>
     <include file="/db/changelog/local/changelog-2.23.0-team-manage-state.xml"/>
     <include file="/db/changelog/local/changelog-2.23.1-team-manage-state-hotfix.xml"/>
+    <include file="/db/changelog/local/changelog-2.24.0-lock-description.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.24.0-lock-description.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.24.0-lock-description.xml
@@ -4,8 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
     <changeSet id="2-24-0" author="alfespa17@gmail.com">
-        <update tableName="workspace">
+        <addColumn tableName="workspace">
             <column name="lock_description" type="varchar(512)"/>
-        </update>
+        </addColumn>
     </changeSet>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.24.0-lock-description.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.24.0-lock-description.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-24-0" author="alfespa17@gmail.com">
+        <update tableName="workspace">
+            <column name="lock_description" type="varchar(512)"/>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -16,6 +16,7 @@ import {
   UserOutlined,
 } from "@ant-design/icons";
 import {
+  Alert,
   Avatar,
   Breadcrumb,
   Button,

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -831,6 +831,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                 </Space>
               </Space>
               <Space className="workspace-lock-details" direction="vertical">
+                <Paragraph>
                   <span>
                     {workspace.data.attributes.locked ? (
                         <>
@@ -846,6 +847,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                         </>
                     )}
                   </span>
+                </Paragraph>
               </Space>
               <Tabs
                   activeKey={activeKey}
@@ -857,8 +859,8 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                         {actions &&
                             actions
                                 .reduce((acc, action) => {
-                            if (!action.attributes.displayCriteria) {
-                              acc.push(action);
+                                  if (!action.attributes.displayCriteria) {
+                                    acc.push(action);
                               return acc;
                             }
 

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -522,6 +522,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
             description: values.description,
             folder: values.folder,
             locked: values.locked,
+            lockedDescription: values.lockedDescription,
             executionMode: values.executionMode,
             moduleSshKey: values.moduleSshKey,
             terraformVersion: values.terraformVersion,
@@ -828,16 +829,33 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                   </span>
                 </Space>
               </Space>
+              <Space className="workspace-lock-details" direction="vertical">
+                  <span>
+                    {workspace.data.attributes.locked ? (
+                        <>
+                          <Alert
+                              message="Lock Description"
+                              description="This is a warning notice about copywriting."
+                              type="warning"
+                              showIcon
+                          />
+                        </>
+                    ) : (
+                        <>
+                        </>
+                    )}
+                  </span>
+              </Space>
               <Tabs
-                activeKey={activeKey}
-                defaultActiveKey={selectedTab}
-                onTabClick={handleStatesClick}
-                tabBarExtraContent={
-                  <>
-                    <Space direction="horizontal">
-                      {actions &&
-                        actions
-                          .reduce((acc, action) => {
+                  activeKey={activeKey}
+                  defaultActiveKey={selectedTab}
+                  onTabClick={handleStatesClick}
+                  tabBarExtraContent={
+                    <>
+                      <Space direction="horizontal">
+                        {actions &&
+                            actions
+                                .reduce((acc, action) => {
                             if (!action.attributes.displayCriteria) {
                               acc.push(action);
                               return acc;
@@ -1352,7 +1370,13 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                         >
                           <Switch disabled={!manageWorkspace}/>
                         </Form.Item>
-
+                        <Form.Item
+                            valuePropName="lockDescription"
+                            name="lockDescription"
+                            label="Setup custom lock description message"
+                        >
+                          <Input.TextArea placeholder="Lock description details" disabled={!manageWorkspace}/>
+                        </Form.Item>
                         <Form.Item
                           name="iacType"
                           label="Select IaC type "

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -523,7 +523,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
             description: values.description,
             folder: values.folder,
             locked: values.locked,
-            lockedDescription: values.lockedDescription,
+            lockDescription: values.lockDescription,
             executionMode: values.executionMode,
             moduleSshKey: values.moduleSshKey,
             terraformVersion: values.terraformVersion,
@@ -786,24 +786,24 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                   workspace.data.attributes.description
                 )}
                 <Space
-                  size={40}
-                  style={{ marginBottom: "40px" }}
-                  direction="horizontal"
+                    size={40}
+                    style={{marginBottom: "40px"}}
+                    direction="horizontal"
                 >
                   <span>
                     {workspace.data.attributes.locked ? (
-                      <>
-                        <LockOutlined /> Locked
-                      </>
+                        <>
+                          <LockOutlined/> Locked
+                        </>
                     ) : (
-                      <>
-                        <UnlockOutlined /> Unlocked
-                      </>
+                        <>
+                          <UnlockOutlined/> Unlocked
+                        </>
                     )}
                   </span>
                   <span>
-                    <ProfileOutlined /> Resources{" "}
-                    <span style={{ fontWeight: "500" }}>
+                    <ProfileOutlined/> Resources{" "}
+                    <span style={{fontWeight: "500"}}>
                       {resources.length}
                     </span>
                   </span>
@@ -812,9 +812,9 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                     <span>
                       {getIaCNameById(workspace.data.attributes?.iacType)}{" "}
                       <a
-                        onClick={handleClickSettings}
-                        className="workspace-button"
-                        style={{ color: "#3b3d45" }}
+                          onClick={handleClickSettings}
+                          className="workspace-button"
+                          style={{color: "#3b3d45"}}
                       >
                         v{workspace.data.attributes.terraformVersion}
                       </a>
@@ -822,22 +822,19 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                   </Space>
 
                   <span>
-                    <ClockCircleOutlined /> Updated{" "}
-                    <span style={{ fontWeight: "500" }}>
+                    <ClockCircleOutlined/> Updated{" "}
+                    <span style={{fontWeight: "500"}}>
                       {DateTime.fromISO(lastRun).toRelative() ??
-                        "never executed"}
+                          "never executed"}
                     </span>
                   </span>
-                </Space>
-              </Space>
-              <Space className="workspace-lock-details" direction="vertical">
-                <Paragraph>
+
                   <span>
                     {workspace.data.attributes.locked ? (
                         <>
                           <Alert
                               message="Lock Description"
-                              description="This is a warning notice about copywriting."
+                              description= {workspace.data.attributes.lockDescription}
                               type="warning"
                               showIcon
                           />
@@ -847,8 +844,9 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                         </>
                     )}
                   </span>
-                </Paragraph>
+                </Space>
               </Space>
+
               <Tabs
                   activeKey={activeKey}
                   defaultActiveKey={selectedTab}
@@ -1263,6 +1261,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                           description: workspace.data.attributes.description,
                           folder: workspace.data.attributes.folder,
                           locked: workspace.data.attributes.locked,
+                          lockDescription: workspace.data.attributes.lockDescription,
                           moduleSshKey: workspace.data.attributes.moduleSshKey,
                           executionMode:
                             workspace.data.attributes.executionMode,
@@ -1374,7 +1373,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                           <Switch disabled={!manageWorkspace}/>
                         </Form.Item>
                         <Form.Item
-                            valuePropName="lockDescription"
+                            valuePropName="value"
                             name="lockDescription"
                             label="Setup custom lock description message"
                         >


### PR DESCRIPTION
This will allow to set a lock description for a workspace and show a message warning like this:

![image](https://github.com/user-attachments/assets/9e6e49c4-fa5e-4b9c-a1c6-fcaedf87d557)

![image](https://github.com/user-attachments/assets/c9d65964-06b9-459d-bcb9-5c4078b88ceb)


fix #1358 