### PR TITLE
fix: Moving liquibase script constraint to a new file

### DIFF
--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -67,4 +67,5 @@
     <include file="/db/changelog/local/changelog-2.23.1-team-manage-state-hotfix.xml"/>
     <include file="/db/changelog/local/changelog-2.24.0-lock-description.xml"/>
     <include file="/db/changelog/local/changelog-2.24.0-collection-data.xml"/>
+    <include file="/db/changelog/local/changelog-2.24.0-collection-data-constraints.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.24.0-collection-data-constraints.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.24.0-collection-data-constraints.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-24-0-2" author="alfespa17@gmail.com">
+        <addUniqueConstraint
+                columnNames="organization_id, name"
+                constraintName="const_collection"
+                deferrable="true"
+                disabled="true"
+                initiallyDeferred="true"
+                tableName="collection"
+                validate="true"/>
+        <addUniqueConstraint
+                columnNames="collection_id, item_key"
+                constraintName="const_collection_item"
+                deferrable="true"
+                disabled="true"
+                initiallyDeferred="true"
+                tableName="item"
+                validate="true"/>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.24.0-collection-data.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.24.0-collection-data.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <databaseChangeLog
-    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
     <changeSet id="2-24-0-1" author="alfespa17@gmail.com">
         <createTable tableName="collection">
             <column name="id" type="varchar(36)">
@@ -24,14 +24,6 @@
                 <constraints nullable="false" foreignKeyName="fk_collection_org" references="organization(id)"/>
             </column>
         </createTable>
-        <addUniqueConstraint
-                columnNames="organization_id, name"
-                constraintName="const_collection"
-                deferrable="true"
-                disabled="true"
-                initiallyDeferred="true"
-                tableName="collection"
-                validate="true"/>
         <createTable tableName="item">
             <column name="id" type="varchar(36)">
                 <constraints primaryKey="true"/>
@@ -61,14 +53,6 @@
                 <constraints nullable="false" foreignKeyName="fk_collection_item" references="collection(id)"/>
             </column>
         </createTable>
-        <addUniqueConstraint
-                columnNames="collection_id, item_key"
-                constraintName="const_collection_item"
-                deferrable="true"
-                disabled="true"
-                initiallyDeferred="true"
-                tableName="item"
-                validate="true"/>
         <createTable tableName="reference">
             <column name="id" type="varchar(36)">
                 <constraints primaryKey="true"/>


### PR DESCRIPTION
The latest beta release 2.24.0-beta.5 include `changelog-2.24.0-collection-data.xml` that was later modified adding some constraints [here](https://github.com/AzBuilder/terrakube/pull/1529/files), in order to not break liquibase execution I move the database constraints to a new file