### PR TITLE
feat: mount pvc on jobs

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
@@ -140,8 +140,8 @@ public class EphemeralExecutorService {
             Volume sharedVolume = new Volume();
             sharedVolume.setName(PluginVolumeName);
             PersistentVolumeClaimVolumeSource pvcSource = new PersistentVolumeClaimVolumeSource();
-            Optional<String> configPVCClaimName = Optional.ofNullable(executorContext.getEnvironmentVariables().get(PVC_CLAIM_NAME));
-            pvcSource.setClaimName(configPVCClaimName.orElse("terrakube-plugin-pvc"));
+            String pvcClaimName = executorContext.getEnvironmentVariables().getOrDefault(PVC_CLAIM_NAME, "terrakube-plugin-pvc");
+            pvcSource.setClaimName(pvcClaimName);
             sharedVolume.setPersistentVolumeClaim(pvcSource);
 
             VolumeMount sharedVolumeMount = new VolumeMount();


### PR DESCRIPTION
Hi @alfespa17 !

I'd like to propose this small change for ephemeral agents. The idea is that we use a Persistent volume claim (PVC) that we mount on our jobs at each run. Then since `TF_PLUGIN_CACHE_DIR` is set, tofu "automatically" comes to grab the content of this folder in case the provider was previously downloaded. 

NB: PVC must be defined in the Terrakube Helm charts. Terrakube app should not be responsible for PVC provisionning.

Lemme know your thoughts
PS: not tested