### PR TITLE
fix: Update liquibase scripts to fix issue when running in SQL Azure

### DIFF
--- a/api/src/main/resources/db/changelog/local/changelog-2.25.1-webhook-events.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.25.1-webhook-events.xml
@@ -32,6 +32,6 @@
             referencedColumnNames="id" onDelete="CASCADE" />
         <addForeignKeyConstraint baseTableName="webhook_event" baseColumnNames="template_id"
             constraintName="fk_webhook_event_template_id" referencedTableName="template"
-            referencedColumnNames="id" onDelete="SET NULL" />
+            referencedColumnNames="id"/>
     </changeSet>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.25.1-webhook-tidyup.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.25.1-webhook-tidyup.xml
@@ -4,6 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
     <changeSet id="2-25-1-21" author="Stanley Zhang (stanley.zhang@ityin.net)">
+        <dropForeignKeyConstraint  baseTableName="webhook"
+                                   constraintName="fk_webhook_template_id"/>
         <dropColumn tableName="webhook">
             <column name="branch" />
             <column name="path" />

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>2.25.0</revision>
+        <revision>2.26.0</revision>
         <sonar.organization>azbuilder</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.project.key>AzBuilder_azb-server</sonar.project.key>


### PR DESCRIPTION
For some reason liquibase scripts did run correctly in postgresql but not in sql azure, this PR update the script to fix the issue.

Changing the scripts update the md5sum inside the table `DATABASECHANGELOG` that is manage by liquibase, that will require to execute the following manually:

```shell
UPDATE DATABASECHANGELOG SET MD5SUM='9:a3d5f8c336d36a036e7c150abea93732' WHERE ID='2-25-1-1';
UPDATE DATABASECHANGELOG SET MD5SUM='9:3a462f1637e96c42cf298f2e74ffc934' WHERE ID='2-25-1-21';
```

> The above will only impact user using postgresql that deployed version 2.26.0-beta.2 or 2.26.0-beta.3


I tried adding a new script to fix/change the values automatically but it is not possible

```xml
<?xml version="1.0" encoding="UTF-8"?>
<databaseChangeLog
    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
    <changeSet id="2-25-1-1-fix" author="alfespa17@gmail.com">
        <sql dbms="postgresql">
            UPDATE DATABASECHANGELOG SET MD5SUM='9:a3d5f8c336d36a036e7c150abea93732' WHERE ID='2-25-1-1';
        </sql>
        <sql dbms="postgresql">
            UPDATE DATABASECHANGELOG SET MD5SUM='9:3a462f1637e96c42cf298f2e74ffc934' WHERE ID='2-25-1-21';
        </sql>
    </changeSet>
</databaseChangeLog>
```

Adding changelog changelog-2.25.1-webhook-data-fix-liquibase.xml:
```xml
    <include file="/db/changelog/local/changelog-2.25.0-workspace-access.xml"/>
    <include file="/db/changelog/local/changelog-2.25.1-webhook-events.xml" />
    <include file="/db/changelog/local/changelog-2.25.1-webhook-data-fix-liquibase.xml" />
    <include file="/db/changelog/local/changelog-2.25.1-webhook-data.xml" />
```

Liquibase validate the file checksum always

```
2025-03-21T15:35:43.948Z  INFO 1 --- [           main] liquibase.ui                             : ERROR: Exception Primary Class:  ValidationFailedException
2025-03-21T15:35:43.948Z  INFO 1 --- [           main] liquibase.ui                             : ERROR: Exception Primary Reason:  Validation Failed:
     2 changesets check sum
          db/changelog/local/changelog-2.25.1-webhook-events.xml::2-25-1-1::Stanley Zhang (stanley.zhang@ityin.net) was: 9:748ad7ef6346910bec2088a64ec949bc but is now: 9:a3d5f8c336d36a036e7c150abea93732
          db/changelog/local/changelog-2.25.1-webhook-tidyup.xml::2-25-1-21::Stanley Zhang (stanley.zhang@ityin.net) was: 9:f5fbbbb911470fd982c709c3de271d5c but is now: 9:3a462f1637e96c42cf298f2e74ffc934

2025-03-21T15:35:43.948Z  INFO 1 --- [           main] liquibase.ui                             : ERROR: Exception Primary Source:  4.31.1
```