### PR TITLE
feat: Validate workspace relationship when deleting a vcs provider

### DIFF
--- a/api/src/main/java/org/terrakube/api/rs/vcs/Vcs.java
+++ b/api/src/main/java/org/terrakube/api/rs/vcs/Vcs.java
@@ -32,6 +32,7 @@ import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 import lombok.Getter;
 import lombok.Setter;
+import org.terrakube.api.rs.workspace.Workspace;
 
 @ReadPermission(expression = "team view vcs")
 @CreatePermission(expression = "team manage vcs")
@@ -106,6 +107,9 @@ public class Vcs extends GenericAuditFields {
 
     @ManyToOne
     private Organization organization;
+
+    @OneToMany(mappedBy = "vcs")
+    private List<Workspace> workspace;
 
     @OneToMany(mappedBy = "vcs", orphanRemoval = true, cascade = {CascadeType.REMOVE}) 
     private List<GitHubAppToken> gitHubAppToken;

--- a/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/Workspace.java
@@ -125,7 +125,7 @@ public class Workspace extends GenericAuditFields {
     @OneToMany(mappedBy = "workspace")
     private List<WorkspaceTag> workspaceTag;
 
-    @OneToOne
+    @ManyToOne
     private Vcs vcs;
 
     @OneToOne

--- a/ui/src/domain/Settings/VCS.jsx
+++ b/ui/src/domain/Settings/VCS.jsx
@@ -8,7 +8,8 @@ import {
   Row,
   Col,
   Popconfirm,
-  Typography,
+  Typography, 
+  message,
 } from "antd";
 import { GithubOutlined, GitlabOutlined } from "@ant-design/icons";
 import { AddVCS } from "./AddVCS";
@@ -92,13 +93,19 @@ export const VCSSettings = ({ vcsMode }) => {
   const onDelete = (id) => {
     console.log("deleted " + id);
     axiosInstance.get(`organization/${orgid}/vcs/${id}?include=workspace`).then((response) => {
-      console.log(response);
-
+      console.log(response.data);
+      if(response.data.included.length > 0) {
+        console.log("VCS used by:")
+        console.log(response.data.included);
+        message.error("This VCS is currently in use by one or more workspaces. Please remove the VCS from all workspaces before deleting it.");
+      } else {
+        axiosInstance.delete(`organization/${orgid}/vcs/${id}`).then((response) => {
+          console.log(response);
+          loadVCS();
+        });
+      }
     });
-    // axiosInstance.delete(`organization/${orgid}/vcs/${id}`).then((response) => {
-    //   console.log(response);
-    //   loadVCS();
-    // });
+
   };
 
   const getCallBackUrl = (id) => {

--- a/ui/src/domain/Settings/VCS.jsx
+++ b/ui/src/domain/Settings/VCS.jsx
@@ -91,10 +91,14 @@ export const VCSSettings = ({ vcsMode }) => {
 
   const onDelete = (id) => {
     console.log("deleted " + id);
-    axiosInstance.delete(`organization/${orgid}/vcs/${id}`).then((response) => {
+    axiosInstance.get(`organization/${orgid}/vcs/${id}?include=workspace`).then((response) => {
       console.log(response);
-      loadVCS();
+
     });
+    // axiosInstance.delete(`organization/${orgid}/vcs/${id}`).then((response) => {
+    //   console.log(response);
+    //   loadVCS();
+    // });
   };
 
   const getCallBackUrl = (id) => {

--- a/ui/src/domain/Settings/VCS.jsx
+++ b/ui/src/domain/Settings/VCS.jsx
@@ -94,7 +94,7 @@ export const VCSSettings = ({ vcsMode }) => {
     console.log("deleted " + id);
     axiosInstance.get(`organization/${orgid}/vcs/${id}?include=workspace`).then((response) => {
       console.log(response.data);
-      if(response.data.included.length > 0) {
+      if(response.data.included != null && response.data.included.length > 0) {
         console.log("VCS used by:")
         console.log(response.data.included);
         message.error("This VCS is currently in use by one or more workspaces. Please remove the VCS from all workspaces before deleting it.");


### PR DESCRIPTION
This will show a message that a VCS provider can't be deleted because there a workspaces that are using it

![image](https://github.com/user-attachments/assets/f47a668e-ba1f-4480-9445-51da9711e04f)


> This will only work for workspace that were deleted after this was implemented https://github.com/AzBuilder/terrakube/pull/1502 because there could be some deleted workspaces that could have the reference in the database, for previous workspaces it will be required to connect to the database and remove the reference manually

Fix #1666