### PR TITLE
feat: Support to trigger a job when creating releases in Github

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookResult.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookResult.java
@@ -19,4 +19,5 @@ public class WebhookResult {
     private List<String> fileChanges;
     private String commit;
     private Number prNumber;
+    private boolean isRelease;
 }

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
@@ -94,7 +94,7 @@ public class WebhookService {
             job.setRefresh(true);
             job.setPlanChanges(true);
             job.setRefreshOnly(false);
-            job.setOverrideBranch(webhookResult.getBranch());
+            job.setOverrideBranch(webhookResult.isRelease() ? "refs/tags/" + webhookResult.getBranch() : webhookResult.getBranch());
             job.setOrganization(workspace.getOrganization());
             job.setWorkspace(workspace);
             job.setCreatedBy(webhookResult.getCreatedBy());

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/WebhookService.java
@@ -105,7 +105,8 @@ public class WebhookService {
             job.setVia(webhookResult.getVia());
             job.setCommitId(webhookResult.getCommit());
             Job savedJob = jobRepository.save(job);
-            sendCommitStatus(savedJob);
+            if (!webhookResult.isRelease())
+                sendCommitStatus(savedJob);
             scheduleJobService.createJobContext(savedJob);
         } catch (Exception e) {
             log.error("Error creating the job", e);

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -135,6 +135,8 @@ public class GitHubWebhookService extends WebhookServiceBase {
                 result.setValid(true);
                 result.setRelease(true);
                 result.setBranch(rootNode.path("release").path("tag_name").asText());
+            } else {
+                throw new IllegalArgumentException("No valid github event " + result.getEvent());
             }
         }
 

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -135,9 +135,10 @@ public class GitHubWebhookService extends WebhookServiceBase {
                 result.setValid(true);
                 result.setRelease(true);
                 result.setBranch(rootNode.path("release").path("tag_name").asText());
-            } else {
-                throw new IllegalArgumentException("No valid github event " + result.getEvent());
             }
+        } else {
+            result.setValid(false);
+            log.error("No valid github event " + result.getEvent());
         }
 
         return result;

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -128,6 +128,14 @@ public class GitHubWebhookService extends WebhookServiceBase {
                 List<String> prFileChanges = getPrFileChanges(vcs, new String[]{repoOwner, repoName}, prFilesUrl);
                 result.setFileChanges(prFileChanges);
             }
+        } else if ("release".equals(event)) {
+            String action = rootNode.path("action").asText();
+            if ("created".equals(action)){
+                log.info("Received release created webhook event for repository {}", rootNode.path("repository").path("full_name"));
+            }
+            result.setValid(true);
+            result.setRelease(true);
+            result.setBranch(rootNode.path("release").path("tag_name").asText());
         }
 
         return result;

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -134,7 +134,7 @@ public class GitHubWebhookService extends WebhookServiceBase {
                 log.info("Received release created webhook event for repository {}", rootNode.path("repository").path("full_name"));
                 result.setValid(true);
                 result.setRelease(true);
-                result.setBranch(rootNode.path("release").path("tag_name").asText());
+                result.setBranch("refs/tags/" + rootNode.path("release").path("tag_name").asText());
             } else {
                 throw new IllegalArgumentException("No valid github event " + result.getEvent());
             }

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -134,7 +134,7 @@ public class GitHubWebhookService extends WebhookServiceBase {
                 log.info("Received release created webhook event for repository {}", rootNode.path("repository").path("full_name"));
                 result.setValid(true);
                 result.setRelease(true);
-                result.setBranch("refs/tags/" + rootNode.path("release").path("tag_name").asText());
+                result.setBranch(rootNode.path("release").path("tag_name").asText());
             } else {
                 throw new IllegalArgumentException("No valid github event " + result.getEvent());
             }

--- a/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -132,10 +132,10 @@ public class GitHubWebhookService extends WebhookServiceBase {
             String action = rootNode.path("action").asText();
             if ("created".equals(action)){
                 log.info("Received release created webhook event for repository {}", rootNode.path("repository").path("full_name"));
+                result.setValid(true);
+                result.setRelease(true);
+                result.setBranch(rootNode.path("release").path("tag_name").asText());
             }
-            result.setValid(true);
-            result.setRelease(true);
-            result.setBranch(rootNode.path("release").path("tag_name").asText());
         }
 
         return result;

--- a/api/src/main/java/org/terrakube/api/rs/webhook/WebhookEventType.java
+++ b/api/src/main/java/org/terrakube/api/rs/webhook/WebhookEventType.java
@@ -3,5 +3,6 @@ package org.terrakube.api.rs.webhook;
 public enum WebhookEventType {
     PUSH,
     PULL_REQUEST,
-    PING
+    PING,
+    RELEASE,
 }

--- a/ui/src/domain/Workspaces/Settings/Webhook.tsx
+++ b/ui/src/domain/Workspaces/Settings/Webhook.tsx
@@ -257,16 +257,17 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
         >
           <Select.Option value="push">Push</Select.Option>
           <Select.Option value="pull_request">Pull Request</Select.Option>
+          <Select.Option value="release">Release</Select.Option>
         </Select>
       ),
     },
     {
-      title: "Branch",
+      title: "Branch/release",
       dataIndex: "branch",
       key: "branch",
       render: (_: string, record: any, index: number) => (
         <Input
-          placeholder="List of regex to match aginst branch names"
+          placeholder="List of regex to match aginst branch names or release names"
           name="branch"
           status={record.branchStatus}
           value={record.branch}


### PR DESCRIPTION
This PR is adding support to trigger a job in Terrakube when a Github Release is created.

Example:

![image](https://github.com/user-attachments/assets/77ab24d1-c9f3-4b5b-8dd3-5cd8fd21f9f0)

![image](https://github.com/user-attachments/assets/c9f7e5e6-c6ce-475f-b3bc-560ba10070de)

The webhooks setup is using a regex like `release/v.*`

![image](https://github.com/user-attachments/assets/e4155dc1-308b-4176-b4b3-fd88b86089a8)

It will trigger something similar inside the logs

```
2025-05-06T15:58:26.485Z  INFO 17946 --- [nio-8080-exec-8] o.t.api.plugin.vcs.WebhookServiceBase    : WorkspaceId: 777be819-c32b-4eb6-906d-1432b2862e4c
2025-05-06T15:58:26.485Z  INFO 17946 --- [nio-8080-exec-8] o.t.api.plugin.vcs.WebhookServiceBase    : verify signature for Github webhook
2025-05-06T15:58:26.485Z  INFO 17946 --- [nio-8080-exec-8] o.t.api.plugin.vcs.WebhookServiceBase    : Parsing Github webhook payload
2025-05-06T15:58:26.486Z  INFO 17946 --- [nio-8080-exec-8] o.t.a.p.v.p.github.GitHubWebhookService  : Received release created webhook event for repository "AzSwarm/test-template-automatic"
2025-05-06T15:58:26.490Z  INFO 17946 --- [nio-8080-exec-8] o.t.api.plugin.vcs.WebhookService        : webhook result WebhookResult(workspaceId=777be819-c32b-4eb6-906d-1432b2862e4c, branch=release/v1.0.6, isValid=true, event=release, createdBy=null, via=Github, fileChanges=null, commit=null, prNumber=null, isRelease=true)
2025-05-06T15:58:26.493Z  INFO 17946 --- [nio-8080-exec-8] o.t.api.plugin.vcs.WebhookService        : webhook event release for workspace test-template-automatic, using template with id 42201234-a5e2-4c62-b2fc-9729ca6b4515
2025-05-06T15:58:26.509Z  INFO 17946 --- [nio-8080-exec-8] o.t.a.p.scheduler.ScheduleJobService     : Create Job Context DEFAULT.TerrakubeV2_Job_1
```

The github app will require to listen to the following events:

- releases

![image](https://github.com/user-attachments/assets/490778f2-6ea1-4171-aef9-9144501c41b5)
