### PR TITLE
feat: Improve log-reader-url logic for remote CLI driven workflow

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -297,7 +297,6 @@
             <artifactId>kubernetes-client</artifactId>
             <version>${kubernetes-client.version}</version>
         </dependency>
-
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
@@ -58,8 +58,8 @@ public class DexWebSecurityAdapter {
                                                         .requestMatchers(HttpMethod.PUT,
                                                                         "/tfstate/v1/archive/*/terraform.json.tfstate")
                                                         .permitAll()
-                                                        .requestMatchers("/remote/tfe/v2/plans/*/logs").permitAll()
-                                                        .requestMatchers("/remote/tfe/v2/applies/*/logs").permitAll()
+                                                        .requestMatchers("/remote/tfe/v2/plans/logs/*").permitAll()
+                                                        .requestMatchers("/remote/tfe/v2/applies/logs/*").permitAll()
                                                         .requestMatchers("/app/*/*/runs/*").permitAll()
                                                         .requestMatchers("/tofu/index.json").permitAll()
                                                         .anyRequest().authenticated();

--- a/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
@@ -58,8 +58,8 @@ public class DexWebSecurityAdapter {
                                                         .requestMatchers(HttpMethod.PUT,
                                                                         "/tfstate/v1/archive/*/terraform.json.tfstate")
                                                         .permitAll()
-                                                        .requestMatchers("/remote/tfe/v2/plans/logs/*").permitAll()
-                                                        .requestMatchers("/remote/tfe/v2/applies/logs/*").permitAll()
+                                                        .requestMatchers("/remote/tfe/v2/plans/logs/**").permitAll()
+                                                        .requestMatchers("/remote/tfe/v2/applies/logs/**").permitAll()
                                                         .requestMatchers("/app/*/*/runs/*").permitAll()
                                                         .requestMatchers("/tofu/index.json").permitAll()
                                                         .anyRequest().authenticated();

--- a/api/src/main/java/org/terrakube/api/plugin/security/encryption/EncryptionService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/encryption/EncryptionService.java
@@ -19,7 +19,7 @@ public class EncryptionService {
 
     private static final String ALGORITHM = "AES/GCM/NoPadding";
     private static final int GCM_TAG_LENGTH = 128;  // Tag length in bits
-    private static final int GCM_IV_LENGTH = 16;  // GCM IV length (recommended is 12 bytes)
+    private static final int GCM_IV_LENGTH = 12;  // GCM IV length (recommended is 12 bytes)
 
 
     @Value("${org.terrakube.token.internal}")

--- a/api/src/main/java/org/terrakube/api/plugin/security/encryption/EncryptionService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/encryption/EncryptionService.java
@@ -12,6 +12,7 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.Base64;
 
 @Service
@@ -115,9 +116,8 @@ public class EncryptionService {
      * @return A randomly generated IV byte array
      */
     private byte[] generateIv() {
-        //byte[] iv = new byte[16]; // AES block size is 16 bytes
-        //new SecureRandom().nextBytes(iv);
-        return RandomStringUtils.secureStrong().nextAlphanumeric(16).getBytes(StandardCharsets.UTF_8);
-        //return iv;
+        byte[] iv = new byte[16]; // AES block size is 16 bytes
+        new SecureRandom().nextBytes(iv);
+        return iv;
     }
 }

--- a/api/src/main/java/org/terrakube/api/plugin/security/encryption/InternalEncryptionService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/encryption/InternalEncryptionService.java
@@ -1,0 +1,119 @@
+package org.terrakube.api.plugin.security.encryption;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Service
+@Slf4j
+public class InternalEncryptionService {
+
+    private static final String ALGORITHM = "AES/CBC/PKCS5Padding";
+
+    @Value("${org.terrakube.token.internal}")
+    private String internalToken;
+
+    /**
+     * Encrypts the given value using AES encryption with the internal token as the key.
+     *
+     * @param value The plaintext string to encrypt
+     * @return The encrypted string in Base64 format, with IV prepended
+     */
+    public String encrypt(String value) {
+        try {
+            // Generate SecretKeySpec using the internal token
+            SecretKeySpec keySpec = new SecretKeySpec(generateHashFromToken(internalToken), "AES");
+
+            // Generate a random Initialization Vector (IV)
+            byte[] iv = generateIv();
+            IvParameterSpec ivSpec = new IvParameterSpec(iv);
+
+            // Configure the Cipher for encryption
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec, ivSpec);
+
+            // Perform encryption
+            byte[] encryptedBytes = cipher.doFinal(value.getBytes(StandardCharsets.UTF_8));
+
+            // Encode IV and encrypted data in Base64, and return as "IV:EncryptedData"
+            String ivBase64 = Base64.getEncoder().encodeToString(iv);
+            String encryptedBase64 = Base64.getEncoder().encodeToString(encryptedBytes);
+            return ivBase64 + ":" + encryptedBase64;
+        } catch (Exception e) {
+            log.error("Error during AES encryption: {}", e.getMessage(), e);
+            throw new RuntimeException("Encryption failed", e);
+        }
+    }
+
+    /**
+     * Decrypts the given encrypted text (Base64 encoded) using AES with the internal token as the key.
+     *
+     * @param encryptedText The encrypted string in the format "IV:EncryptedData"
+     * @return The decrypted plaintext string
+     */
+    public String decrypt(String encryptedText) {
+        try {
+            // Split the input into IV and cipher text
+            String[] parts = encryptedText.split(":");
+            if (parts.length != 2) {
+                throw new IllegalArgumentException("Invalid encrypted string format. Expected 'IV:EncryptedData'");
+            }
+            String ivBase64 = parts[0];
+            String encryptedBase64 = parts[1];
+
+            // Decode IV and encrypted data from Base64
+            byte[] iv = Base64.getDecoder().decode(ivBase64);
+            byte[] encryptedBytes = Base64.getDecoder().decode(encryptedBase64);
+
+            // Create SecretKeySpec and IvParameterSpec for decryption
+            SecretKeySpec keySpec = new SecretKeySpec(generateHashFromToken(internalToken), "AES");
+            IvParameterSpec ivSpec = new IvParameterSpec(iv);
+
+            // Configure Cipher for decryption
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, keySpec, ivSpec);
+
+            // Perform decryption
+            byte[] originalBytes = cipher.doFinal(encryptedBytes);
+
+            // Return the plaintext string
+            return new String(originalBytes, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            log.error("Error during AES decryption: {}", e.getMessage(), e);
+            throw new RuntimeException("Decryption failed", e);
+        }
+    }
+
+    /**
+     * Generates a 256-bit hash from the provided token using SHA-256,
+     * which will be used as the AES key.
+     *
+     * @param token The secret token used as input for the hash
+     * @return A 256-bit hash byte array
+     * @throws NoSuchAlgorithmException If SHA-256 algorithm is not available
+     */
+    private byte[] generateHashFromToken(String token) throws NoSuchAlgorithmException {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        return digest.digest(token.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Generates a random 16-byte Initialization Vector (IV) for AES.
+     *
+     * @return A randomly generated IV byte array
+     */
+    private byte[] generateIv() {
+        byte[] iv = new byte[16]; // AES block size is 16 bytes
+        new SecureRandom().nextBytes(iv);
+        return iv;
+    }
+}

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -300,20 +300,22 @@ public class RemoteTfeController {
     }
 
     @Transactional
-    @GetMapping(produces = "application/vnd.api+json", path = "/plans/logs/{planId}")
-    public ResponseEntity<String> getPlanLogs(@PathVariable("planId") String planId,
+    @GetMapping(produces = "application/vnd.api+json", path = "/plans/logs/{planId1}/{planId2}")
+    public ResponseEntity<String> getPlanLogs(@PathVariable("planId1") String planId1,@PathVariable("planId2") String planId2,
             @RequestParam int offset, @RequestParam int limit) throws IOException {
+        log.info("Getting plan logs for planId: {}", planId1 + "/" + planId2);
         return ResponseEntity.of(Optional
-                .ofNullable(new String(remoteTfeService.getPlanLogs(planId, offset, limit), StandardCharsets.UTF_8)));
+                .ofNullable(new String(remoteTfeService.getPlanLogs(planId1 + "/" + planId2, offset, limit), StandardCharsets.UTF_8)));
     }
 
     @Transactional
-    @GetMapping(produces = "application/vnd.api+json", path = "/applies/logs/{applyId}")
-    public ResponseEntity<String> getApplyLogs(@PathVariable("applyId") String planId,
+    @GetMapping(produces = "application/vnd.api+json", path = "/applies/logs/{applyId1}/{applyId2}")
+    public ResponseEntity<String> getApplyLogs(@PathVariable("applyId1") String applyId1,@PathVariable("applyId2") String applyId2,
             @RequestParam int offset, @RequestParam int limit) throws IOException {
+        log.info("Getting plan logs for applyId: {}", applyId1 + "/" + applyId2);
         return ResponseEntity
                 .of(Optional.ofNullable(
-                        new String(remoteTfeService.getApplyLogs(planId, offset, limit), StandardCharsets.UTF_8)));
+                        new String(remoteTfeService.getApplyLogs(applyId1 + "/" + applyId2, offset, limit), StandardCharsets.UTF_8)));
     }
 
     @Transactional

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeController.java
@@ -300,16 +300,16 @@ public class RemoteTfeController {
     }
 
     @Transactional
-    @GetMapping(produces = "application/vnd.api+json", path = "/plans/{planId}/logs")
-    public ResponseEntity<String> getPlanLogs(@PathVariable("planId") int planId,
+    @GetMapping(produces = "application/vnd.api+json", path = "/plans/logs/{planId}")
+    public ResponseEntity<String> getPlanLogs(@PathVariable("planId") String planId,
             @RequestParam int offset, @RequestParam int limit) throws IOException {
         return ResponseEntity.of(Optional
                 .ofNullable(new String(remoteTfeService.getPlanLogs(planId, offset, limit), StandardCharsets.UTF_8)));
     }
 
     @Transactional
-    @GetMapping(produces = "application/vnd.api+json", path = "/applies/{applyId}/logs")
-    public ResponseEntity<String> getApplyLogs(@PathVariable("applyId") int planId,
+    @GetMapping(produces = "application/vnd.api+json", path = "/applies/logs/{applyId}")
+    public ResponseEntity<String> getApplyLogs(@PathVariable("applyId") String planId,
             @RequestParam int offset, @RequestParam int limit) throws IOException {
         return ResponseEntity
                 .of(Optional.ofNullable(

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -1158,7 +1158,7 @@ public class RemoteTfeService {
         planRunModel.getAttributes().put("status", planStatus);
         String encryptedPlanId = internalEncryptionService.encrypt(String.valueOf(planId));
         planRunModel.getAttributes().put("log-read-url",
-                String.format("https://%s/remote/tfe/v2/plans/logs/%s", hostname, Arrays.toString(Base64.getUrlEncoder().encode(encryptedPlanId.getBytes(StandardCharsets.UTF_8)))));
+                String.format("https://%s/remote/tfe/v2/plans/logs/%s", hostname, encryptedPlanId));
         plansData.setData(planRunModel);
         return plansData;
     }
@@ -1196,14 +1196,14 @@ public class RemoteTfeService {
         applyModel.getAttributes().put("status", applyStatus);
         String encryptedPlanId = internalEncryptionService.encrypt(String.valueOf(planId));
         applyModel.getAttributes().put("log-read-url",
-                String.format("https://%s/remote/tfe/v2/applies/logs/%s", hostname, Arrays.toString(Base64.getUrlEncoder().encode(encryptedPlanId.getBytes(StandardCharsets.UTF_8)))));
+                String.format("https://%s/remote/tfe/v2/applies/logs/%s", hostname, encryptedPlanId));
 
         applyRunData.setData(applyModel);
         return applyRunData;
     }
 
     byte[] getPlanLogs(String planId, int offset, int limit) {
-        planId = internalEncryptionService.decrypt(Arrays.toString(Base64.getUrlDecoder().decode(planId.getBytes(StandardCharsets.UTF_8))));
+        planId = internalEncryptionService.decrypt(planId);
         Job job = jobRepository.getReferenceById(Integer.valueOf(planId));
         byte[] logs = "".getBytes();
         TextStringBuilder logsOutput = new TextStringBuilder();
@@ -1238,7 +1238,7 @@ public class RemoteTfeService {
     }
 
     byte[] getApplyLogs(String planId, int offset, int limit) {
-        planId = internalEncryptionService.decrypt(Arrays.toString(Base64.getUrlDecoder().decode(planId.getBytes(StandardCharsets.UTF_8))));
+        planId = internalEncryptionService.decrypt(planId);
         Job job = jobRepository.getReferenceById(Integer.valueOf(planId));
         byte[] logs = "".getBytes();
         TextStringBuilder logsOutputApply = new TextStringBuilder();

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -15,7 +15,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Service;
 import org.terrakube.api.plugin.scheduler.ScheduleJobService;
-import org.terrakube.api.plugin.security.encryption.InternalEncryptionService;
+import org.terrakube.api.plugin.security.encryption.EncryptionService;
 import org.terrakube.api.plugin.state.model.apply.ApplyRunData;
 import org.terrakube.api.plugin.state.model.apply.ApplyRunModel;
 import org.terrakube.api.plugin.state.model.configuration.ConfigurationData;
@@ -98,7 +98,7 @@ public class RemoteTfeService {
 
     private AccessRepository accessRepository;
 
-    private InternalEncryptionService internalEncryptionService;
+    private EncryptionService encryptionService;
 
     public RemoteTfeService(JobRepository jobRepository,
                             ContentRepository contentRepository,
@@ -117,7 +117,7 @@ public class RemoteTfeService {
                             TeamTokenService teamTokenService,
                             ArchiveRepository archiveRepository,
                             AccessRepository accessRepository,
-                            InternalEncryptionService internalEncryptionService) {
+                            EncryptionService encryptionService) {
         this.jobRepository = jobRepository;
         this.contentRepository = contentRepository;
         this.organizationRepository = organizationRepository;
@@ -135,7 +135,7 @@ public class RemoteTfeService {
         this.teamTokenService = teamTokenService;
         this.archiveRepository = archiveRepository;
         this.accessRepository = accessRepository;
-        this.internalEncryptionService = internalEncryptionService;
+        this.encryptionService = encryptionService;
     }
 
     private boolean validateTerrakubeUser(JwtAuthenticationToken currentUser) {
@@ -1156,7 +1156,8 @@ public class RemoteTfeService {
         planRunModel.getAttributes().put("actions", actions);
 
         planRunModel.getAttributes().put("status", planStatus);
-        String encryptedPlanId = internalEncryptionService.encrypt(String.valueOf(planId));
+        String encryptedPlanId = encryptionService.encrypt(String.valueOf(planId));
+        log.info("log-read-url: {}", String.format("https://%s/remote/tfe/v2/plans/logs/%s", hostname, encryptedPlanId));
         planRunModel.getAttributes().put("log-read-url",
                 String.format("https://%s/remote/tfe/v2/plans/logs/%s", hostname, encryptedPlanId));
         plansData.setData(planRunModel);
@@ -1194,7 +1195,8 @@ public class RemoteTfeService {
             }
         }
         applyModel.getAttributes().put("status", applyStatus);
-        String encryptedPlanId = internalEncryptionService.encrypt(String.valueOf(planId));
+        String encryptedPlanId = encryptionService.encrypt(String.valueOf(planId));
+        log.info("log-read-url: {}", String.format("https://%s/remote/tfe/v2/applies/logs/%s", hostname, encryptedPlanId));
         applyModel.getAttributes().put("log-read-url",
                 String.format("https://%s/remote/tfe/v2/applies/logs/%s", hostname, encryptedPlanId));
 
@@ -1203,72 +1205,82 @@ public class RemoteTfeService {
     }
 
     byte[] getPlanLogs(String planId, int offset, int limit) {
-        planId = internalEncryptionService.decrypt(planId);
-        Job job = jobRepository.getReferenceById(Integer.valueOf(planId));
+        planId = encryptionService.decrypt(planId);
+        log.info("Searching logs for plan {}", planId);
+        Optional<Job> job = jobRepository.findById(Integer.valueOf(planId));
         byte[] logs = "".getBytes();
-        TextStringBuilder logsOutput = new TextStringBuilder();
-        if (job.getStep() != null && !job.getStep().isEmpty())
-            for (Step step : job.getStep()) {
-                if (step.getStepNumber() == 100) {
-                    log.info("Checking logs for plan: {}", step.getId());
+        if(job.isPresent()) {
+            TextStringBuilder logsOutput = new TextStringBuilder();
+            if (job.get().getStep() != null && !job.get().getStep().isEmpty())
+                for (Step step : job.get().getStep()) {
+                    if (step.getStepNumber() == 100) {
+                        log.info("Checking logs for plan: {}", step.getId());
 
-                    try {
-                        @SuppressWarnings("unchecked")
-                        List<MapRecord<String, String, String>> messagesPlan = redisTemplate.opsForStream()
-                                .read(StreamOffset.fromStart(String.valueOf(job.getId())),
-                                        StreamOffset.latest(String.valueOf(job.getId())));
+                        try {
+                            @SuppressWarnings("unchecked")
+                            List<MapRecord<String, String, String>> messagesPlan = redisTemplate.opsForStream()
+                                    .read(StreamOffset.fromStart(String.valueOf(job.get().getId())),
+                                            StreamOffset.latest(String.valueOf(job.get().getId())));
 
-                        for (MapRecord<String, String, String> mapRecord : messagesPlan) {
-                            Map<String, String> streamData = (Map<String, String>) mapRecord.getValue();
-                            logsOutput.appendln(streamData.get("output"));
+                            for (MapRecord<String, String, String> mapRecord : messagesPlan) {
+                                Map<String, String> streamData = (Map<String, String>) mapRecord.getValue();
+                                logsOutput.appendln(streamData.get("output"));
+                            }
+
+                            String logsOutputString = logsOutput.toString();
+                            int potentialEndIndex = limit + offset;
+                            int endIndex = logsOutputString.length() > potentialEndIndex ? potentialEndIndex
+                                    : logsOutputString.length();
+                            logs = logsOutputString.substring(offset, endIndex).getBytes(StandardCharsets.UTF_8);
+                            log.debug("{}", logs);
+                        } catch (Exception ex) {
+                            log.debug(ex.getMessage());
                         }
-
-                        String logsOutputString = logsOutput.toString();
-                        int potentialEndIndex = limit + offset;
-                        int endIndex = logsOutputString.length() > potentialEndIndex ? potentialEndIndex
-                                : logsOutputString.length();
-                        logs = logsOutputString.substring(offset, endIndex).getBytes(StandardCharsets.UTF_8);
-                        log.debug("{}", logs);
-                    } catch (Exception ex) {
-                        log.debug(ex.getMessage());
                     }
                 }
-            }
+        } else {
+            log.warn("No logs found for plan {}", planId);
+        }
         return logs;
     }
 
-    byte[] getApplyLogs(String planId, int offset, int limit) {
-        planId = internalEncryptionService.decrypt(planId);
-        Job job = jobRepository.getReferenceById(Integer.valueOf(planId));
+    byte[] getApplyLogs(String applyId, int offset, int limit) {
+        applyId = encryptionService.decrypt(applyId);
+        log.info("Searching logs for apply {}", applyId);
+        Optional<Job> job = jobRepository.findById(Integer.valueOf(applyId));
         byte[] logs = "".getBytes();
-        TextStringBuilder logsOutputApply = new TextStringBuilder();
-        if (job.getStep() != null && !job.getStep().isEmpty())
-            for (Step step : job.getStep()) {
-                if (step.getStepNumber() == 100) {
-                    log.debug("Checking logs stepId for apply: {}", step.getId());
+        if (job.isPresent()) {
+            TextStringBuilder logsOutputApply = new TextStringBuilder();
+            if (job.get().getStep() != null && !job.get().getStep().isEmpty())
+                for (Step step : job.get().getStep()) {
+                    if (step.getStepNumber() == 100) {
+                        log.debug("Checking logs stepId for apply: {}", step.getId());
 
-                    try {
-                        @SuppressWarnings("unchecked")
-                        List<MapRecord<String, String, String>> messagesApply = redisTemplate.opsForStream().read(
-                                StreamOffset.fromStart(String.valueOf(job.getId())),
-                                StreamOffset.latest(String.valueOf(job.getId())));
+                        try {
+                            @SuppressWarnings("unchecked")
+                            List<MapRecord<String, String, String>> messagesApply = redisTemplate.opsForStream().read(
+                                    StreamOffset.fromStart(String.valueOf(job.get().getId())),
+                                    StreamOffset.latest(String.valueOf(job.get().getId())));
 
-                        for (MapRecord<String, String, String> mapRecord : messagesApply) {
-                            Map<String, String> streamData = (Map<String, String>) mapRecord.getValue();
-                            logsOutputApply.appendln(streamData.get("output"));
+                            for (MapRecord<String, String, String> mapRecord : messagesApply) {
+                                Map<String, String> streamData = (Map<String, String>) mapRecord.getValue();
+                                logsOutputApply.appendln(streamData.get("output"));
+                            }
+
+                            String logsOutputString = logsOutputApply.toString();
+                            int potentialEndIndex = limit + offset;
+                            int endIndex = logsOutputString.length() > potentialEndIndex ? potentialEndIndex
+                                    : logsOutputString.length();
+                            logs = logsOutputString.substring(offset, endIndex).getBytes(StandardCharsets.UTF_8);
+                            log.debug("{}", logs);
+                        } catch (Exception ex) {
+                            log.debug(ex.getMessage());
                         }
-
-                        String logsOutputString = logsOutputApply.toString();
-                        int potentialEndIndex = limit + offset;
-                        int endIndex = logsOutputString.length() > potentialEndIndex ? potentialEndIndex
-                                : logsOutputString.length();
-                        logs = logsOutputString.substring(offset, endIndex).getBytes(StandardCharsets.UTF_8);
-                        log.debug("{}", logs);
-                    } catch (Exception ex) {
-                        log.debug(ex.getMessage());
                     }
                 }
-            }
+        } else {
+            log.warn("No logs found for apply {}", applyId);
+        }
         return logs;
     }
 

--- a/api/src/test/java/org/terrakube/api/EncryptionTests.java
+++ b/api/src/test/java/org/terrakube/api/EncryptionTests.java
@@ -1,25 +1,17 @@
 package org.terrakube.api;
 
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.util.Assert;
 
 import java.io.IOException;
-import java.util.Base64;
 
 public class EncryptionTests extends ServerApplicationTests {
 
     @Test
     void encryptSampleString() throws IOException {
-        System.out.println(internalEncryptionService.encrypt("1"));
-
-        System.out.println(internalEncryptionService.decrypt("Lmwg3SuyVyUXigwyeL3cIw==:rsEz8g9+DTddJzPNdR5i0Q=="));
-        System.out.println(internalEncryptionService.decrypt("50lo2k1YltIvX7AnysBS7g==:Jg5tfC0WKHSnhc3rehpwLQ=="));
-        System.out.println(internalEncryptionService.decrypt("XzZvk27NLwq8T+3a6aPR5A==:iMMvmOwgpGF6GQ/5UKq9/g=="));
-        System.out.println(internalEncryptionService.decrypt("XZ3lEvltygvOHu4XozmKGA==:wPjWuDwQLxT9yqZJQsxzEg=="));
-
-
-        System.out.println(Base64.getUrlEncoder().encodeToString("gD0IWvMRbf74p93nMIlOBg==:c2a6xFBE7PXy1tNNjYU2JA==".getBytes()));
-
-        System.out.println(Base64.getUrlDecoder().decode("Z0QwSVd2TVJiZjc0cDkzbk1JbE9CZz09OmMyYTZ4RkJFN1BYeTF0Tk5qWVUySkE9PQ==").toString());
+        String encryptedValue = encryptionService.encrypt("1");
+        System.out.println(encryptedValue);
+        Assert.equals(encryptionService.decrypt(encryptedValue), "1");
     }
 
 

--- a/api/src/test/java/org/terrakube/api/EncryptionTests.java
+++ b/api/src/test/java/org/terrakube/api/EncryptionTests.java
@@ -1,0 +1,26 @@
+package org.terrakube.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Base64;
+
+public class EncryptionTests extends ServerApplicationTests {
+
+    @Test
+    void encryptSampleString() throws IOException {
+        System.out.println(internalEncryptionService.encrypt("1"));
+
+        System.out.println(internalEncryptionService.decrypt("Lmwg3SuyVyUXigwyeL3cIw==:rsEz8g9+DTddJzPNdR5i0Q=="));
+        System.out.println(internalEncryptionService.decrypt("50lo2k1YltIvX7AnysBS7g==:Jg5tfC0WKHSnhc3rehpwLQ=="));
+        System.out.println(internalEncryptionService.decrypt("XzZvk27NLwq8T+3a6aPR5A==:iMMvmOwgpGF6GQ/5UKq9/g=="));
+        System.out.println(internalEncryptionService.decrypt("XZ3lEvltygvOHu4XozmKGA==:wPjWuDwQLxT9yqZJQsxzEg=="));
+
+
+        System.out.println(Base64.getUrlEncoder().encodeToString("gD0IWvMRbf74p93nMIlOBg==:c2a6xFBE7PXy1tNNjYU2JA==".getBytes()));
+
+        System.out.println(Base64.getUrlDecoder().decode("Z0QwSVd2TVJiZjc0cDkzbk1JbE9CZz09OmMyYTZ4RkJFN1BYeTF0Tk5qWVUySkE9PQ==").toString());
+    }
+
+
+}

--- a/api/src/test/java/org/terrakube/api/ServerApplicationTests.java
+++ b/api/src/test/java/org/terrakube/api/ServerApplicationTests.java
@@ -19,7 +19,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
-import org.terrakube.api.plugin.security.encryption.InternalEncryptionService;
+import org.terrakube.api.plugin.security.encryption.EncryptionService;
 import org.terrakube.api.plugin.token.pat.PatService;
 import org.terrakube.api.plugin.scheduler.job.tcl.TclService;
 import org.terrakube.api.repository.*;
@@ -30,8 +30,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
-import static org.mockito.Mockito.when;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -50,7 +48,7 @@ class ServerApplicationTests {
     int port;
 
     @Autowired
-    InternalEncryptionService internalEncryptionService;
+    EncryptionService encryptionService;
 
     @Autowired
     JobRepository jobRepository;

--- a/api/src/test/java/org/terrakube/api/ServerApplicationTests.java
+++ b/api/src/test/java/org/terrakube/api/ServerApplicationTests.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
+import org.terrakube.api.plugin.security.encryption.InternalEncryptionService;
 import org.terrakube.api.plugin.token.pat.PatService;
 import org.terrakube.api.plugin.scheduler.job.tcl.TclService;
 import org.terrakube.api.repository.*;
@@ -47,6 +48,9 @@ class ServerApplicationTests {
 
     @LocalServerPort
     int port;
+
+    @Autowired
+    InternalEncryptionService internalEncryptionService;
 
     @Autowired
     JobRepository jobRepository;


### PR DESCRIPTION
Previously when using the CLI driven workflow with remote execution Terrakube return the property `log-read-url` to the terraform/tofu cli using the following paths: 

```
/applies/{jobId}/logs
/plans/{jobId}/logs
``` 

> Terraform/tofu cli uses the path to read the log streaming.

With this change the logic will encrypt the value instead of using just the `jobId`, it will use AES/GCM/NoPadding to encrypt the values from the URL like the following:

```
/applies/logs/-1psjhcp26q6cy47f5z94oj4v6/-7471qtqoo6st1opld4jx58nhh
/applies/logs/-5jxcuqypoixzxh981o8yh8sbr/-3ja54lwjtoec60t9mf4jh94xa
```

The values are encrypted using  the internal token secret