### PR TITLE
fix: validate org name only contains letters and numbers, fix java version in gitpod

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "setup-java",
             "type": "shell",
-            "command": "source \"$HOME/.sdkman/bin/sdkman-init.sh\" && sdk install java 17.0.6-tem && sdk install maven 3.9.0",
+            "command": "source \"$HOME/.sdkman/bin/sdkman-init.sh\" && sdk install java 21.0.6-tem && sdk install maven 3.9.0",
             "group": {
                 "kind": "build",
                 "isDefault": true

--- a/ui/src/domain/Organizations/Create.jsx
+++ b/ui/src/domain/Organizations/Create.jsx
@@ -97,8 +97,11 @@ export const CreateOrganization = ({ setOrganizationName }) => {
               name="name"
               label="Organization name"
               tooltip="e.g. company-name"
-              extra=" Organization names must be unique and will be part of your resource names used in various tools, for example terrakube/www-prod."
-              rules={[{ required: true }]}
+              extra=" Organization names must be unique and will be part of your resource names used in various tools, for example www-prod."
+              rules={[
+                  { required: true,message: 'This field is required!'},
+                  { pattern: /^[a-zA-Z0-9]*$/, message: 'Only letters and numbers are allowed!',}
+              ]}
             >
               <Input />
             </Form.Item>


### PR DESCRIPTION
Fix #1705

![image](https://github.com/user-attachments/assets/c6efca02-214d-4c37-9dbf-0e03f5b9b382)

![image](https://github.com/user-attachments/assets/edf99860-3ef2-421c-a0fd-cdaa94edff35)
