### PR TITLE
fix: Add listen for IPv6 for terrakube UI

### DIFF
--- a/ui/conf/conf.d/bitnami.conf
+++ b/ui/conf/conf.d/bitnami.conf
@@ -1,5 +1,7 @@
 server {
   listen 0.0.0.0:8080;
+  listen [::]:8080;
+
   location / {
     root   /app;
     index  index.html index.htm;


### PR DESCRIPTION
Currently, the UI only listens to IPv4. I'm running an IPv6 only cluster and was unable to run the UI unless I override the conf with a volume mount with proposed changes.