### PR TITLE
feat: support to use -target and -replace flags with CLI driven workflow

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -24,6 +24,8 @@ import org.terrakube.api.rs.collection.item.Item;
 import org.terrakube.api.rs.globalvar.Globalvar;
 import org.terrakube.api.rs.job.Job;
 import org.terrakube.api.rs.job.JobStatus;
+import org.terrakube.api.rs.job.address.Address;
+import org.terrakube.api.rs.job.address.AddressType;
 import org.terrakube.api.rs.ssh.Ssh;
 import org.terrakube.api.rs.vcs.Vcs;
 import org.terrakube.api.rs.workspace.parameters.Category;
@@ -165,9 +167,32 @@ public class ExecutorService {
         executorContext.setRefresh(job.isRefresh());
         executorContext.setRefreshOnly(job.isRefreshOnly());
         executorContext.setAgentUrl(getExecutorUrl(job));
+        executorContext = validateJobAddress(executorContext, job);
         return executorContext.getEnvironmentVariables().containsKey("TERRAKUBE_ENABLE_EPHEMERAL_EXECUTOR")
                 ? ephemeralExecutorService.sendToEphemeralExecutor(job, executorContext)
                 : sendToExecutor(job, executorContext);
+    }
+
+    private ExecutorContext validateJobAddress(ExecutorContext executorContext, Job job) {
+        if (job.getAddress() != null && !job.getAddress().isEmpty()) {
+            List<Address> addressList = job.getAddress();
+            StringBuilder tfCliArgsPlan= new StringBuilder();
+            for(Address address : addressList) {
+                if (address.getType().equals(AddressType.TARGET)) {
+                    tfCliArgsPlan.append(String.format(" -target=\"%s\"", address.getName()));
+                }
+
+                if (address.getType().equals(AddressType.REPLACE)) {
+                    tfCliArgsPlan.append(String.format(" -replace=\"%s\"", address.getName()));
+                }
+            }
+
+            if(!tfCliArgsPlan.isEmpty()) {
+                executorContext.getEnvironmentVariables().put("TF_CLI_ARGS_PLAN", tfCliArgsPlan.toString());
+            }
+        }
+
+        return executorContext;
     }
 
     private String getExecutorUrl(Job job) {

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -174,7 +174,7 @@ public class ExecutorService {
     }
 
     private ExecutorContext validateJobAddress(ExecutorContext executorContext, Job job) {
-        if (job.getAddress() != null && !job.getAddress().isEmpty()) {
+        if (job.getAddress() != null && !job.getAddress().isEmpty() && (job.getTerraformPlan() == null || job.getTerraformPlan().isEmpty())) {
             List<Address> addressList = job.getAddress();
             StringBuilder tfCliArgsPlan= new StringBuilder();
             for(Address address : addressList) {
@@ -188,7 +188,8 @@ public class ExecutorService {
             }
 
             if(!tfCliArgsPlan.isEmpty()) {
-                executorContext.getEnvironmentVariables().put("TF_CLI_ARGS_PLAN", tfCliArgsPlan.toString());
+                log.info("Adding TF_CLI_ARGS_PLAN to environment variables: {}", tfCliArgsPlan.toString());
+                executorContext.getEnvironmentVariables().put("TF_CLI_ARGS_plan", tfCliArgsPlan.toString());
             }
         }
 

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -189,7 +189,7 @@ public class ExecutorService {
 
             if(!tfCliArgsPlan.isEmpty()) {
                 log.info("Adding TF_CLI_ARGS_PLAN to environment variables: {}", tfCliArgsPlan.toString());
-                executorContext.getEnvironmentVariables().put("TF_CLI_ARGS_plan", tfCliArgsPlan.toString());
+                executorContext.getEnvironmentVariables().putIfAbsent("TF_CLI_ARGS_plan", tfCliArgsPlan.toString());
             }
         }
 

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -848,6 +848,7 @@ public class RemoteTfeService {
         if(runsData.getData().getAttributes().get("target-addrs") != null) {
             log.info("Target Addresses {}", runsData.getData().getAttributes().get("target-addrs"));
             List<String> targetAddrs = (List<String>) runsData.getData().getAttributes().get("target-addrs");
+            log.info("Target Addresses Java List {}", targetAddrs);
         }
         //Optional<List<String>> targetList = Optional.ofNullable((List))
         Workspace workspace = workspaceRepository.getReferenceById(UUID.fromString(workspaceId));

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -913,7 +913,7 @@ public class RemoteTfeService {
                 address.setJob(job);
                 addressRepository.save(address);
             }
-            log.info("Target Addresses Java List {}", replaceAddres);
+            log.info("Replace Addresses Java List {}", replaceAddres);
         }
 
         scheduleJobService.createJobContext(job);

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -845,6 +845,11 @@ public class RemoteTfeService {
         log.info("Creating new Terrakube Job");
         log.info("Workspace {} Configuration {}", workspaceId, configurationId);
         log.info("isDestroy {} autoApply {}", isDestroy, autoApply);
+        if(runsData.getData().getAttributes().get("target-addrs") != null) {
+            log.info("Target Addresses {}", runsData.getData().getAttributes().get("target-addrs"));
+            List<String> targetAddrs = (List<String>) runsData.getData().getAttributes().get("target-addrs");
+        }
+        //Optional<List<String>> targetList = Optional.ofNullable((List))
         Workspace workspace = workspaceRepository.getReferenceById(UUID.fromString(workspaceId));
         String sourceTarGz = String.format("https://%s/remote/tfe/v2/configuration-versions/%s/terraformContent.tar.gz",
                 hostname, configurationId);

--- a/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/state/RemoteTfeService.java
@@ -904,7 +904,7 @@ public class RemoteTfeService {
         }
 
         if(runsData.getData().getAttributes().get("replace-addrs") != null) {
-            log.info("Target Addresses {}", runsData.getData().getAttributes().get("replace-addrs"));
+            log.info("Replace Addresses {}", runsData.getData().getAttributes().get("replace-addrs"));
             List<String> replaceAddres = (List<String>) runsData.getData().getAttributes().get("replace-addrs");
             for(String replace: replaceAddres){
                 Address address = new Address();

--- a/api/src/main/java/org/terrakube/api/repository/AddressRepository.java
+++ b/api/src/main/java/org/terrakube/api/repository/AddressRepository.java
@@ -1,4 +1,9 @@
 package org.terrakube.api.repository;
 
-public class AddressRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.terrakube.api.rs.job.address.Address;
+
+import java.util.UUID;
+
+public interface AddressRepository extends JpaRepository<Address, UUID> {
 }

--- a/api/src/main/java/org/terrakube/api/repository/AddressRepository.java
+++ b/api/src/main/java/org/terrakube/api/repository/AddressRepository.java
@@ -1,0 +1,4 @@
+package org.terrakube.api.repository;
+
+public class AddressRepository {
+}

--- a/api/src/main/java/org/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/org/terrakube/api/rs/job/Job.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.terrakube.api.plugin.security.audit.GenericAuditFields;
 import org.terrakube.api.rs.Organization;
 import org.terrakube.api.rs.hooks.job.JobManageHook;
+import org.terrakube.api.rs.job.address.Address;
 import org.terrakube.api.rs.job.step.Step;
 import org.terrakube.api.rs.workspace.Workspace;
 
@@ -101,6 +102,9 @@ public class Job extends GenericAuditFields {
     @UpdatePermission(expression = "user is a super service")
     @OneToMany(mappedBy = "job")
     private List<Step> step;
+
+    @OneToMany(mappedBy = "job")
+    private List<Address> address;
 
 }
 

--- a/api/src/main/java/org/terrakube/api/rs/job/address/Address.java
+++ b/api/src/main/java/org/terrakube/api/rs/job/address/Address.java
@@ -1,4 +1,54 @@
 package org.terrakube.api.rs.job.address;
 
-public class Address {
+import com.yahoo.elide.annotation.Exclude;
+import com.yahoo.elide.annotation.Include;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.terrakube.api.plugin.security.audit.GenericAuditFields;
+import org.terrakube.api.rs.IdConverter;
+import org.terrakube.api.rs.job.Job;
+import org.terrakube.api.rs.job.JobStatus;
+import org.terrakube.api.rs.job.LogStatus;
+
+import java.sql.Types;
+import java.util.UUID;
+import com.yahoo.elide.annotation.Exclude;
+import com.yahoo.elide.annotation.Include;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.terrakube.api.rs.IdConverter;
+import org.terrakube.api.rs.job.Job;
+import org.terrakube.api.rs.job.JobStatus;
+import org.terrakube.api.rs.job.LogStatus;
+
+import jakarta.persistence.*;
+
+        import java.sql.Types;
+import java.util.UUID;
+
+@Include
+@Getter
+@Setter
+@Entity(name = "address")
+public class Address extends GenericAuditFields {
+
+    @Id
+    @JdbcTypeCode(Types.VARCHAR)
+    @Convert(converter = IdConverter.class)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Exclude
+    @Column(name = "type")
+    @Enumerated(EnumType.STRING)
+    private AddressType type;
+
+    @ManyToOne
+    private Job job;
 }

--- a/api/src/main/java/org/terrakube/api/rs/job/address/Address.java
+++ b/api/src/main/java/org/terrakube/api/rs/job/address/Address.java
@@ -1,0 +1,4 @@
+package org.terrakube.api.rs.job.address;
+
+public class Address {
+}

--- a/api/src/main/java/org/terrakube/api/rs/job/address/AddressType.java
+++ b/api/src/main/java/org/terrakube/api/rs/job/address/AddressType.java
@@ -1,4 +1,6 @@
 package org.terrakube.api.rs.job.address;
 
 public enum AddressType {
+    REPLACE,
+    TARGET
 }

--- a/api/src/main/java/org/terrakube/api/rs/job/address/AddressType.java
+++ b/api/src/main/java/org/terrakube/api/rs/job/address/AddressType.java
@@ -1,0 +1,4 @@
+package org.terrakube.api.rs.job.address;
+
+public enum AddressType {
+}

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -73,4 +73,5 @@
     <include file="/db/changelog/local/changelog-2.25.1-webhook-events.xml" />
     <include file="/db/changelog/local/changelog-2.25.1-webhook-data.xml" />
     <include file="/db/changelog/local/changelog-2.25.1-webhook-tidyup.xml" />
+    <include file="/db/changelog/local/changelog-2.26.0-cli-address.xml" />
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.26.0-cli-address.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.26.0-cli-address.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-25-1-1" author="Stanley Zhang (stanley.zhang@ityin.net)">
+        <createTable tableName="webhook_event">
+            <column name="id" type="varchar(36)">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+            <column name="branch" type="varchar(512)" >
+                <constraints nullable="false"/>
+            </column> 
+            <column name="path" type="varchar(512)" >
+                <constraints nullable="false"/>
+            </column>
+            <column name="event" type="varchar(72)" >
+                <constraints nullable="false"/>
+            </column>
+            <column name="template_id" type="varchar(36)" >
+                <constraints nullable="false"/>
+            </column>
+            <column name="priority" type="int" />
+            <column name="webhook_id" type="varchar(36)" />
+            <column name="created_date" type="datetime" />
+            <column name="updated_date" type="datetime" />
+            <column name="created_by" type="varchar(128)" />
+            <column name="updated_by" type="varchar(128)" />
+        </createTable>
+        <addForeignKeyConstraint baseTableName="webhook_event" baseColumnNames="webhook_id"
+            constraintName="fk_webhook_event_webhook_id" referencedTableName="webhook"
+            referencedColumnNames="id" onDelete="CASCADE" />
+        <addForeignKeyConstraint baseTableName="webhook_event" baseColumnNames="template_id"
+            constraintName="fk_webhook_event_template_id" referencedTableName="template"
+            referencedColumnNames="id" onDelete="SET NULL" />
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.26.0-cli-address.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.26.0-cli-address.xml
@@ -3,35 +3,25 @@
     xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
-    <changeSet id="2-25-1-1" author="Stanley Zhang (stanley.zhang@ityin.net)">
-        <createTable tableName="webhook_event">
+    <changeSet id="2-26-0-1" author="alfespa17@gmail.com">
+        <createTable tableName="address">
             <column name="id" type="varchar(36)">
                 <constraints primaryKey="true" nullable="false" />
             </column>
-            <column name="branch" type="varchar(512)" >
+            <column name="name" type="varchar(256)" >
                 <constraints nullable="false"/>
             </column> 
-            <column name="path" type="varchar(512)" >
+            <column name="type" type="varchar(16)" >
                 <constraints nullable="false"/>
             </column>
-            <column name="event" type="varchar(72)" >
-                <constraints nullable="false"/>
-            </column>
-            <column name="template_id" type="varchar(36)" >
-                <constraints nullable="false"/>
-            </column>
-            <column name="priority" type="int" />
-            <column name="webhook_id" type="varchar(36)" />
             <column name="created_date" type="datetime" />
             <column name="updated_date" type="datetime" />
             <column name="created_by" type="varchar(128)" />
             <column name="updated_by" type="varchar(128)" />
+            <column name="job_id" type="varchar(36)" />
         </createTable>
-        <addForeignKeyConstraint baseTableName="webhook_event" baseColumnNames="webhook_id"
-            constraintName="fk_webhook_event_webhook_id" referencedTableName="webhook"
-            referencedColumnNames="id" onDelete="CASCADE" />
-        <addForeignKeyConstraint baseTableName="webhook_event" baseColumnNames="template_id"
-            constraintName="fk_webhook_event_template_id" referencedTableName="template"
+        <addForeignKeyConstraint baseTableName="address" baseColumnNames="job_id"
+            constraintName="fk_address_job_id" referencedTableName="job"
             referencedColumnNames="id" onDelete="SET NULL" />
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION

### Without target flag
```shell
user@pop-os:~/git/simple-terraform$ terraform plan

Running plan in Terraform Cloud. Output will stream here. Pressing Ctrl-C
will stop streaming the logs, but will not stop the plan running remotely.

Preparing the remote plan...

To view this run in a browser, visit:
https://8080-azbuilder-terrakube-zas3imae35e.ws-us118.gitpod.io/app/simple/simple_test/runs/run-1

Waiting for the plan to start...

***************************************
Running Terraform PLAN
***************************************

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # null_resource.next will be created
  + resource "null_resource" "next" {
      + id = (known after apply)
    }

  # null_resource.next2 will be created
  + resource "null_resource" "next2" {
      + id = (known after apply)
    }

  # null_resource.next3 will be created
  + resource "null_resource" "next3" {
      + id = (known after apply)
    }

  # null_resource.next4 will be created
  + resource "null_resource" "next4" {
      + id = (known after apply)
    }

  # null_resource.previous will be created
  + resource "null_resource" "previous" {
      + id = (known after apply)
    }

  # time_sleep.wait_30_seconds will be created
  + resource "time_sleep" "wait_30_seconds" {
      + create_duration  = "30s"
      + destroy_duration = "45s"
      + id               = (known after apply)
    }

  # module.time_module.random_integer.time will be created
  + resource "random_integer" "time" {
      + id     = (known after apply)
      + max    = 5
      + min    = 1
      + result = (known after apply)
    }

Plan: 7 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + creation_time = "30s"
  + fake_data     = {
      + data     = "Hello World"
      + resource = {
          + resource1 = "fake"
        }
    }

```

### With target flag

```shell
user@pop-os:~/git/simple-terraform$ terraform plan -target=time_sleep.wait_30_seconds

Running plan in Terraform Cloud. Output will stream here. Pressing Ctrl-C
will stop streaming the logs, but will not stop the plan running remotely.

Preparing the remote plan...

To view this run in a browser, visit:
https://8080-azbuilder-terrakube-zas3imae35e.ws-us118.gitpod.io/app/simple/simple_test/runs/run-2

Waiting for the plan to start...

***************************************
Running Terraform PLAN
***************************************

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # null_resource.previous will be created
  + resource "null_resource" "previous" {
      + id = (known after apply)
    }

  # time_sleep.wait_30_seconds will be created
  + resource "time_sleep" "wait_30_seconds" {
      + create_duration  = "30s"
      + destroy_duration = "45s"
      + id               = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + creation_time = "30s"
╷
│ Warning: Resource targeting is in effect
│ 
│ You are creating a plan with the -target option, which means that the
│ result of this plan may not represent all of the changes requested by the
│ current configuration.
│ 
│ The -target option is not for routine use, and is provided only for
│ exceptional situations such as recovering from errors or mistakes, or when
│ Terraform specifically suggests to use it as part of an error message.

```

### Replace flag

```shell
user@pop-os:~/git/simple-terraform$ terraform plan -replace=time_sleep.wait_30_seconds

Running plan in Terraform Cloud. Output will stream here. Pressing Ctrl-C
will stop streaming the logs, but will not stop the plan running remotely.

Preparing the remote plan...

To view this run in a browser, visit:
https://8080-azbuilder-terrakube-zas3imae35e.ws-us118.gitpod.io/app/simple/simple_test/runs/run-4

Waiting for the plan to start...

***************************************
Running Terraform PLAN
***************************************
module.time_module.random_integer.time: Refreshing state... [id=3]
null_resource.previous: Refreshing state... [id=8453405252639364908]
time_sleep.wait_30_seconds: Refreshing state... [id=2025-03-17T19:37:42Z]
null_resource.next4: Refreshing state... [id=695527150358536858]
null_resource.next: Refreshing state... [id=5608491521324904523]
null_resource.next3: Refreshing state... [id=7978755604606084072]
null_resource.next2: Refreshing state... [id=1031510302611639606]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # time_sleep.wait_30_seconds will be replaced, as requested
-/+ resource "time_sleep" "wait_30_seconds" {
      ~ id               = "2025-03-17T19:37:42Z" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

```