### PR TITLE
feat: support value in the tolerations config

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
@@ -77,7 +77,14 @@ public class EphemeralExecutorService {
                 String[] info = tolerationData.split(":");
                 Toleration toleration = new Toleration();
 
-                toleration.setKey(info[0]);
+                if (info[0].contains("=")) {
+                    String[] keyValue = info[0].split("=");
+                    toleration.setKey(keyValue[0]);
+                    toleration.setValue(keyValue[1]);
+                } else {
+                    toleration.setKey(info[0]);
+                }
+                
                 toleration.setOperator(info.length > 1 ? info[1] : "Exists");
                 toleration.setEffect(info.length > 2 ? info[2] : null);
 


### PR DESCRIPTION
This PR support value in the toleration config.

In GCP we can't create tolerations using only key, and in some configurations, we need to support value in the toleration.

Now, terrakube supports only: **key:operator:effect**, the PR insert the possibilily to set: **key=value:operator:effect**.

Thank you