### PR TITLE
feat: add possibility to mount config map on ephemeral job agent

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
@@ -86,7 +86,7 @@ public class EphemeralExecutorService {
         Optional<String> configMapMountPathOpt = Optional.ofNullable(executorContext.getEnvironmentVariables().get("CONFIG_MAP_MOUNT_PATH"));
         if (configMapNameOpt.isPresent()) {
             String configMapName = configMapNameOpt.get();
-            String mountPath = configMapMountPathOpt.orElse("/etc/config");  // Default mount path if not specified
+            String mountPath = configMapMountPathOpt.orElse("/home/");  // Default mount path if not specified
 
             // Define ConfigMap volume
             Volume configMapVolume = new Volume();

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
@@ -50,7 +50,7 @@ public class EphemeralExecutorService {
         }
         final List<EnvVar> executorEnvVarFlags = Arrays.asList(executorFlagBatch, executorFlagBatchJsonContent);
 
-        Optional<String> nodeSelector = Optional.ofNullable(executorContext.getEnvironmentVariables().containsKey(NODE_SELECTOR) ? executorContext.getEnvironmentVariables().get(NODE_SELECTOR) : null);
+        Optional<String> nodeSelector = Optional.ofNullable(executorContext.getEnvironmentVariables().getOrDefault(NODE_SELECTOR, null));
         Map<String, String> nodeSelectorInfo = new HashMap();
         log.info("Custom Node selector: {} {}", nodeSelector.isPresent(), nodeSelector.isEmpty());
         if(nodeSelector.isPresent()) {
@@ -64,7 +64,7 @@ public class EphemeralExecutorService {
             nodeSelectorInfo = ephemeralConfiguration.getNodeSelector();
         }
 
-        Optional<String> annotationsInfo = Optional.ofNullable(executorContext.getEnvironmentVariables().containsKey(ANNOTATIONS) ? executorContext.getEnvironmentVariables().get(ANNOTATIONS) : null);
+        Optional<String> annotationsInfo = Optional.ofNullable(executorContext.getEnvironmentVariables().getOrDefault(ANNOTATIONS, null));
         Map<String, String> annotations = new HashMap();
         log.info("Custom Annotations: {}", annotationsInfo.isPresent());
         if(annotationsInfo.isPresent()) {
@@ -75,8 +75,8 @@ public class EphemeralExecutorService {
         }
 
         Optional<String> serviceAccountInfo = Optional.ofNullable(
-                executorContext.getEnvironmentVariables().containsKey(SERVICE_ACCOUNT) ? executorContext.getEnvironmentVariables().get(SERVICE_ACCOUNT) : null);
-        String serviceAccount = serviceAccountInfo.isPresent() ? serviceAccountInfo.get() : null;
+                executorContext.getEnvironmentVariables().getOrDefault(SERVICE_ACCOUNT, null));
+        String serviceAccount = serviceAccountInfo.orElse(null);
 
         // Volume and VolumeMount for ConfigMap if specified
         List<Volume> volumes = new ArrayList<>();

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
@@ -20,6 +20,9 @@ public class EphemeralExecutorService {
     private static final String NODE_SELECTOR = "EPHEMERAL_CONFIG_NODE_SELECTOR_TAGS";
     private static final String SERVICE_ACCOUNT = "EPHEMERAL_CONFIG_SERVICE_ACCOUNT";
     private static final String ANNOTATIONS = "EPHEMERAL_CONFIG_ANNOTATIONS";
+    private static final String CONFIG_MAP_NAME = "EPHEMERAL_CONFIG_MAP_NAME";
+    private static final String CONFIG_MAP_PATH = "EPHEMERAL_CONFIG_MAP_MOUNT_PATH";
+
 
     KubernetesClient kubernetesClient;
     EphemeralConfiguration ephemeralConfiguration;
@@ -28,7 +31,6 @@ public class EphemeralExecutorService {
         final String jobName = "job-" + job.getId();
         deleteEphemeralJob(job);
         log.info("Ephemeral Executor Image {}, Job: {}, Namespace: {}, NodeSelector: {}", ephemeralConfiguration.getImage(), jobName, ephemeralConfiguration.getNamespace(), ephemeralConfiguration.getNodeSelector());
-
         SecretEnvSource secretEnvSource = new SecretEnvSource();
         secretEnvSource.setName(ephemeralConfiguration.getSecret());
         EnvFromSource envFromSource = new EnvFromSource();
@@ -48,6 +50,7 @@ public class EphemeralExecutorService {
         } catch (Exception e) {
             log.error(e.getMessage());
         }
+
         final List<EnvVar> executorEnvVarFlags = Arrays.asList(executorFlagBatch, executorFlagBatchJsonContent);
 
         Optional<String> nodeSelector = Optional.ofNullable(executorContext.getEnvironmentVariables().getOrDefault(NODE_SELECTOR, null));
@@ -82,8 +85,8 @@ public class EphemeralExecutorService {
         List<Volume> volumes = new ArrayList<>();
         List<VolumeMount> volumeMounts = new ArrayList<>();
 
-        Optional<String> configMapNameOpt = Optional.ofNullable(executorContext.getEnvironmentVariables().get("CONFIG_MAP_NAME"));
-        Optional<String> configMapMountPathOpt = Optional.ofNullable(executorContext.getEnvironmentVariables().get("CONFIG_MAP_MOUNT_PATH"));
+        Optional<String> configMapNameOpt = Optional.ofNullable(executorContext.getEnvironmentVariables().get(CONFIG_MAP_NAME));
+        Optional<String> configMapMountPathOpt = Optional.ofNullable(executorContext.getEnvironmentVariables().get(CONFIG_MAP_PATH));
         if (configMapNameOpt.isPresent()) {
             String configMapName = configMapNameOpt.get();
             String mountPath = configMapMountPathOpt.orElse("/tmp");  // Default mount path if not specified

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
@@ -86,7 +86,7 @@ public class EphemeralExecutorService {
         Optional<String> configMapMountPathOpt = Optional.ofNullable(executorContext.getEnvironmentVariables().get("CONFIG_MAP_MOUNT_PATH"));
         if (configMapNameOpt.isPresent()) {
             String configMapName = configMapNameOpt.get();
-            String mountPath = configMapMountPathOpt.orElse("/home/");  // Default mount path if not specified
+            String mountPath = configMapMountPathOpt.orElse("/tmp");  // Default mount path if not specified
 
             // Define ConfigMap volume
             Volume configMapVolume = new Volume();

--- a/ui/src/domain/Workspaces/Create.jsx
+++ b/ui/src/domain/Workspaces/Create.jsx
@@ -799,7 +799,7 @@ export const CreateWorkspace = () => {
                 name="webhookBranch"
                 label="Webhook Branch"
                 tooltip="A list of branch prefixes that will trigger a run."
-                extra="A list of brach prefixes besides the default VCS branch that will trigger a run, for example 'feat,fix'. Values are separated by comma."
+                extra="A list of branch regex besides the default VCS branch that will trigger a run, for example 'feat,fix'. Values are separated by comma."
                 rules={[{ required: false }]}
               >
                 <Input placeholder={defaultBranch} />

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -1478,7 +1478,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                           name="pushWebhookBranch"
                           label="Webhook Branch"
                           tooltip="A list of branch prefixes that will trigger a run."
-                          extra="A list of brach prefixes besides the default VCS branch that will trigger a run, for example 'feat,fix'. Values are separated by comma."
+                          extra="A list of branch regex besides the default VCS branch that will trigger a run, for example 'feat,fix'. Values are separated by comma."
                           rules={[{ required: false }]}
                         >
                           <Input placeholder={defaultBranch} disabled={!manageWorkspace}/>


### PR DESCRIPTION
Hey @alfespa17 !

We are currently working on ephemeral agents and we would like to add the ability to mount volumes on the jobs to allow for custom configuration like passing configuration files to interact with cloud providers. Do you think that could be a cool feature ?

Also, following this [PR](https://github.com/AzBuilder/terrakube/pull/1457) I update the message in the Terrakube UI to tell user that they can use regex for branch matching as well !

Regards !