### PR TITLE
fix: Remove mysql code

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -25,7 +25,6 @@
         <rest-assured.version>5.5.1</rest-assured.version>
         <!--groovy.version>4.0.20</groovy.version-->
         <postgresql.version>42.7.5</postgresql.version>
-        <mysql.version>9.2.0</mysql.version>
         <mockserver-spring-test-listener.version>5.15.0</mockserver-spring-test-listener.version>
         <snakeyaml.version>2.4</snakeyaml.version>
         <quartz.version>2.5.0</quartz.version>
@@ -225,11 +224,6 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>${postgresql.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
-            <version>${mysql.version}</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>

--- a/api/src/main/java/org/terrakube/api/plugin/datasource/DataSourceAutoConfiguration.java
+++ b/api/src/main/java/org/terrakube/api/plugin/datasource/DataSourceAutoConfiguration.java
@@ -53,14 +53,6 @@ public class DataSourceAutoConfiguration {
                 ds.setSslMode(dataSourceConfigurationProperties.getSslMode());
                 dataSource = ds;
                 break;
-            case MYSQL:
-                DriverManagerDataSource mysql = new DriverManagerDataSource();
-                mysql.setDriverClassName("com.mysql.cj.jdbc.Driver");
-                mysql.setUrl(String.format("jdbc:mysql://%s:%s/%s?serverTimezone=UTC", dataSourceConfigurationProperties.getHostname(), dataSourceConfigurationProperties.getDatabasePort(), dataSourceConfigurationProperties.getDatabaseName()));
-                mysql.setUsername(dataSourceConfigurationProperties.getDatabaseUser());
-                mysql.setPassword(dataSourceConfigurationProperties.getDatabasePassword());
-                dataSource = mysql;
-                break;
             default:
                 DriverManagerDataSource h2DataSource = new DriverManagerDataSource();
                 h2DataSource.setDriverClassName("org.h2.Driver");

--- a/api/src/main/java/org/terrakube/api/plugin/datasource/DataSourceType.java
+++ b/api/src/main/java/org/terrakube/api/plugin/datasource/DataSourceType.java
@@ -5,6 +5,5 @@ public enum DataSourceType {
     SQL_AZURE,
     AWS,
     GCP,
-    POSTGRESQL,
-    MYSQL,
+    POSTGRESQL
 }


### PR DESCRIPTION
MYSQL 8.0  looks like is no longer working and it has not been tested in a long time and maybe it will require several code changes that could impact postgresql and mssql

fix #1909