### PR TITLE
fix: Gitlab webhook creation

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -133,8 +133,9 @@ public class GitLabWebhookService extends WebhookServiceBase {
         try {
             log.info("Search gitlab project id using {}, {}", ownerAndRepo, workspace.getVcs().getApiUrl());
             projectId = getGitlabProjectId(ownerAndRepo, token, workspace.getVcs().getApiUrl());
-        } catch (Exception e) {
+        } catch (InterruptedException | IOException e) {
             log.error(e.getMessage());
+            Thread.currentThread().interrupt();
         }
         URI gitlabUri = UriComponentsBuilder.fromHttpUrl(workspace.getVcs().getApiUrl() + "/projects/" + projectId + "/hooks").build(true).toUri();
 

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -163,7 +163,7 @@ public class GitLabWebhookService extends WebhookServiceBase {
         String projectId = "";
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(gitlabBaseUrl + "/api/v4/search?scope=projects&search=" + ownerAndRepo))
+                .uri(URI.create(gitlabBaseUrl + "/search?scope=projects&search=" + ownerAndRepo))
                 .header("Authorization", "Bearer " + accessToken)
                 .header("Content-Type", "application/json")
                 .GET()


### PR DESCRIPTION
This will fix the logic to get the project id when creating a webhook with Gitlab

Example: 

![image](https://github.com/user-attachments/assets/a73bdae6-d22a-49c8-a5d9-f1c0b78a48f9)

![image](https://github.com/user-attachments/assets/763058ba-33f0-4f50-853a-35d3a8fd5e94)

![image](https://github.com/user-attachments/assets/9af872c0-d0a1-43c6-9714-b90ecda45131)


Fix #1583 