### PR TITLE
feat:  revamped runs section in workspaces

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -320,7 +320,7 @@ public class ScheduleJob implements org.quartz.Job {
     }
 
     private void updateJobStatusOnVcs(Job job, JobStatus jobStatus) {
-        if (job.getVia().equals(JobVia.UI.name()) || job.getVia().equals(JobVia.CLI.name())) {
+        if (job.getVia().equals(JobVia.UI.name()) || job.getVia().equals(JobVia.CLI.name()) || job.getVia().equals(JobVia.Schedule.name())) {
             return; 
         }
         

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJobTrigger.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/ScheduleJobTrigger.java
@@ -9,6 +9,7 @@ import org.terrakube.api.repository.ScheduleRepository;
 import org.terrakube.api.repository.TemplateRepository;
 import org.terrakube.api.rs.job.Job;
 import org.terrakube.api.rs.job.JobStatus;
+import org.terrakube.api.rs.job.JobVia;
 import org.terrakube.api.rs.template.Template;
 import org.terrakube.api.rs.workspace.schedule.Schedule;
 import org.quartz.JobExecutionContext;
@@ -59,6 +60,7 @@ public class ScheduleJobTrigger implements org.quartz.Job {
             job.setStatus(JobStatus.pending);
             job.setCreatedBy("serviceAccount");
             job.setUpdatedBy("serviceAccount");
+            job.setVia(JobVia.Schedule.name());
             Date triggerDate = new Date(System.currentTimeMillis());
             job.setCreatedDate(triggerDate);
             job.setUpdatedDate(triggerDate);

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/inactive/InactiveJobs.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/inactive/InactiveJobs.java
@@ -56,7 +56,7 @@ public class InactiveJobs implements org.quartz.Job {
                             stepRepository.save(step);
                         }
                     }
-                    if (job.getVia().equals(JobVia.CLI.name()) || job.getVia().equals(JobVia.UI.name()) ) {
+                    if (job.getVia().equals(JobVia.CLI.name()) || job.getVia().equals(JobVia.UI.name()) || job.getVia().equals(JobVia.Schedule.name()) ) {
                         log.info("No information to update for job", job.getId());
                         return;
                     } else {

--- a/api/src/main/java/org/terrakube/api/rs/job/JobVia.java
+++ b/api/src/main/java/org/terrakube/api/rs/job/JobVia.java
@@ -5,5 +5,6 @@ public enum JobVia {
    CLI,
    Github,
    Gitlab,
-   Bitbucket
+   Bitbucket,
+   Schedule
 }

--- a/ui/src/domain/Modules/List.tsx
+++ b/ui/src/domain/Modules/List.tsx
@@ -1,5 +1,5 @@
 import { ClockCircleOutlined, CloudOutlined, CloudUploadOutlined, DownloadOutlined } from "@ant-design/icons";
-import { Breadcrumb, Button, Card, Input, Layout, List, Space, Tag, Typography, theme, Row, Col } from "antd";
+import { Button, Card, Input, Layout, List, Space, Tag, Typography, Row, Col } from "antd";
 import { DateTime } from "luxon";
 import { useEffect, useState } from "react";
 import { IconContext } from "react-icons";
@@ -34,10 +34,6 @@ export const ModuleList = ({ setOrganizationName, organizationName }: Props) => 
   const [filteredModules, setFilteredModules] = useState<FlatModule[]>([]);
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
-
-  const {
-    token: { colorBgContainer },
-  } = theme.useToken();
 
   const onSearch = (value: string) => {
     applyFilters(value);
@@ -101,13 +97,20 @@ export const ModuleList = ({ setOrganizationName, organizationName }: Props) => 
       ]}
       fluid
       actions={
-        <Button type="primary" htmlType="button" icon={<CloudUploadOutlined />} onClick={handlePublish}>
-          Publish module
-        </Button>
+        <Space>
+          <Button type="primary" htmlType="button" icon={<CloudUploadOutlined />} onClick={handlePublish}>
+            Publish module
+          </Button>
+        </Space>
       }
     >
-      <div className="site-layout-content">
-        <Search placeholder="Filter modules" onSearch={onSearch} allowClear style={{ marginBottom: "16px" }} />
+      <div style={{ width: "100%", marginTop: "24px" }}>
+        <Search
+          placeholder="Filter modules"
+          onSearch={onSearch}
+          allowClear
+          style={{ width: "100%", marginBottom: "16px" }}
+        />
         <List
           split={false}
           dataSource={filteredModules}

--- a/ui/src/domain/Workspaces/Details.tsx
+++ b/ui/src/domain/Workspaces/Details.tsx
@@ -76,6 +76,7 @@ import { WorkspaceGeneral } from "./Settings/General";
 import { WorkspaceWebhook } from "./Settings/Webhook.jsx";
 import { getIaCIconById, getIaCNameById, renderVCSLogo } from "./Workspaces";
 import "./Workspaces.css";
+import RunList from "@/modules/workspaces/components/RunList";
 const { Paragraph } = Typography;
 
 const include = {
@@ -731,63 +732,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
                   {jobVisible ? (
                     <DetailsJob jobId={jobId!} />
                   ) : (
-                    <div>
-                      <h3>Run List</h3>
-                      <List
-                        itemLayout="horizontal"
-                        dataSource={jobs.sort((a, b) => parseInt(a.id) - parseInt(b.id)).reverse()}
-                        renderItem={(item) => (
-                          <List.Item
-                            extra={
-                              <div className="textLeft">
-                                <Tag
-                                  icon={
-                                    item.status == "completed" ? (
-                                      <CheckCircleOutlined />
-                                    ) : item.status == "noChanges" ? (
-                                      <CheckCircleOutlined />
-                                    ) : item.status == "running" ? (
-                                      <SyncOutlined spin />
-                                    ) : item.status === "waitingApproval" ? (
-                                      <ExclamationCircleOutlined />
-                                    ) : item.status === "cancelled" ? (
-                                      <StopOutlined />
-                                    ) : item.status === "failed" ? (
-                                      <StopOutlined />
-                                    ) : (
-                                      <ClockCircleOutlined />
-                                    )
-                                  }
-                                  color={item.statusColor}
-                                >
-                                  {item.status}
-                                </Tag>{" "}
-                                <br />
-                                <span className="metadata">{item.latestChange}</span>
-                              </div>
-                            }
-                          >
-                            <List.Item.Meta
-                              style={{ margin: "0px", padding: "0px" }}
-                              avatar={<Avatar shape="square" icon={<UserOutlined />} />}
-                              title={<a onClick={() => handleClick(item.id)}>{item.title}</a>}
-                              description={
-                                <span>
-                                  {" "}
-                                  #job-{item.id} |
-                                  {item.commitId !== "000000000" ? (
-                                    <> commitId {item.commitId?.substring(0, 6)} </>
-                                  ) : (
-                                    ""
-                                  )}
-                                  | <b>{item.createdBy}</b> triggered via {item.via || "UI"}
-                                </span>
-                              }
-                            />
-                          </List.Item>
-                        )}
-                      />
-                    </div>
+                    <RunList jobs={jobs} onRunClick={handleClick} />
                   )}
                 </TabPane>
                 <TabPane tab="States" key="3" disabled={!manageState}>

--- a/ui/src/domain/types.ts
+++ b/ui/src/domain/types.ts
@@ -74,12 +74,14 @@ export enum JobStatus {
   Failed = "failed",
   Unknown = "unknown",
 }
+
 export enum JobVia {
   Ui = "UI",
   Cli = "CLI",
   Github = "Github",
   Gitlab = "Gitlab",
   Bitbucket = "Bitbucket",
+  Schedule = "Schedule"
 }
 
 export type JobAttributes = {
@@ -100,10 +102,14 @@ export type JobStep = {
 };
 export type FlatJob = {
   id: string;
-  latestChange: string;
   title: string;
+  status: JobStatus;
   statusColor: string;
-} & JobAttributes;
+  latestChange: string;
+  commitId?: string;
+  createdBy: string;
+  via?: JobVia;
+};
 // VCS
 
 export enum VcsType {

--- a/ui/src/modules/workspaces/components/RunFilter.tsx
+++ b/ui/src/modules/workspaces/components/RunFilter.tsx
@@ -1,0 +1,232 @@
+import {
+  BarsOutlined,
+  ExclamationCircleOutlined,
+  StopOutlined,
+  SyncOutlined,
+  CheckCircleOutlined,
+  ClockCircleOutlined,
+  PauseCircleOutlined,
+} from "@ant-design/icons";
+import { Card, Row, Col, Segmented, theme, Select, Flex } from "antd";
+import { FlatJob, JobStatus } from "../../../domain/types";
+import { useEffect, useState, useMemo, ReactNode } from "react";
+
+type Props = {
+  jobs: FlatJob[];
+  onFiltered: (jobs: FlatJob[]) => void;
+  applyFilter: (jobs: FlatJob[], filter: string) => FlatJob[];
+  templateNames: {[key: string]: string};
+};
+
+type StatusCount = {
+  [key: string]: number;
+};
+
+type StatusIconMap = {
+  [key in JobStatus | 'All']: ReactNode;
+};
+
+// Storage keys for persisting filter state
+const RUNS_FILTER_KEY = "runsFilterValue";
+const RUNS_TEMPLATE_FILTER_KEY = "runsTemplateFilter";
+
+// Map status to their icons and colors
+const statusIcons: StatusIconMap = {
+  [JobStatus.Completed]: <CheckCircleOutlined style={{ color: "#2eb039" }} />,
+  [JobStatus.NoChanges]: <CheckCircleOutlined style={{ color: "#2eb039" }} />,
+  [JobStatus.Running]: <SyncOutlined style={{ color: "#108ee9" }} />,
+  [JobStatus.WaitingApproval]: <ExclamationCircleOutlined style={{ color: "#fa8f37" }} />,
+  [JobStatus.Pending]: <PauseCircleOutlined style={{ color: "#808080" }} />,
+  [JobStatus.Cancelled]: <StopOutlined style={{ color: "#FB0136" }} />,
+  [JobStatus.Failed]: <StopOutlined style={{ color: "#FB0136" }} />,
+  [JobStatus.Approved]: <CheckCircleOutlined style={{ color: "#2eb039" }} />,
+  [JobStatus.Queue]: <ClockCircleOutlined style={{ color: "#808080" }} />,
+  [JobStatus.Rejected]: <StopOutlined style={{ color: "#FB0136" }} />,
+  [JobStatus.Unknown]: <ExclamationCircleOutlined style={{ color: "#808080" }} />,
+  [JobStatus.NotExecuted]: <ClockCircleOutlined style={{ color: "#808080" }} />,
+  'All': <BarsOutlined />
+};
+
+// Helper function to capitalize first letter
+const capitalize = (str: string): string => {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+};
+
+// Safely parse JSON with a fallback value
+const safeJsonParse = (jsonString: string | null, fallback: any): any => {
+  if (!jsonString) return fallback;
+  
+  try {
+    return JSON.parse(jsonString);
+  } catch (e) {
+    console.warn('Failed to parse JSON:', e);
+    return fallback;
+  }
+};
+
+// Statuses to always show in the filter
+const alwaysShowStatuses = [
+  'All',
+  JobStatus.WaitingApproval,
+  JobStatus.Failed,
+  JobStatus.Running,
+  JobStatus.Pending,
+  JobStatus.Completed
+];
+
+export default function RunFilter({ jobs, onFiltered, applyFilter, templateNames }: Props) {
+  const {
+    token: { colorBgContainer },
+  } = theme.useToken();
+
+  const [statusFilter, setStatusFilter] = useState<string>(
+    sessionStorage.getItem(RUNS_FILTER_KEY) || "All"
+  );
+  const [templateFilters, setTemplateFilters] = useState<string[]>(
+    safeJsonParse(sessionStorage.getItem(RUNS_TEMPLATE_FILTER_KEY), [])
+  );
+  const [statusCounts, setStatusCounts] = useState<StatusCount>({});
+
+  // Save filter values to session storage when they change
+  useEffect(() => {
+    sessionStorage.setItem(RUNS_FILTER_KEY, statusFilter);
+  }, [statusFilter]);
+
+  useEffect(() => {
+    sessionStorage.setItem(RUNS_TEMPLATE_FILTER_KEY, JSON.stringify(templateFilters));
+  }, [templateFilters]);
+
+  // Get template options for the dropdown
+  const templateOptions = useMemo(() => {
+    const uniqueTemplates = new Set<string>();
+    
+    jobs.forEach(job => {
+      const templateId = (job as any).templateReference;
+      if (templateId) {
+        uniqueTemplates.add(templateId);
+      }
+    });
+    
+    return Array.from(uniqueTemplates).map(templateId => ({
+      label: templateNames[templateId] || `Template ${templateId}`,
+      value: templateId
+    }));
+  }, [jobs, templateNames]);
+
+  // Count the number of jobs in each status and track available statuses
+  useEffect(() => {
+    const counts: StatusCount = { All: jobs.length };
+    
+    // Initialize counts for statuses we always want to show
+    alwaysShowStatuses.forEach(status => {
+      if (status !== 'All') {
+        counts[status] = 0;
+      }
+    });
+    
+    // Count jobs by status
+    jobs.forEach(job => {
+      if (counts[job.status]) {
+        counts[job.status]++;
+      } else {
+        counts[job.status] = 1;
+      }
+    });
+    
+    setStatusCounts(counts);
+  }, [jobs]);
+
+  // Generate filter options based on status configuration
+  const filterOptions = useMemo(() => {
+    const options = [];
+    
+    // Add the statuses we always want to show first, in the specified order
+    for (const status of alwaysShowStatuses) {
+      const displayText = status === 'All' ? 'All' : capitalize(status);
+      options.push({
+        label: `${displayText} ${statusCounts[status] || 0}`,
+        value: status,
+        icon: statusIcons[status as JobStatus]
+      });
+    }
+
+    // Add any additional statuses that exist in the data and aren't already added
+    Object.keys(statusCounts).forEach(status => {
+      if (!alwaysShowStatuses.includes(status as JobStatus | 'All') && statusCounts[status] > 0) {
+        const displayText = status === 'All' ? 'All' : capitalize(status);
+        options.push({
+          label: `${displayText} ${statusCounts[status]}`,
+          value: status,
+          icon: statusIcons[status as JobStatus]
+        });
+      }
+    });
+
+    return options;
+  }, [statusCounts]);
+
+  // Apply filters when filter or jobs change
+  useEffect(() => {
+    // Apply status filter
+    let filteredJobs = applyFilter(jobs, statusFilter);
+    
+    // Apply template filters
+    if (templateFilters.length > 0) {
+      filteredJobs = filteredJobs.filter(job => {
+        const templateId = (job as any).templateReference;
+        return templateId && templateFilters.includes(templateId);
+      });
+    }
+    
+    onFiltered(filteredJobs);
+  }, [statusFilter, templateFilters, jobs, applyFilter, onFiltered]);
+
+  // Handle filter changes
+  const handleStatusFilterChange = (value: string) => {
+    setStatusFilter(value);
+  };
+
+  const handleTemplateFilterChange = (values: string[]) => {
+    setTemplateFilters(values);
+  };
+
+  return (
+    <Card
+      style={{ marginBottom: "16px", background: colorBgContainer }}
+      styles={{
+        body: {
+          padding: "5px 10px",
+        },
+      }}
+    >
+      <Row align="middle">
+        <Col span={16}>
+          <Segmented
+            onChange={handleStatusFilterChange}
+            value={statusFilter}
+            options={filterOptions}
+          />
+        </Col>
+        <Col span={8}>
+          <Flex justify="end">
+            <Select 
+              mode="multiple"
+              style={{ width: 250 }}
+              value={templateFilters}
+              onChange={handleTemplateFilterChange}
+              options={templateOptions}
+              placeholder="Filter by template"
+              maxTagCount="responsive"
+              showSearch
+              allowClear
+              optionFilterProp="label"
+              filterOption={(input, option) =>
+                (option?.label?.toString() || '').toLowerCase().includes(input.toLowerCase())
+              }
+            />
+          </Flex>
+        </Col>
+      </Row>
+    </Card>
+  );
+} 

--- a/ui/src/modules/workspaces/components/RunList.tsx
+++ b/ui/src/modules/workspaces/components/RunList.tsx
@@ -1,0 +1,220 @@
+import { List, Avatar, Tag, Pagination, Tooltip } from "antd";
+import { UserOutlined } from "@ant-design/icons";
+import {
+  CheckCircleOutlined,
+  ClockCircleOutlined,
+  ExclamationCircleOutlined,
+  StopOutlined,
+  SyncOutlined,
+} from "@ant-design/icons";
+import { FlatJob, JobStatus } from "../../../domain/types";
+import { useState, useEffect, useCallback } from "react";
+import axiosInstance from "../../../config/axiosConfig";
+import { ORGANIZATION_ARCHIVE } from "../../../config/actionTypes";
+import RunFilter from "./RunFilter";
+
+// Storage key for persisting pagination state
+const RUNS_PAGE_KEY = "runsCurrentPage";
+const RUNS_FILTER_KEY = "runsFilterValue";
+const RUNS_TEMPLATE_FILTER_KEY = "runsTemplateFilter";
+
+// Helper function to format date
+const formatDate = (dateString?: string) => {
+  if (!dateString) return '';
+  try {
+    const date = new Date(dateString);
+    return date.toLocaleString();
+  } catch (e) {
+    return dateString;
+  }
+};
+
+// Safely parse JSON with a fallback value
+const safeJsonParse = (jsonString: string | null, fallback: any): any => {
+  if (!jsonString) return fallback;
+  
+  try {
+    return JSON.parse(jsonString);
+  } catch (e) {
+    console.warn('Failed to parse JSON:', e);
+    return fallback;
+  }
+};
+
+type Props = {
+  jobs: FlatJob[];
+  onRunClick: (id: string) => void;
+};
+
+export default function RunList({ jobs, onRunClick }: Props) {
+  const [currentPage, setCurrentPage] = useState<number>(
+    parseInt(sessionStorage.getItem(RUNS_PAGE_KEY) || "1")
+  );
+  const pageSize = 10;
+  const [templateNames, setTemplateNames] = useState<{[key: string]: string}>({});
+  const organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
+  const [filteredJobs, setFilteredJobs] = useState<FlatJob[]>(jobs);
+
+  // Save pagination state to session storage
+  useEffect(() => {
+    sessionStorage.setItem(RUNS_PAGE_KEY, currentPage.toString());
+  }, [currentPage]);
+
+  // Load all templates to map template IDs to names
+  useEffect(() => {
+    axiosInstance.get(`organization/${organizationId}/template`).then((response) => {
+      const templates = response.data.data;
+      const templateMap: {[key: string]: string} = {};
+
+      templates.forEach((template: any) => {
+        templateMap[template.id] = template.attributes.name;
+      });
+
+      setTemplateNames(templateMap);
+    });
+  }, [organizationId]);
+
+  // Filter jobs based on the current filter
+  const applyFilter = useCallback((jobsToFilter: FlatJob[], filterValue: string) => {
+    if (filterValue !== "All") {
+      return jobsToFilter.filter(job => job.status === filterValue);
+    }
+    return jobsToFilter;
+  }, []);
+
+  // Apply all filters (status and templates)
+  const applyAllFilters = useCallback((jobsToFilter: FlatJob[]) => {
+    const statusFilter = sessionStorage.getItem(RUNS_FILTER_KEY) || "All";
+    const templateFiltersStr = sessionStorage.getItem(RUNS_TEMPLATE_FILTER_KEY) || "[]";
+    const templateFilters = safeJsonParse(templateFiltersStr, []) as string[];
+    
+    // Apply status filter
+    let filtered = applyFilter(jobsToFilter, statusFilter);
+    
+    // Apply template filters
+    if (templateFilters.length > 0) {
+      filtered = filtered.filter(job => {
+        const templateId = (job as any).templateReference;
+        return templateId && templateFilters.includes(templateId);
+      });
+    }
+    
+    return filtered;
+  }, [applyFilter]);
+
+  // Update filtered jobs when the jobs prop changes, applying all filters
+  useEffect(() => {
+    setFilteredJobs(applyAllFilters(jobs));
+  }, [jobs, applyAllFilters]);
+
+  const getTemplateName = (job: FlatJob) => {
+    const templateId = (job as any).templateReference;
+    if (templateId && templateNames[templateId]) {
+      return templateNames[templateId];
+    }
+    return "Terraform";
+  };
+
+  const renderStatusTag = (status: JobStatus, statusColor: string) => (
+    <Tag
+      icon={
+        status === JobStatus.Completed ? (
+          <CheckCircleOutlined />
+        ) : status === JobStatus.NoChanges ? (
+          <CheckCircleOutlined />
+        ) : status === JobStatus.Running ? (
+          <SyncOutlined spin />
+        ) : status === JobStatus.WaitingApproval ? (
+          <ExclamationCircleOutlined />
+        ) : status === JobStatus.Cancelled ? (
+          <StopOutlined />
+        ) : status === JobStatus.Failed ? (
+          <StopOutlined />
+        ) : (
+          <ClockCircleOutlined />
+        )
+      }
+      color={statusColor}
+    >
+      {status.toLowerCase()}
+    </Tag>
+  );
+
+  const sortedJobs = filteredJobs.sort((a, b) => parseInt(a.id) - parseInt(b.id)).reverse();
+  const paginatedJobs = sortedJobs.slice((currentPage - 1) * pageSize, currentPage * pageSize);
+  
+  // Find the job with highest ID to mark as current
+  const highestId = sortedJobs.length > 0 ? sortedJobs[0].id : "-1";
+
+  // Reset to first page when filters change, but not when jobs update due to refresh
+  useEffect(() => {
+    const savedPage = parseInt(sessionStorage.getItem(RUNS_PAGE_KEY) || "1");
+    if (savedPage > 1 && Math.ceil(filteredJobs.length / pageSize) < savedPage) {
+      setCurrentPage(1);
+    }
+  }, [filteredJobs]);
+
+  // Page change handler
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  return (
+    <div>
+      <h3>Run List</h3>
+      <RunFilter 
+        jobs={jobs} 
+        onFiltered={setFilteredJobs} 
+        applyFilter={applyFilter}
+        templateNames={templateNames}
+      />
+      <List
+        itemLayout="horizontal"
+        dataSource={paginatedJobs}
+        renderItem={(item) => (
+          <List.Item
+            actions={[
+              <div key="status" style={{ textAlign: 'right' }}>
+                {renderStatusTag(item.status, item.statusColor)}
+                <div>
+                  <Tooltip title={formatDate((item as any).createdDate)}>
+                    <span className="metadata">{item.latestChange}</span>
+                  </Tooltip>
+                </div>
+              </div>
+            ]}
+          >
+            <List.Item.Meta
+              avatar={<Avatar shape="square" icon={<UserOutlined />} />}
+              title={
+                <span>
+                  <a onClick={() => onRunClick(item.id)} style={{ color: 'inherit' }}>{item.title}</a>
+                  {item.id === highestId && (
+                    <Tag style={{ marginLeft: 8 }}>CURRENT</Tag>
+                  )}
+                </span>
+              }
+              description={
+                <span>
+                  #job-{item.id} &nbsp;&nbsp;|&nbsp;&nbsp; <b>{item.createdBy}</b> triggered via <b>{item.via || "UI"}</b> using template <b>{getTemplateName(item)}</b> &nbsp;&nbsp;|&nbsp;&nbsp; <a>#{item.commitId?.substring(0, 6)}</a>
+                </span>
+              }
+            />
+          </List.Item>
+        )}
+        pagination={false}
+      />
+      {sortedJobs.length > 0 && (
+        <div style={{ textAlign: 'right', marginTop: '16px' }}>
+          <Pagination
+            current={currentPage}
+            pageSize={pageSize}
+            total={sortedJobs.length}
+            onChange={handlePageChange}
+            showSizeChanger={false}
+          />
+        </div>
+      )}
+    </div>
+  );
+} 


### PR DESCRIPTION
- Added support for template name display
- Implemented pagination for improved navigation
- Added filters for template and job status
- Included timeclock tooltip on relative execution time for precise tracking
- Reflect via Schedule for scheduled jobs

<img width="1412" alt="Screenshot 2025-04-11 at 6 15 29 PM" src="https://github.com/user-attachments/assets/72f199a0-7f46-4e11-9061-d69cbc631d32" />

fixes #1503