### PR TITLE
Feature: AWS IAM auth for POSTGRES dataSource

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -257,6 +257,10 @@
             <artifactId>sts</artifactId>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
         </dependency>

--- a/api/src/main/java/org/terrakube/api/plugin/datasource/DataSourceAutoConfiguration.java
+++ b/api/src/main/java/org/terrakube/api/plugin/datasource/DataSourceAutoConfiguration.java
@@ -36,7 +36,14 @@ public class DataSourceAutoConfiguration {
                 break;
             case POSTGRESQL:
                 log.info("postgresql datasource using SSL Mode: {}", dataSourceConfigurationProperties.getSslMode());
-                PGSimpleDataSource ds = new PGSimpleDataSource();
+                PGSimpleDataSource ds;
+                if (dataSourceConfigurationProperties.isAwsIamAuth()) {
+                    PostgresAwsIamAuthDataSource dsAwsIam = new PostgresAwsIamAuthDataSource();
+                    dsAwsIam.setRegion(dataSourceConfigurationProperties.getAwsRegion());
+                    ds = dsAwsIam;
+                } else {
+                    ds = new PGSimpleDataSource();
+                }
                 ds.setServerNames(new String[]{dataSourceConfigurationProperties.getHostname()});
                 ds.setPortNumbers(new int[]{Integer.parseInt(dataSourceConfigurationProperties.getDatabasePort())});
                 ds.setDatabaseName(dataSourceConfigurationProperties.getDatabaseName());

--- a/api/src/main/java/org/terrakube/api/plugin/datasource/DataSourceConfigurationProperties.java
+++ b/api/src/main/java/org/terrakube/api/plugin/datasource/DataSourceConfigurationProperties.java
@@ -21,4 +21,6 @@ public class DataSourceConfigurationProperties {
     private String sslMode;
     private String databasePort;
     private String databaseSchema;
+    private boolean awsIamAuth;
+    private String awsRegion;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/datasource/DataSourceType.java
+++ b/api/src/main/java/org/terrakube/api/plugin/datasource/DataSourceType.java
@@ -6,5 +6,5 @@ public enum DataSourceType {
     AWS,
     GCP,
     POSTGRESQL,
-    MYSQL
+    MYSQL,
 }

--- a/api/src/main/java/org/terrakube/api/plugin/datasource/PostgresAwsIamAuthDataSource.java
+++ b/api/src/main/java/org/terrakube/api/plugin/datasource/PostgresAwsIamAuthDataSource.java
@@ -1,0 +1,48 @@
+package org.terrakube.api.plugin.datasource;
+
+import lombok.extern.slf4j.Slf4j;
+import org.postgresql.ds.PGSimpleDataSource;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.rds.RdsUtilities;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@Slf4j
+public class PostgresAwsIamAuthDataSource extends PGSimpleDataSource {
+    public void setRegion(String region) {
+        this.awsRegion = Region.of(region);
+    }
+
+    private Region awsRegion;
+    private String authToken;
+    private long lastTokenRefresh = 0;
+    private static final long TOKEN_EXPIRY_TIME = 10 * 60 * 1000;
+
+    @Override
+    public Connection getConnection(String user, String password) throws SQLException {
+        // If the token is older than 10 minutes, refresh it
+        long currentTime = System.currentTimeMillis();
+        if (currentTime - lastTokenRefresh > TOKEN_EXPIRY_TIME) {
+            lastTokenRefresh = currentTime;
+
+            log.debug("Refreshing postgres password using AWS SDK");
+
+            RdsUtilities rdsUtilities = RdsUtilities.builder()
+                    .region(awsRegion)
+                    .credentialsProvider(DefaultCredentialsProvider.create())
+                    .build();
+
+            authToken = rdsUtilities.generateAuthenticationToken(r -> r
+                    .hostname(getServerNames()[0])
+                    .port(getPortNumbers()[0])
+                    .username(getUser())
+                    .region(awsRegion)
+                    .build()
+            );
+        }
+
+        return super.getConnection(user, authToken);
+    }
+}

--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -51,6 +51,8 @@ org.terrakube.api.plugin.datasource.databasePassword=${DatasourcePassword}
 org.terrakube.api.plugin.datasource.sslMode=${DatasourceSslMode:disable}
 org.terrakube.api.plugin.datasource.databasePort=${DatasourcePort:5432}
 org.terrakube.api.plugin.datasource.databaseSchema=${DatasourceSchema:public}
+org.terrakube.api.plugin.datasource.awsIamAuth=${DatasourceAwsIamAuth:false}
+org.terrakube.api.plugin.datasource.awsRegion=${DatasourceAwsRegion:aws-region-not-set}
 
 ################
 #OWNER INSTANCE#

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -51,6 +51,8 @@ org.terrakube.api.plugin.datasource.databasePassword=${DatasourcePassword}
 org.terrakube.api.plugin.datasource.sslMode=${DatasourceSslMode:disable}
 org.terrakube.api.plugin.datasource.databasePort=${DatasourcePort:5432}
 org.terrakube.api.plugin.datasource.databaseSchema=${DatasourceSchema:public}
+org.terrakube.api.plugin.datasource.awsIamAuth=${DatasourceAwsIamAuth:false}
+org.terrakube.api.plugin.datasource.awsRegion=${DatasourceAwsRegion:aws-region-not-set}
 
 ################
 #OWNER INSTANCE#


### PR DESCRIPTION
Hello, 

For my use case, I need Terrakube to connect to RDS. We have a strict no static password, Terrakube already supports S3 access using AWS DefaultCredentialsProvider but does not have a way to do it for dataSources.

This PR allow connecting to RDS Postgres database using the AWS IAM.

Added:
- A custom implementation of `PGSimpleDataSource.getConnection` that allows pulling and refreshing AWS RDS token
- Two new configs:
  - `DatasourceAwsIamAuth` (`boolean`, default: `false`): Enable pulling Postgres password using AWS IAM
  - `DatasourceAwsRegion` (`string`, default: `"aws-region-not-set"`): The region of the RDS
- A new dependency on: `software.amazon.awssdk` > `rds`

Test:
- It was tested on AWS RDS Postgres

Let me know if you want me to change things, this is my first java PR 