### PR TITLE
fix: Make footer year dynamic by using new Date().getFullYear() instead of static year

### DIFF
--- a/ui/src/domain/Home/App.tsx
+++ b/ui/src/domain/Home/App.tsx
@@ -139,7 +139,7 @@ const App = () => {
           <Route path="/organizations/:orgid/settings/tags" element={<OrganizationSettings selectedTab="7" />} />
           <Route path="/organizations/:orgid/settings/actions" element={<OrganizationSettings selectedTab="8" />} />
         </Routes>
-        <Footer style={{ textAlign: "center" }}>Terrakube {window._env_.REACT_APP_TERRAKUBE_VERSION} ©2025</Footer>
+        <Footer style={{ textAlign: "center" }}>Terrakube {window._env_.REACT_APP_TERRAKUBE_VERSION} ©{new Date().getFullYear()}</Footer>
       </Layout>
     </Router>
   );


### PR DESCRIPTION
Hello @alfespa17, @jcanizalez,

This pull request updates the footer to dynamically display the current year instead of using a hardcoded value.
The change replaces the static year 2025 with {new Date().getFullYear()}, ensuring the footer is always up-to-date.

Let me know if there's anything else you'd like me to improve.