### PR TITLE
fix: wrong dependency scope inside the registry

### DIFF
--- a/registry/pom.xml
+++ b/registry/pom.xml
@@ -133,6 +133,7 @@
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-spring-test-listener</artifactId>
             <version>${mockserver-spring-test-listener.version}</version>
+	    <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
Fix #1886

This will remove the dependency commons-text from the registry container.

Adding scope `test` will give the following inside the container

![Image](https://github.com/user-attachments/assets/6e6950c6-04eb-49b1-8350-72b09925168a)

Without `test`scope  will create the container like the following that is including apache commons text 1.9

![Image](https://github.com/user-attachments/assets/5fa1db45-9450-4260-bd7e-59c1feff6311)