### PR TITLE
feat: Adding new manage job permission

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/token/team/TeamTokenController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/team/TeamTokenController.java
@@ -70,6 +70,8 @@ public class TeamTokenController {
             permissions.setManageProvider(permissions.manageProvider || group.isManageProvider());
             permissions.setManageTemplate(permissions.manageTemplate || group.isManageTemplate());
             permissions.setManageVcs(permissions.manageVcs || group.isManageVcs());
+            permissions.setManageCollection(permissions.manageCollection || group.isManageCollection());
+            permissions.setManageJob(permissions.manageJob || group.isManageJob());
         });
         return new ResponseEntity<>(permissions, HttpStatus.ACCEPTED);
     }
@@ -120,5 +122,7 @@ public class TeamTokenController {
         private boolean manageProvider;
         private boolean manageVcs;
         private boolean manageTemplate;
+        private boolean manageCollection;
+        private boolean manageJob;
     }
 }

--- a/api/src/main/java/org/terrakube/api/rs/checks/job/TeamManageJob.java
+++ b/api/src/main/java/org/terrakube/api/rs/checks/job/TeamManageJob.java
@@ -32,11 +32,11 @@ public class TeamManageJob extends OperationCheck<Job> {
         boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
         for (Team team : teamList) {
             if (isServiceAccount){
-                if (groupService.isServiceMember(requestScope.getUser(), team.getName()) && team.isManageWorkspace()){
+                if (groupService.isServiceMember(requestScope.getUser(), team.getName()) && team.isManageJob()){
                     return true;
                 }
             } else {
-                if (groupService.isMember(requestScope.getUser(), team.getName()) && team.isManageWorkspace())
+                if (groupService.isMember(requestScope.getUser(), team.getName()) && team.isManageJob())
                     return true;
             }
         }

--- a/api/src/main/java/org/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/org/terrakube/api/rs/job/Job.java
@@ -30,7 +30,7 @@ import lombok.Setter;
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.CREATE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = JobManageHook.class)
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.UPDATE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = JobManageHook.class)
 @ReadPermission(expression = "team view job")
-@CreatePermission(expression = "team view job")
+@CreatePermission(expression = "team manage job")
 @UpdatePermission(expression = "team manage job OR user is a super service")
 @Include(rootLevel = false)
 @Getter

--- a/api/src/main/java/org/terrakube/api/rs/team/Team.java
+++ b/api/src/main/java/org/terrakube/api/rs/team/Team.java
@@ -46,6 +46,9 @@ public class Team {
     @Column(name = "manage_collection")
     private boolean manageCollection;
 
+    @Column(name = "manage_job")
+    private boolean manageJob;
+
     @Column(name = "manage_workspace")
     private boolean manageWorkspace;
 

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -68,4 +68,5 @@
     <include file="/db/changelog/local/changelog-2.24.0-lock-description.xml"/>
     <include file="/db/changelog/local/changelog-2.24.0-collection-data.xml"/>
     <include file="/db/changelog/local/changelog-2.24.0-collection-data-constraints.xml"/>
+    <include file="/db/changelog/local/changelog-2.24.0-manage-job.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.24.0-manage-job.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.24.0-manage-job.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-24-0-3" author="alfespa17@gmail.com">
+        <addColumn tableName="team">
+            <column name="manage_job" type="boolean" defaultValue="false"/>
+        </addColumn>
+        <update tableName="team">
+            <column name="manage_job" valueBoolean="false"/>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/test/java/org/terrakube/api/JobTests.java
+++ b/api/src/test/java/org/terrakube/api/JobTests.java
@@ -2,10 +2,14 @@ package org.terrakube.api;
 
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.graphql.tester.AutoConfigureGraphQlTester;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
+import org.terrakube.api.repository.TeamRepository;
 import org.terrakube.api.rs.job.Job;
+import org.terrakube.api.rs.team.Team;
 import org.terrakube.api.rs.workspace.Workspace;
 
 import java.util.List;
@@ -17,6 +21,9 @@ import static org.mockserver.model.HttpResponse.response;
 
 class JobTests extends ServerApplicationTests {
 
+    @Autowired
+    TeamRepository teamRepository;
+
     @Test
     void createJobAsOrgMember() {
         mockServer.reset();
@@ -27,6 +34,10 @@ class JobTests extends ServerApplicationTests {
         ).respond(
                 response().withStatusCode(HttpStatus.ACCEPTED.value()).withBody("")
         );
+
+        Team team = teamRepository.findById(UUID.fromString("58529721-425e-44d7-8b0d-1d515043c2f7")).get();
+        team.setManageJob(true);
+        teamRepository.save(team);
 
         given()
                 .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
@@ -54,6 +65,10 @@ class JobTests extends ServerApplicationTests {
                 .log()
                 .all()
                 .statusCode(HttpStatus.CREATED.value());
+
+        team = teamRepository.findById(UUID.fromString("58529721-425e-44d7-8b0d-1d515043c2f7")).get();
+        team.setManageJob(false);
+        teamRepository.save(team);
     }
 
     @Test
@@ -66,6 +81,10 @@ class JobTests extends ServerApplicationTests {
         ).respond(
                 response().withStatusCode(HttpStatus.ACCEPTED.value()).withBody("")
         );
+
+        Team team = teamRepository.findById(UUID.fromString("58529721-425e-44d7-8b0d-1d515043c2f7")).get();
+        team.setManageJob(true);
+        teamRepository.save(team);
 
         given()
                 .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
@@ -130,6 +149,10 @@ class JobTests extends ServerApplicationTests {
                 .log()
                 .all()
                 .statusCode(HttpStatus.NO_CONTENT.value());
+
+        team = teamRepository.findById(UUID.fromString("58529721-425e-44d7-8b0d-1d515043c2f7")).get();
+        team.setManageJob(false);
+        teamRepository.save(team);
     }
 
 }

--- a/api/src/test/java/org/terrakube/api/TfcApiTests.java
+++ b/api/src/test/java/org/terrakube/api/TfcApiTests.java
@@ -2,11 +2,20 @@ package org.terrakube.api;
 
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.graphql.tester.AutoConfigureGraphQlTester;
 import org.springframework.http.HttpStatus;
+import org.terrakube.api.repository.TeamRepository;
+import org.terrakube.api.rs.team.Team;
+
+import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 
 class TfcApiTests extends ServerApplicationTests {
+
+    @Autowired
+    TeamRepository teamRepository;
 
     @Test
     void ping() {
@@ -126,6 +135,10 @@ class TfcApiTests extends ServerApplicationTests {
 
     @Test
     void getWorkspace() {
+        Team team = teamRepository.findById(UUID.fromString("58529721-425e-44d7-8b0d-1d515043c2f7")).get();
+        team.setManageJob(true);
+        teamRepository.save(team);
+
         given()
                 .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
                 .when()
@@ -157,6 +170,10 @@ class TfcApiTests extends ServerApplicationTests {
                 .log()
                 .all()
                 .statusCode(HttpStatus.OK.value());
+
+        team = teamRepository.findById(UUID.fromString("58529721-425e-44d7-8b0d-1d515043c2f7")).get();
+        team.setManageJob(false);
+        teamRepository.save(team);
     }
 
     @Test
@@ -187,6 +204,10 @@ class TfcApiTests extends ServerApplicationTests {
 
     @Test
     void lockWorkspace() {
+        Team team = teamRepository.findById(UUID.fromString("58529721-425e-44d7-8b0d-1d515043c2f7")).get();
+        team.setManageJob(true);
+        teamRepository.save(team);
+
         given()
                 .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
                 .when()
@@ -228,10 +249,18 @@ class TfcApiTests extends ServerApplicationTests {
                 .log()
                 .all()
                 .statusCode(HttpStatus.CONFLICT.value());
+
+        team = teamRepository.findById(UUID.fromString("58529721-425e-44d7-8b0d-1d515043c2f7")).get();
+        team.setManageJob(false);
+        teamRepository.save(team);
     }
 
     @Test
     void unlockWorkspace() {
+        Team team = teamRepository.findById(UUID.fromString("58529721-425e-44d7-8b0d-1d515043c2f7")).get();
+        team.setManageJob(true);
+        teamRepository.save(team);
+
         given()
                 .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
                 .when()
@@ -263,5 +292,9 @@ class TfcApiTests extends ServerApplicationTests {
                 .log()
                 .all()
                 .statusCode(HttpStatus.OK.value());
+
+        team = teamRepository.findById(UUID.fromString("58529721-425e-44d7-8b0d-1d515043c2f7")).get();
+        team.setManageJob(false);
+        teamRepository.save(team);
     }
 }

--- a/ui/src/domain/Jobs/Create.jsx
+++ b/ui/src/domain/Jobs/Create.jsx
@@ -1,5 +1,5 @@
 import { React, useState, useEffect } from "react";
-import { Form, Button, Select, Modal, Space } from "antd";
+import { Form, Button, Select, Modal, Space, message } from "antd";
 import {
   ORGANIZATION_ARCHIVE,
   WORKSPACE_ARCHIVE,
@@ -75,7 +75,11 @@ export const CreateJob = ({ changeJob }) => {
         console.log(response);
         setVisible(false);
         changeJob(response.data.data.id);
-      });
+      }).catch((error) => {
+        console.log(error);
+        setVisible(false);
+        message.error(error);
+    });
   };
 
   return (

--- a/ui/src/domain/Jobs/Create.jsx
+++ b/ui/src/domain/Jobs/Create.jsx
@@ -31,18 +31,18 @@ export const CreateJob = ({ changeJob }) => {
 
   const loadTemplates = () => {
     axiosInstance
-      .get(`organization/${organizationId}/template`)
-      .then((response) => {
-        var templatesList = response.data.data.filter(function (obj) {
-          //exclude CLI based templates
-          return (
-            obj.attributes.name !== "Terraform-Plan/Apply-Cli" &&
-            obj.attributes.name !== "Terraform-Plan/Destroy-Cli"
-          );
+        .get(`organization/${organizationId}/template`)
+        .then((response) => {
+          var templatesList = response.data.data.filter(function (obj) {
+            //exclude CLI based templates
+            return (
+                obj.attributes.name !== "Terraform-Plan/Apply-Cli" &&
+                obj.attributes.name !== "Terraform-Plan/Destroy-Cli"
+            );
+          });
+          setTemplates(templatesList);
+          setLoading(false);
         });
-        setTemplates(templatesList);
-        setLoading(false);
-      });
   };
 
   const onCreate = (values) => {
@@ -66,95 +66,95 @@ export const CreateJob = ({ changeJob }) => {
     console.log(body);
 
     axiosInstance
-      .post(`organization/${organizationId}/job`, body, {
-        headers: {
-          "Content-Type": "application/vnd.api+json",
-        },
-      })
-      .then((response) => {
-        console.log(response);
-        setVisible(false);
-        changeJob(response.data.data.id);
-      }).catch((error) => {
-        console.log(error);
-        setVisible(false);
-        message.error(error);
+        .post(`organization/${organizationId}/job`, body, {
+          headers: {
+            "Content-Type": "application/vnd.api+json",
+          },
+        })
+        .then((response) => {
+          console.log(response);
+          setVisible(false);
+          changeJob(response.data.data.id);
+        }).catch((error) => {
+      message.error('Not able to create job: ' + error.response.data.errors[0].detail)
+      setVisible(false);
+      console.log(error)
     });
   };
 
   return (
-    <div>
-      <Button
-        type="primary"
-        htmlType="button"
-        onClick={() => {
-          setVisible(true);
-        }}
-        icon={<PlusOutlined />}
-      >
-        New job
-      </Button>
+      <div>
+        <Button
+            type="primary"
+            htmlType="button"
+            onClick={() => {
+              setVisible(true);
+            }}
+            icon={<PlusOutlined />}
+        >
+          New job
+        </Button>
 
-      <Modal
-        open={visible}
-        title="Start a new job"
-        okText="Start"
-        cancelText="Cancel"
-        onCancel={onCancel}
-        onOk={() => {
-          form
-            .validateFields()
-            .then((values) => {
-              form.resetFields();
-              onCreate(values);
-            })
-            .catch((info) => {
-              console.log("Validate Failed:", info);
-            });
-        }}
-      >
-        <Space direction="vertical">
-          <div className="popup-text">
-            <InfoCircleTwoTone style={{ fontSize: "16px" }} /> You will be
-            redirected to the run details page to see this job executed.
-          </div>
-          <Form
-            form={form}
-            layout="vertical"
-            name="create-org"
-            validateMessages={validateMessages}
-          >
-            <Form.Item
-              name="templateId"
-              label="Choose job type"
-              rules={[{ required: true }]}
+        <Modal
+            open={visible}
+            title="Start a new job"
+            okText="Start"
+            cancelText="Cancel"
+            onCancel={onCancel}
+            onOk={() => {
+              form
+                  .validateFields()
+                  .then((values) => {
+                    form.resetFields();
+                    onCreate(values);
+                  })
+                  .catch((info) => {
+                    console.log("Validate Failed:", info);
+                  });
+            }}
+        >
+          <Space direction="vertical">
+            <div className="popup-text">
+              <InfoCircleTwoTone style={{ fontSize: "16px" }} /> You will be
+              redirected to the run details page to see this job executed.
+            </div>
+            <Form
+                form={form}
+                layout="vertical"
+                name="create-org"
+                validateMessages={validateMessages}
             >
-              {loading || !templates ? (
-                <p>Data loading...</p>
-              ) : (
-                <Select>
-                  {templates.map((item) => (
-                    <Select.Option key={item.id} value={item.id}>
+              <Form.Item
+                  name="templateId"
+                  label="Choose job type"
+                  rules={[{ required: true }]}
+              >
+                {loading || !templates ? (
+                    <p>Data loading...</p>
+                ) : (
+                    <Select>
+                      {templates.map((item) => (
+                          <Select.Option key={item.id} value={item.id}>
                       <span
-                        style={
-                          item.attributes.name.includes("Destroy")
-                            ? { color: "red" }
-                            : {}
-                        }
+                          style={
+                            item.attributes.name.includes("Destroy")
+                                ? { color: "red" }
+                                : {}
+                          }
                       >
                         {item.attributes.name.includes("Destroy") && (
-                          <DeleteOutlined style={{ marginRight: 8 }} />
+                            <DeleteOutlined style={{ marginRight: 8 }} />
                         )}
                         {item.attributes.name}
                       </span>
-                    </Select.Option>
-                  ))}
-                </Select>
-              )}
-            </Form.Item>
-          </Form>
-        </Space>
-      </Modal>
-    </div>
+                          </Select.Option>
+                      ))}
+                    </Select>
+                )}
+              </Form.Item>
+            </Form>
+          </Space>
+        </Modal>
+      </div>
   );
 };

--- a/ui/src/domain/Settings/EditTeam.jsx
+++ b/ui/src/domain/Settings/EditTeam.jsx
@@ -65,6 +65,7 @@ export const EditTeam = ({ mode, setMode, teamId, loadTeams }) => {
         manageVcs: response.data.data.attributes.manageVcs,
         manageTemplate: response.data.data.attributes.manageTemplate,
         manageCollection: response.data.data.attributes.manageCollection,
+        manageJob: response.data.data.attributes.manageJob,
       });
       setLoading(false);
       loadTokens(response.data.data.attributes.name);
@@ -85,6 +86,7 @@ export const EditTeam = ({ mode, setMode, teamId, loadTeams }) => {
           manageVcs: values.manageVcs,
           manageTemplate: values.manageTemplate,
           manageCollection: values.manageCollection,
+          manageJob: values.manageJob,
         },
       },
     };
@@ -123,6 +125,7 @@ export const EditTeam = ({ mode, setMode, teamId, loadTeams }) => {
           manageVcs: values.manageVcs,
           manageTemplate: values.manageTemplate,
           manageCollection: values.manageCollection,
+          manageJob: values.manageJob
         },
       },
     };
@@ -304,6 +307,18 @@ export const EditTeam = ({ mode, setMode, teamId, loadTeams }) => {
                 tooltip={{
                   title:
                       "Allow members to create and manage all collections within the organization",
+                  icon: <InfoCircleOutlined />,
+                }}
+            >
+              <Switch />
+            </Form.Item>
+            <Form.Item
+                name="manageJob"
+                valuePropName="checked"
+                label="Manage Job"
+                tooltip={{
+                  title:
+                      "Allow members to create jobs inside the organization",
                   icon: <InfoCircleOutlined />,
                 }}
             >

--- a/ui/src/domain/Settings/Teams.jsx
+++ b/ui/src/domain/Settings/Teams.jsx
@@ -139,6 +139,9 @@ export const TeamSettings = ({key}) => {
                           {item.attributes.manageCollection ? (
                               <span>Collection</span>
                           ) : null}
+                          {item.attributes.manageJob ? (
+                              <span>Job</span>
+                          ) : null}
                           {item.attributes.manageProvider ? (
                             <span>Providers</span>
                           ) : null}


### PR DESCRIPTION
Adding specific permission to trigger jobs from the UI and CLI

![image](https://github.com/user-attachments/assets/eef3e1f9-e860-40d5-98ed-69ae21bd154b)

![image](https://github.com/user-attachments/assets/1bca9875-8e93-4aa9-84e6-3adb6e396cf8)

If the user doesnt have the manage job permission the UI will show a little error message now

![image](https://github.com/user-attachments/assets/53c8ae09-b735-47a0-8dec-9b7c1b8adbe6)

When running the terraform/tofu cli it will show the message like this:

```shell
user@pop-os:~/git/simple-terraform$ terraform plan
╷
│ Error: Insufficient rights to generate a plan
│ 
│ The provided credentials have insufficient rights to generate a plan. In
│ order to generate plans, at least plan permissions on the workspace are
│ required.
╵

```