### PR TITLE
fix: UI directs to login page when the access token is expired

### DIFF
--- a/ui/src/domain/Home/App.js
+++ b/ui/src/domain/Home/App.js
@@ -24,6 +24,12 @@ const { Header, Footer } = Layout;
 const App = () => {
   const auth = useAuth();
   const [organizationName, setOrganizationName] = useState("...");
+  const expiry = auth?.user?.expires_at;
+  
+  // Checking with the expiry time in the localstorage and when it has crossed the access has been revoked so It will clear the local storage and by default with no localstorage object it will route to login page.
+  if(auth.isAuthenticated && auth?.user && Math.floor(Date.now() / 1000) > expiry){
+    localStorage.clear();
+  }
 
   if (!auth.isAuthenticated) {
     return <Login />;


### PR DESCRIPTION
## Description

I have fixed the issue by using the expiry timestamp existing in the user object in localstorage. But I assume it needs to be fixed when it is been rejected in authorization process of each protected route.

Let me know if authorization middleware is done then I can work that as well.

## Results 

There is an expiry timestamp in the localstorage, change it to nearby time and wait until time crosses and try to request anything in the UI then it will route to login page.
I have tested manually by modifying the expiry time in the localstorage to mimic the real time expiration.
Kindly let me know if any error exists.

Fix #1620