### PR TITLE
fix: Remove VCS client reference when deleting workspace

### DIFF
--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -719,18 +719,34 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
       },
     };
     axiosInstance
-      .patch(`organization/${organizationId}/workspace/${id}`, body, genericHeader)
-      .then((response) => {
-        console.log(response);
-        if (response.status === 204) {
-          console.log(response);
-          message.success("Workspace deleted successfully");
-          navigate(`/organizations/${organizationId}/workspaces`);
-        } else {
-          message.error("Workspace deletion failed");
-        }
-      });
-    deleteWebhook();
+        .patch(
+            `/organization/${organizationId}/workspace/${id}/relationships/vcs`,
+            {
+              data: null,
+            },
+            {
+              headers: {
+                "Content-Type": "application/vnd.api+json",
+              },
+            }
+        )
+        .then((response) => {
+          console.log("Deleting VCS refernce successfully");
+          axiosInstance
+              .patch(`organization/${organizationId}/workspace/${id}`, body, genericHeader)
+              .then((response) => {
+                console.log(response);
+                if (response.status === 204) {
+                  console.log(response);
+                  message.success("Workspace deleted successfully");
+                  navigate(`/organizations/${organizationId}/workspaces`);
+                } else {
+                  message.error("Workspace deletion failed");
+                }
+              });
+          deleteWebhook();
+        });
+
   };
 
   return (


### PR DESCRIPTION
This will remove the VCS id relationship from a Worskpace when deleting the resource from the UI

This will allow to remove the VCS connection without the following error once there are no workspaces using the VCS id.

```
Caused by: org.h2.jdbc.JdbcSQLIntegrityConstraintViolationException: Referential integrity constraint violation: "FK_WORKSPACE_VCS: PUBLIC.WORKSPACE FOREIGN KEY(VCS_ID) REFERENCES PUBLIC.VCS(ID) ('16ca2667-cf85-4ffa-85af-fa93dde65b84')"; SQL statement:
delete from vcs where id=? [23503-224]
```

Fix #1100 