### PR TITLE
feat: Allow to select branch name when using the UI

### DIFF
--- a/ui/src/domain/Jobs/Create.jsx
+++ b/ui/src/domain/Jobs/Create.jsx
@@ -1,5 +1,5 @@
 import { React, useState, useEffect } from "react";
-import { Form, Button, Select, Modal, Space, message } from "antd";
+import {Form, Button, Select, Modal, Space, message, Input} from "antd";
 import {
   ORGANIZATION_ARCHIVE,
   WORKSPACE_ARCHIVE,
@@ -123,6 +123,9 @@ export const CreateJob = ({ changeJob }) => {
                 layout="vertical"
                 name="create-org"
                 validateMessages={validateMessages}
+                initialValues={{
+                    branchName: "test-branch-name",
+                }}
             >
               <Form.Item
                   name="templateId"
@@ -152,6 +155,13 @@ export const CreateJob = ({ changeJob }) => {
                     </Select>
                 )}
               </Form.Item>
+                <Form.Item
+                    name="branchName"
+                    label="Branch Name"
+                    tooltip="Select the branch to use for this job. When using the CLI driven workflow do not modify the branch name."
+                >
+                    <Input />
+                </Form.Item>
             </Form>
           </Space>
         </Modal>

--- a/ui/src/domain/Jobs/Create.jsx
+++ b/ui/src/domain/Jobs/Create.jsx
@@ -13,7 +13,7 @@ import {
 
 const validateMessages = { required: "${label} is required!" };
 
-export const CreateJob = ({ changeJob, defaultBranch }) => {
+export const CreateJob = ({ changeJob }) => {
   const workspaceId = sessionStorage.getItem(WORKSPACE_ARCHIVE);
   const organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
   const [visible, setVisible] = useState(false);

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -967,7 +967,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                       >
                         {workspace.data.attributes.locked ? "Unlock" : "Lock"}
                       </Button>
-                      <CreateJob changeJob={changeJob, workspace.data.attributes.branch } />
+                      <CreateJob changeJob={changeJob } />
                     </Space>
                   </>
                 }

--- a/ui/src/domain/Workspaces/Details.jsx
+++ b/ui/src/domain/Workspaces/Details.jsx
@@ -967,7 +967,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }) => {
                       >
                         {workspace.data.attributes.locked ? "Unlock" : "Lock"}
                       </Button>
-                      <CreateJob changeJob={changeJob} />
+                      <CreateJob changeJob={changeJob, workspace.data.attributes.branch } />
                     </Space>
                   </>
                 }


### PR DESCRIPTION
Fix #1622 

![image](https://github.com/user-attachments/assets/7a2f89e6-f3e0-41d2-86d1-ff82a709c156)

> When using the CLI driven workflow the branch name is "remote-content" and it should not be changed

![image](https://github.com/user-attachments/assets/454dd013-db48-4495-85fb-6e39f7730adc)
