### PR TITLE
fix: Replace SiAzuredevops with VscAzureDevops in react-icons 5.4.0

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@ant-design/icons": "^5.5.1",
     "@babel/core": "^7.26.0",
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@babel/preset-env": "^7.26.0",
     "@babel/standalone": "^7.26.2",
     "@monaco-editor/react": "^4.6.0",

--- a/ui/src/ActionLoader.jsx
+++ b/ui/src/ActionLoader.jsx
@@ -129,7 +129,7 @@ const importAntdIcons = async (icons) => {
 
 // List of react-icons to consider for dynamic importing
 const reactIcons = [
-  "SiMicrosoftazure",
+  "VscAzure",
   "SiAmazonaws",
   "SiGithub",
   "SiGrafana",

--- a/ui/src/domain/Modules/Create.jsx
+++ b/ui/src/domain/Modules/Create.jsx
@@ -16,7 +16,8 @@ import {
 } from "../../config/actionTypes";
 import axiosInstance from "../../config/axiosConfig";
 import { GithubOutlined, GitlabOutlined } from "@ant-design/icons";
-import { SiBitbucket, SiAzuredevops } from "react-icons/si";
+import { SiBitbucket  } from "react-icons/si";
+import { VscAzureDevops } from "react-icons/vsc";
 import { IconContext } from "react-icons";
 import { SiGit } from "react-icons/si";
 import { useNavigate, Link } from "react-router-dom";
@@ -102,7 +103,7 @@ export const CreateModule = () => {
       case "AZURE_DEVOPS":
         return (
           <IconContext.Provider value={{ size: "20px" }}>
-            <SiAzuredevops />
+            <VscAzureDevops />
             &nbsp;&nbsp;
           </IconContext.Provider>
         );
@@ -358,7 +359,7 @@ export const CreateModule = () => {
                       &nbsp;&nbsp;Bitbucket
                     </Button>
                     <Button
-                      icon={<SiAzuredevops />}
+                      icon={<VscAzureDevops />}
                       onClick={() => {
                         handleVCSClick("AZURE_DEVOPS");
                       }}

--- a/ui/src/domain/Modules/Details.jsx
+++ b/ui/src/domain/Modules/Details.jsx
@@ -29,9 +29,11 @@ import {
 import { GitlabOutlined, GithubOutlined } from "@ant-design/icons";
 import {
   SiBitbucket,
-  SiAzuredevops,
-  SiMicrosoftazure,
 } from "react-icons/si";
+import {
+  VscAzure,
+  VscAzureDevops,
+} from "react-icons/vsc";
 import { FaAws } from "react-icons/fa";
 import { BiBookBookmark } from "react-icons/bi";
 import { RiFolderHistoryLine } from "react-icons/ri";
@@ -74,7 +76,7 @@ export const ModuleDetails = ({ setOrganizationName, organizationName }) => {
       case "azurerm":
         return (
           <IconContext.Provider value={{ color: "#008AD7", size: "1.5em" }}>
-            <SiMicrosoftazure />
+            <VscAzure />
           </IconContext.Provider>
         );
       case "aws":
@@ -272,7 +274,7 @@ export const ModuleDetails = ({ setOrganizationName, organizationName }) => {
       case "AZURE_DEVOPS":
         return (
           <IconContext.Provider value={{ size: "18px" }}>
-            <SiAzuredevops />
+            <VscAzureDevops />
             &nbsp;
           </IconContext.Provider>
         );

--- a/ui/src/domain/Modules/List.jsx
+++ b/ui/src/domain/Modules/List.jsx
@@ -17,7 +17,7 @@ import {
   ClockCircleOutlined,
   DownloadOutlined,
 } from "@ant-design/icons";
-import { SiMicrosoftazure } from "react-icons/si";
+import { VscAzure } from "react-icons/vsc";
 import { FaAws } from "react-icons/fa";
 import { RiFolderHistoryLine } from "react-icons/ri";
 import { IconContext } from "react-icons";
@@ -114,7 +114,7 @@ export const ModuleList = ({ setOrganizationName, organizationName }) => {
       case "azurerm":
         return (
           <IconContext.Provider value={{ color: "#008AD7", size: "1.5em" }}>
-            <SiMicrosoftazure />
+            <VscAzure />
           </IconContext.Provider>
         );
       case "aws":

--- a/ui/src/domain/Organizations/Details.jsx
+++ b/ui/src/domain/Organizations/Details.jsx
@@ -28,7 +28,8 @@ import {
   ImportOutlined,
 } from "@ant-design/icons";
 import { BiTerminal } from "react-icons/bi";
-import { SiTerraform, SiBitbucket, SiAzuredevops } from "react-icons/si";
+import { SiTerraform, SiBitbucket } from "react-icons/si";
+import { VscAzureDevops } from "react-icons/vsc";
 import { IconContext } from "react-icons";
 import axiosInstance, { axiosGraphQL } from "../../config/axiosConfig";
 import { useParams, useNavigate } from "react-router-dom";
@@ -100,7 +101,7 @@ export const OrganizationDetails = ({
       return (
         <IconContext.Provider value={{ size: "18px" }}>
           <Tooltip title="Azure Devops">
-            <SiAzuredevops />
+            <VscAzureDevops />
           </Tooltip>
         </IconContext.Provider>
       );

--- a/ui/src/domain/Settings/AddVCS.jsx
+++ b/ui/src/domain/Settings/AddVCS.jsx
@@ -17,7 +17,8 @@ import {
   GitlabOutlined,
   DownOutlined,
 } from "@ant-design/icons";
-import { SiBitbucket, SiAzuredevops } from "react-icons/si";
+import { SiBitbucket } from "react-icons/si";
+import { VscAzureDevops } from "react-icons/vsc";
 import { HiOutlineExternalLink } from "react-icons/hi";
 import axiosInstance from "../../config/axiosConfig";
 import { useParams } from "react-router-dom";
@@ -806,7 +807,7 @@ export const AddVCS = ({ setMode, loadVCS }) => {
             <Dropdown menu={{ items: azDevOpsItems }}>
               <Button size="large">
                 <Space>
-                  <SiAzuredevops /> Azure Devops <DownOutlined />
+                  <VscAzureDevops /> Azure Devops <DownOutlined />
                 </Space>
               </Button>
             </Dropdown>

--- a/ui/src/domain/Settings/VCS.jsx
+++ b/ui/src/domain/Settings/VCS.jsx
@@ -14,7 +14,8 @@ import { GithubOutlined, GitlabOutlined } from "@ant-design/icons";
 import { AddVCS } from "./AddVCS";
 import { useParams } from "react-router-dom";
 import { DeleteOutlined, EditOutlined } from "@ant-design/icons";
-import { SiBitbucket, SiAzuredevops } from "react-icons/si";
+import { SiBitbucket } from "react-icons/si";
+import { VscAzureDevops } from "react-icons/vsc";
 import axiosInstance from "../../config/axiosConfig";
 import { IconContext } from "react-icons";
 import { ORGANIZATION_NAME } from "../../config/actionTypes";
@@ -42,7 +43,7 @@ export const VCSSettings = ({ vcsMode }) => {
       case "AZURE_DEVOPS":
         return (
           <IconContext.Provider value={{ size: "20px" }}>
-            <SiAzuredevops />
+            <VscAzureDevops />
           </IconContext.Provider>
         );
       default:

--- a/ui/src/domain/Workspaces/Create.jsx
+++ b/ui/src/domain/Workspaces/Create.jsx
@@ -23,7 +23,8 @@ import {
 import { React, useEffect, useState, version } from "react";
 import { IconContext } from "react-icons";
 import { BiBookBookmark, BiTerminal, BiUpload } from "react-icons/bi";
-import { SiAzuredevops, SiBitbucket, SiGit } from "react-icons/si";
+import { SiBitbucket, SiGit } from "react-icons/si";
+import { VscAzureDevops } from "react-icons/vsc";
 import { Link, useNavigate } from "react-router-dom";
 import { v7 as uuid } from "uuid";
 import {
@@ -208,7 +209,7 @@ export const CreateWorkspace = () => {
       case "AZURE_DEVOPS":
         return (
           <IconContext.Provider value={{ size: "20px" }}>
-            <SiAzuredevops />
+            <VscAzureDevops />
             &nbsp;
           </IconContext.Provider>
         );
@@ -632,7 +633,7 @@ export const CreateWorkspace = () => {
                     <Dropdown menu={{ items: azDevOpsItems }}>
                       <Button size="large">
                         <Space>
-                          <SiAzuredevops /> Azure Devops <DownOutlined />
+                          <VscAzureDevops /> Azure Devops <DownOutlined />
                         </Space>
                       </Button>
                     </Dropdown>

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -43,7 +43,8 @@ import { IconContext } from "react-icons";
 import { BiTerminal } from "react-icons/bi";
 import { FiGitCommit } from "react-icons/fi";
 import { HiOutlineExternalLink } from "react-icons/hi";
-import { SiAzuredevops, SiBitbucket, SiTerraform } from "react-icons/si";
+import { SiBitbucket, SiTerraform } from "react-icons/si";
+import { VscAzureDevops } from "react-icons/vsc";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { v7 as uuid } from "uuid";
 import ActionLoader from "../../ActionLoader.jsx";
@@ -700,7 +701,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
       case "AZURE_DEVOPS":
         return (
           <IconContext.Provider value={{ size: "18px" }}>
-            <SiAzuredevops />
+            <VscAzureDevops />
             &nbsp;
           </IconContext.Provider>
         );

--- a/ui/src/domain/Workspaces/Import.jsx
+++ b/ui/src/domain/Workspaces/Import.jsx
@@ -26,7 +26,8 @@ import {
   GitlabOutlined,
   DownOutlined,
 } from "@ant-design/icons";
-import { SiBitbucket, SiAzuredevops } from "react-icons/si";
+import { SiBitbucket } from "react-icons/si";
+import { VscAzureDevops } from "react-icons/vsc";
 import { useNavigate, Link } from "react-router-dom";
 import parse from "html-react-parser";
 const { Content } = Layout;
@@ -221,7 +222,7 @@ export const ImportWorkspace = () => {
       case "AZURE_DEVOPS":
         return (
           <IconContext.Provider value={{ size: "20px" }}>
-            <SiAzuredevops />
+            <VscAzureDevops />
             &nbsp;
           </IconContext.Provider>
         );
@@ -573,7 +574,7 @@ export const ImportWorkspace = () => {
                       <Dropdown menu={{ items: azDevOpsItems }}>
                         <Button size="large">
                           <Space>
-                            <SiAzuredevops /> Azure Devops <DownOutlined />
+                            <VscAzureDevops /> Azure Devops <DownOutlined />
                           </Space>
                         </Button>
                       </Dropdown>

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -189,7 +189,7 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.20.0"
     "@babel/helper-split-export-declaration" "^7.18.6"
 
-"@babel/helper-create-class-features-plugin@^7.25.9":
+"@babel/helper-create-class-features-plugin@^7.21.0", "@babel/helper-create-class-features-plugin@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz#7644147706bb90ff613297d49ed5266bde729f83"
   integrity sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==
@@ -509,6 +509,16 @@
   resolved "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz"
   integrity sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==
 
+"@babel/plugin-proposal-private-property-in-object@^7.21.11":
+  version "7.21.11"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz#69d597086b6760c4126525cfa154f34631ff272c"
+  integrity sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-create-class-features-plugin" "^7.21.0"
+    "@babel/helper-plugin-utils" "^7.20.2"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
+
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
   resolved "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz"
@@ -620,6 +630,13 @@
   integrity sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-private-property-in-object@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz#0dc6671ec0ea22b6e94a1114f857970cd39de1ad"
+  integrity sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-syntax-top-level-await@^7.8.3":
   version "7.14.5"
@@ -3567,20 +3584,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001317, caniuse-lite@^1.0.30001400:
-  version "1.0.30001442"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz"
-  integrity sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==
-
-caniuse-lite@^1.0.30001646:
-  version "1.0.30001653"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001653.tgz#b8af452f8f33b1c77f122780a4aecebea0caca56"
-  integrity sha512-XGWQVB8wFQ2+9NZwZ10GxTYC5hk0Fa+q8cSkr0tgvMhYhMHP/QC+WTgrePMDBWiWc/pV+1ik82Al20XOK25Gcw==
-
-caniuse-lite@^1.0.30001663:
-  version "1.0.30001667"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001667.tgz#99fc5ea0d9c6e96897a104a8352604378377f949"
-  integrity sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001317, caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001663:
+  version "1.0.30001689"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001689.tgz"
+  integrity sha512-CmeR2VBycfa+5/jOfnp/NpWPGd06nf1XYiefUvhXFfZE4GkRc9jv+eGPS4nT558WS/8lYCzV8SlANCIPvbWP1g==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
Build image was failing with the following message when using react-icons 5.4.0

`Attempted import error: 'SiAzuredevops' is not exported from 'react-icons/si' (imported as 'SiAzuredevops').`