### PR TITLE
Fix: S3 IAM access through Kubernetes service account

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -253,6 +253,10 @@
             <artifactId>s3</artifactId>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
         </dependency>

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -145,6 +145,10 @@
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>s3</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>com.google.cloud</groupId>
 			<artifactId>google-cloud-storage</artifactId>

--- a/registry/pom.xml
+++ b/registry/pom.xml
@@ -126,6 +126,10 @@
 			<artifactId>s3</artifactId>
 		</dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-spring-test-listener</artifactId>
             <version>${mockserver-spring-test-listener.version}</version>


### PR DESCRIPTION
Hello,
As discussed in #1728, this pull request fix the missing dependency for connecting to S3 bucket using Kubernetes service account.

For some reason I am not able to build main but this was tested on `release/2.24.X`.