### PR TITLE
fix: always exec plan after error

### DIFF
--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -121,7 +121,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                             null).get();
                 }
 
-            if (exitCode != 1) {
+            if(exitCode != 1) {
                 executionPlan = true;
             }
 
@@ -142,6 +142,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             result.setExitCode(1);
         }
         return result;
+        
     }
 
     @Override

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -121,13 +121,13 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                             null).get();
                 }
 
-            if(exitCode != 1) {
+            if (exitCode != 1) {
                 executionPlan = true;
             }
 
-            log.warn("Terraform plan Executed Successfully: {} Exit Code: {}", executionPlan, exitCode);
+            log.warn("Terraform plan Executed: {} Exit Code: {}", executionPlan, exitCode);
 
-            scriptAfterSuccessPlan = executePostOperationScripts(terraformJob, terraformWorkingDir, planOutput, executionPlan);
+            scriptAfterSuccessPlan = executePostOperationScripts(terraformJob, terraformWorkingDir, planOutput, true);
 
             Thread.sleep(10000);
 
@@ -142,7 +142,6 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             result.setExitCode(1);
         }
         return result;
-
     }
 
     @Override

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -142,7 +142,6 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             result.setExitCode(1);
         }
         return result;
-        
     }
 
     @Override


### PR DESCRIPTION
Hey @alfespa17 !

So I'm pushing as a first idea. The logic is that, for read-only operations like plan command we might want to run what's next to for instance display a slack message in case of error as mentionned in #1548. I don't think it is breaking any current logic and allows to achieve more complex patterns with templates ?

Idk what do you think ?
Lemme know if I missed something !