### PR TITLE
fix: Change liquibase script to run only for mssql

### DIFF
--- a/api/src/main/resources/db/changelog/local/changelog-2.26.0-vars-size.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.26.0-vars-size.xml
@@ -4,7 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
             http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
-    <changeSet id="2-26-1-3" author="207031497+Vx-V@users.noreply.github.com">
+    <changeSet id="2-26-1-3" author="207031497+Vx-V@users.noreply.github.com" dbms="mssql">
         <modifyDataType
                 columnName="variable_value"
                 newDataType="varchar(max)"


### PR DESCRIPTION
Updating liquibase script that only works in mssql

> tested with sql_azure

```
  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::               (v3.3.10)
025-04-14T20:29:49.913Z  INFO 1 --- [           main] org.terrakube.api.ServerApplication      : Starting ServerApplication v2.26.0 using Java 17.0.14 with PID 1 (/workspace/BOOT-INF/classes started by cnb in /workspace)
2025-04-14T20:29:49.941Z  INFO 1 --- [           main] org.terrakube.api.ServerApplication      : The following 1 profile is active: "demo"
2025-04-14T20:29:54.490Z  INFO 1 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Multiple Spring Data modules found, entering strict repository configuration mode
2025-04-14T20:29:54.490Z  INFO 1 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JPA repositories in DEFAULT mode.
2025-04-14T20:29:55.070Z  INFO 1 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 572 ms. Found 26 JPA repository interfaces.
2025-04-14T20:29:57.893Z  INFO 1 --- [           main] o.s.cloud.context.scope.GenericScope     : BeanFactory id=15a8166b-0432-3b05-bb47-81c7cf9d0fe3
2025-04-14T20:30:00.701Z  INFO 1 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port 8080 (http)
2025-04-14T20:30:00.732Z  INFO 1 --- [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
2025-04-14T20:30:00.733Z  INFO 1 --- [           main] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/10.1.39]
2025-04-14T20:30:00.906Z  INFO 1 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
2025-04-14T20:30:00.914Z  INFO 1 --- [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 10712 ms
2025-04-14T20:30:02.390Z  INFO 1 --- [           main] o.t.a.p.s.StreamingConfiguration         : Redis Configuration=> User: username is null, Hostname: terrakube-redis-master, Port: 6379, Ssl: false
2025-04-14T20:30:02.416Z  INFO 1 --- [           main] o.t.a.p.s.StreamingConfiguration         : Redis connection is not using username parameter
2025-04-14T20:30:02.417Z  INFO 1 --- [           main] o.t.a.p.s.StreamingConfiguration         : Using default Redis connection
2025-04-14T20:30:02.978Z  INFO 1 --- [           main] o.t.a.p.d.DataSourceAutoConfiguration    : DataSourceType: SQL_AZURE

....
025-04-14T20:31:40.162Z  INFO 1 --- [           main] liquibase.changelog                      : ChangeSet db/changelog/local/changelog-2.26.0-module-vars-size.xml::2-26-1-1::lah@whiteawaygroup.com ran successfully in 568ms
2025-04-14T20:31:40.441Z  INFO 1 --- [           main] liquibase.ui                             : Running Changeset: db/changelog/local/changelog-2.26.0-vars-size.xml::2-26-1-3::207031497+Vx-V@users.noreply.github.com
2025-04-14T20:31:40.719Z  INFO 1 --- [           main] liquibase.changelog                      : globalvar.variable_value datatype was changed to varchar(max)
2025-04-14T20:31:40.924Z  INFO 1 --- [           main] liquibase.changelog                      : item.item_value datatype was changed to varchar(max)
2025-04-14T20:31:41.126Z  INFO 1 --- [           main] liquibase.changelog                      : variable.variable_value datatype was changed to varchar(max)
2025-04-14T20:31:41.199Z  INFO 1 --- [           main] liquibase.changelog                      : ChangeSet db/changelog/local/changelog-2.26.0-vars-size.xml::2-26-1-3::207031497+Vx-V@users.noreply.github.com ran successfully in 757ms
2025-04-14T20:31:41.478Z  INFO 1 --- [           main] liquibase.ui                             : Running Changeset: db/changelog/demo-data/azure.xml::demo-1::demo-data
2025-04-14T20:31:41.749Z  INFO 1 --- [           main] liquibase.changelog                      : New row inserted into organization
2025-04-14T20:31:41.957Z  INFO 1 --- [           main] liquibase.changelog                      : New row inserted into team
2025-04-14T20:31:42.156Z  INFO 1 --- [           main] liquibase.changelog                      : New row inserted into team
2025-04-14T20:31:42.359Z  INFO 1 --- [           main] liquibase.changelog                      : New row inserted into template
2025-04-14T20:31:42.560Z  INFO 1 --- [           main] liquibase.changelog                      : New row inserted into template
2025-04-14T20:31:42.756Z  INFO 1 --- [           main] liquibase.changelog                      : New row inserted into template
2025-04-14T20:31:42.967Z  INFO 1 --- [           main] liquibase.changelog                      : New row inserted into template
2025-04-14T20:31:43.174Z  INFO 1 --- [           main] liquibase.changelog                      : New row inserted into template
```