### PR TITLE
feat: Allow to continue template execution using "ignoreError" property

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
@@ -27,6 +27,7 @@ public class ExecutorContext {
     private boolean refresh;
     private boolean refreshOnly;
     private boolean showHeader;
+    private boolean ignore_error;
     private String accessToken;
     private String moduleSshKey;
     private String commitId;

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
@@ -27,7 +27,7 @@ public class ExecutorContext {
     private boolean refresh;
     private boolean refreshOnly;
     private boolean showHeader;
-    private boolean ignore_error;
+    private boolean ignoreError;
     private String accessToken;
     private String moduleSshKey;
     private String commitId;

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -135,7 +135,7 @@ public class ExecutorService {
 
         executorContext.setCommandList(flow.getCommands());
         executorContext.setType(flow.getType());
-        executorContext.setIgnore_error(flow.isIgnore_error());
+        executorContext.setIgnoreError(flow.isIgnoreError());
         executorContext.setTerraformVersion(job.getWorkspace().getTerraformVersion());
         if (job.getOverrideSource() == null) {
             executorContext.setSource(job.getWorkspace().getSource());

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -135,6 +135,7 @@ public class ExecutorService {
 
         executorContext.setCommandList(flow.getCommands());
         executorContext.setType(flow.getType());
+        executorContext.setIgnore_error(flow.isIgnore_error());
         executorContext.setTerraformVersion(job.getWorkspace().getTerraformVersion());
         if (job.getOverrideSource() == null) {
             executorContext.setSource(job.getWorkspace().getSource());

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/Flow.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/Flow.java
@@ -14,7 +14,7 @@ public class Flow {
     private String type;
     private String team;
     private String name;
-    private boolean ignore_error = false;
+    private boolean ignoreError = false;
     private String error;
     private int step;
     List<Command> commands;

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/Flow.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/Flow.java
@@ -14,7 +14,7 @@ public class Flow {
     private String type;
     private String team;
     private String name;
-
+    private boolean ignore_error;
     private String error;
     private int step;
     List<Command> commands;

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/Flow.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/model/Flow.java
@@ -14,7 +14,7 @@ public class Flow {
     private String type;
     private String team;
     private String name;
-    private boolean ignore_error;
+    private boolean ignore_error = false;
     private String error;
     private int step;
     List<Command> commands;

--- a/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
+++ b/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
@@ -30,6 +30,7 @@ public class TerraformJob {
     private boolean showHeader;
     private boolean refresh;
     private boolean refreshOnly;
+    private boolean ignore_error;
     private String moduleSshKey;
     private String commitId;
     private boolean tofu;

--- a/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
+++ b/executor/src/main/java/org/terrakube/executor/service/mode/TerraformJob.java
@@ -30,7 +30,7 @@ public class TerraformJob {
     private boolean showHeader;
     private boolean refresh;
     private boolean refreshOnly;
-    private boolean ignore_error;
+    private boolean ignoreError;
     private String moduleSshKey;
     private String commitId;
     private boolean tofu;

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -121,7 +121,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                             null).get();
                 }
 
-            if (exitCode != 1) {
+            if(exitCode != 1) {
                 executionPlan = true;
             }
 
@@ -142,6 +142,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             result.setExitCode(1);
         }
         return result;
+        
     }
 
     @Override

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -121,13 +121,13 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                             null).get();
                 }
 
-            if(exitCode != 1) {
+            if (exitCode != 1) {
                 executionPlan = true;
             }
 
-            log.warn("Terraform plan Executed Successfully: {} Exit Code: {}", executionPlan, exitCode);
+            log.warn("Terraform plan Executed: {} Exit Code: {}", executionPlan, exitCode);
 
-            scriptAfterSuccessPlan = executePostOperationScripts(terraformJob, terraformWorkingDir, planOutput, executionPlan);
+            scriptAfterSuccessPlan = executePostOperationScripts(terraformJob, terraformWorkingDir, planOutput, true);
 
             Thread.sleep(10000);
 
@@ -142,7 +142,6 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             result.setExitCode(1);
         }
         return result;
-
     }
 
     @Override

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -121,13 +121,13 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                             null).get();
                 }
 
-            if(exitCode != 1) {
+            if(exitCode != 1 || terraformJob.isIgnore_error()) {
                 executionPlan = true;
             }
 
             log.warn("Terraform plan Executed: {} Exit Code: {}", executionPlan, exitCode);
 
-            scriptAfterSuccessPlan = executePostOperationScripts(terraformJob, terraformWorkingDir, planOutput, true);
+            scriptAfterSuccessPlan = executePostOperationScripts(terraformJob, terraformWorkingDir, planOutput, executionPlan);
 
             Thread.sleep(10000);
 

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -121,7 +121,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                             null).get();
                 }
 
-            if(exitCode != 1 || terraformJob.isIgnore_error()) {
+            if(exitCode != 1 || terraformJob.isIgnoreError()) {
                 executionPlan = true;
             }
 

--- a/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/org/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -142,7 +142,6 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             result.setExitCode(1);
         }
         return result;
-        
     }
 
     @Override


### PR DESCRIPTION
Hi @alfespa17 !

I'd like to propose this small change and add a new field to the Terrakube template. I change the Flow template in the API and added it to the Executor job. 

However, I'd like your inputs about it, I think I'm missing the part where the data is transmitted from the API that parse the yaml to the Executor that use the content of the Yaml to run the Job. I tried to find it but I couldn't find the connection between the 2 components unfortunately. My guess is that the API set the job in the queue and the executor will pick'em for execute. I'm really not sure that the field `ingore_error` will be available in the Executor context. Could you explain me please ? :) 

Regards