### PR TITLE
feat: Showing variables description in workspace details

### DIFF
--- a/ui/src/domain/Workspaces/Variables.jsx
+++ b/ui/src/domain/Workspaces/Variables.jsx
@@ -43,8 +43,9 @@ const VARIABLES_COLUMS = (organizationId, workspaceId, onEdit, manageWorkspace) 
       return record.sensitive ? (
         <i>Sensitive - write only</i>
       ) : (
-          <Tooltip title={record.description} placement="topLeft" overlayStyle={{ width: 400, wordBreak: "break-word" }} overlayClassName="tooltip" trigger={["hover"]}>
-        <div>{record.value}</div>
+          <Tooltip title={record.description} placement="topLeft" overlayStyle={{width: 400, wordBreak: "break-word"}}
+                   overlayClassName="tooltip" trigger={["hover"]}>
+              <div>{record.value}</div>
           </Tooltip>
       );
     },
@@ -113,7 +114,10 @@ const COLLECTION_VARIABLES_COLUMNS = () => [
       return record.sensitive ? (
           <i>Sensitive - write only</i>
       ) : (
-          <div>{record.value}</div>
+          <Tooltip title={record.description} placement="topLeft" overlayStyle={{width: 400, wordBreak: "break-word"}}
+                   overlayClassName="tooltip" trigger={["hover"]}>
+              <div>{record.value}</div>
+          </Tooltip>
       );
     },
   },
@@ -170,7 +174,11 @@ const GLOBAL_VARIABLES_COLUMNS = () => [
             return record.sensitive ? (
                 <i>Sensitive - write only</i>
             ) : (
-                <div>{record.value}</div>
+                <Tooltip title={record.description} placement="topLeft"
+                         overlayStyle={{width: 400, wordBreak: "break-word"}} overlayClassName="tooltip"
+                         trigger={["hover"]}>
+                    <div>{record.value}</div>
+                </Tooltip>
             );
         },
     }

--- a/ui/src/domain/Workspaces/Variables.jsx
+++ b/ui/src/domain/Workspaces/Variables.jsx
@@ -1,14 +1,14 @@
 import { React, useState } from "react";
 import {
-  Form,
-  Input,
-  Button,
-  Switch,
-  Table,
-  Modal,
-  Space,
-  Tag,
-  Popconfirm,
+    Form,
+    Input,
+    Button,
+    Switch,
+    Table,
+    Modal,
+    Space,
+    Tag,
+    Popconfirm, Tooltip,
 } from "antd";
 import {
   ORGANIZATION_ARCHIVE,
@@ -43,7 +43,9 @@ const VARIABLES_COLUMS = (organizationId, workspaceId, onEdit, manageWorkspace) 
       return record.sensitive ? (
         <i>Sensitive - write only</i>
       ) : (
+          <Tooltip title={record.description} placement="topLeft" overlayStyle={{ width: 400, wordBreak: "break-word" }} overlayClassName="tooltip" trigger={["hover"]}>
         <div>{record.value}</div>
+          </Tooltip>
       );
     },
   },


### PR DESCRIPTION
This will show the variables description using a tooltip like the following inside the workspace details.

![image](https://github.com/user-attachments/assets/58323deb-032d-4203-891c-0b018d841121)

![image](https://github.com/user-attachments/assets/d31a784d-6c0d-4645-a745-d139b0f8e3c7)

![image](https://github.com/user-attachments/assets/8e66e414-a4d7-4b1a-a70a-e48c335a097f)

![image](https://github.com/user-attachments/assets/3c70fd9c-5d78-49a5-9302-a04d4e00c065)

Fix #1619 