### PR TITLE
feat: Adding support to migrate a workspace to a different organization

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/migrate/MigrateController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/migrate/MigrateController.java
@@ -19,7 +19,7 @@ public class MigrateController {
     @Transactional
     @PostMapping(produces = "application/json", path = "/workspace/{workspaceId}/migrateTo/{organizationId}")
     public ResponseEntity<String> migrateWorkspace(@PathVariable("workspaceId") String workspaceId, @PathVariable("organizationId") String organizationId) {
-        log.info("Migrating Workspace {} to organization {}", workspaceId, organizationId);
+        migrateService.migrateWorkspace(workspaceId, organizationId);
         return ResponseEntity.status(200).body("");
     }
 }

--- a/api/src/main/java/org/terrakube/api/plugin/migrate/MigrateController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/migrate/MigrateController.java
@@ -1,0 +1,25 @@
+package org.terrakube.api.plugin.migrate;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/migrate/v1/")
+@AllArgsConstructor
+public class MigrateController {
+
+    @Autowired
+    MigrateService migrateService;
+
+    @Transactional
+    @PostMapping(produces = "application/json", path = "/workspaces/{workspaceId}/migrateTo/{organizationId}")
+    public ResponseEntity<String> migrateWorkspace(@PathVariable("workspaceId") String workspaceId, @PathVariable("organizationId") String organizationId) {
+        log.info("Migrating Workspace {} to organization {}", workspaceId, organizationId);
+        return ResponseEntity.status(200).body("");
+    }
+}

--- a/api/src/main/java/org/terrakube/api/plugin/migrate/MigrateController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/migrate/MigrateController.java
@@ -17,7 +17,7 @@ public class MigrateController {
     MigrateService migrateService;
 
     @Transactional
-    @PostMapping(produces = "application/json", path = "/workspaces/{workspaceId}/migrateTo/{organizationId}")
+    @PostMapping(produces = "application/json", path = "/workspace/{workspaceId}/migrateTo/{organizationId}")
     public ResponseEntity<String> migrateWorkspace(@PathVariable("workspaceId") String workspaceId, @PathVariable("organizationId") String organizationId) {
         log.info("Migrating Workspace {} to organization {}", workspaceId, organizationId);
         return ResponseEntity.status(200).body("");

--- a/api/src/main/java/org/terrakube/api/plugin/migrate/MigrateController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/migrate/MigrateController.java
@@ -17,7 +17,7 @@ public class MigrateController {
     MigrateService migrateService;
 
     @Transactional
-    @PostMapping(produces = "application/json", path = "/workspace/{workspaceId}/migrateTo/{organizationId}")
+    @PostMapping(produces = "application/json", path = "/workspace/{workspaceId}/moveTo/{organizationId}")
     public ResponseEntity<String> migrateWorkspace(@PathVariable("workspaceId") String workspaceId, @PathVariable("organizationId") String organizationId) {
         migrateService.migrateWorkspace(workspaceId, organizationId);
         return ResponseEntity.status(200).body("");

--- a/api/src/main/java/org/terrakube/api/plugin/migrate/MigrateService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/migrate/MigrateService.java
@@ -1,0 +1,75 @@
+package org.terrakube.api.plugin.migrate;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.terrakube.api.repository.JobRepository;
+import org.terrakube.api.repository.OrganizationRepository;
+import org.terrakube.api.repository.WorkspaceRepository;
+import org.terrakube.api.rs.Organization;
+import org.terrakube.api.rs.job.Job;
+import org.terrakube.api.rs.workspace.Workspace;
+import org.terrakube.api.rs.workspace.history.History;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class MigrateService {
+
+    private WorkspaceRepository workspaceRepository;
+    private OrganizationRepository organizationRepository;
+    private JobRepository jobRepository;
+
+    public boolean migrateWorkspace(String workspaceId, String organizationId) {
+        log.info("Migrating workspace {} to organization {}", workspaceId, organizationId);
+
+        // Find the Workspace
+        Optional<Workspace> workspaceOptional = workspaceRepository.findById(UUID.fromString(workspaceId));
+        if (workspaceOptional.isEmpty()) {
+            log.error("Workspace {} not found", workspaceId);
+            return false;
+        }
+
+        Workspace workspace = workspaceOptional.get();
+        String originalOrg = workspace.getOrganization().getId().toString();
+
+        // Check if workspace is locked or deleted
+        if (workspace.isLocked() || workspace.isDeleted()) {
+            log.error("Workspace {} is locked or deleted; cannot migrate", workspaceId);
+            return false;
+        }
+
+        // Find the target Organization
+        Optional<Organization> organizationOptional = organizationRepository.findById(UUID.fromString(organizationId));
+        if (organizationOptional.isEmpty()) {
+            log.error("Organization {} not found", organizationId);
+            return false;
+        }
+
+        Organization newOrganization = organizationOptional.get();
+
+        // Update the Workspace's organization
+        workspace.setOrganization(newOrganization);
+        workspace = workspaceRepository.save(workspace);
+
+        // Log and return success
+        log.info("Workspace {} successfully migrated to organization {}", workspaceId, organizationId);
+
+        log.info("Starting job migration....");
+        for(Job job: workspace.getJob()){
+            job.setOrganization(newOrganization);
+            jobRepository.save(job);
+            log.info("Job {} successfully migrated to organization {}", job.getId(), organizationId);
+        }
+
+        log.info("Migrating history data for workspace {} to organization {}", workspaceId, organizationId);
+        for(History history: workspace.getHistory()){
+            history.setOutput(history.getOutput().replace(originalOrg, organizationId));
+        }
+        return true;
+
+    }
+}

--- a/api/src/main/java/org/terrakube/api/plugin/migrate/MigrateService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/migrate/MigrateService.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.terrakube.api.plugin.storage.StorageTypeService;
+import org.terrakube.api.repository.HistoryRepository;
 import org.terrakube.api.repository.JobRepository;
 import org.terrakube.api.repository.OrganizationRepository;
 import org.terrakube.api.repository.WorkspaceRepository;
@@ -20,6 +21,7 @@ import java.util.UUID;
 @AllArgsConstructor
 public class MigrateService {
 
+    private final HistoryRepository historyRepository;
     private WorkspaceRepository workspaceRepository;
     private OrganizationRepository organizationRepository;
     private JobRepository jobRepository;
@@ -70,6 +72,7 @@ public class MigrateService {
         log.info("Migrating history data for workspace {} to organization {}", workspaceId, organizationId);
         for(History history: workspace.getHistory()){
             history.setOutput(history.getOutput().replace(originalOrg, organizationId));
+            historyRepository.save(history);
         }
 
         storageService.migrateToOrganization(originalOrg, workspaceId, organizationId);

--- a/api/src/main/java/org/terrakube/api/plugin/migrate/MigrateService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/migrate/MigrateService.java
@@ -3,6 +3,7 @@ package org.terrakube.api.plugin.migrate;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.terrakube.api.plugin.storage.StorageTypeService;
 import org.terrakube.api.repository.JobRepository;
 import org.terrakube.api.repository.OrganizationRepository;
 import org.terrakube.api.repository.WorkspaceRepository;
@@ -22,6 +23,7 @@ public class MigrateService {
     private WorkspaceRepository workspaceRepository;
     private OrganizationRepository organizationRepository;
     private JobRepository jobRepository;
+    private StorageTypeService storageService;
 
     public boolean migrateWorkspace(String workspaceId, String organizationId) {
         log.info("Migrating workspace {} to organization {}", workspaceId, organizationId);
@@ -69,6 +71,8 @@ public class MigrateService {
         for(History history: workspace.getHistory()){
             history.setOutput(history.getOutput().replace(originalOrg, organizationId));
         }
+
+        storageService.migrateToOrganization(originalOrg, workspaceId, organizationId);
         return true;
 
     }

--- a/api/src/main/java/org/terrakube/api/plugin/storage/StorageTypeService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/StorageTypeService.java
@@ -30,4 +30,6 @@ public interface StorageTypeService {
     void deleteWorkspaceOutputData(String organizationId, List<Integer> jobList);
 
     void deleteWorkspaceStateData(String organizationId, String workspaceId);
+
+    boolean migrateToOrganization(String organizationId, String workspaceId, String migrateToOrganizationId);
 }

--- a/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
@@ -21,14 +21,14 @@ import java.util.List;
 @Builder
 public class LocalStorageTypeServiceImpl implements StorageTypeService {
 
-    private static final String OUTPUT_DIRECTORY =                "/.terraform-spring-boot/local/output/%s/%s/%s.tfoutput";
-    private static final String CONTENT_DIRECTORY =               "/.terraform-spring-boot/local/content/%s/terraformContent.tar.gz";
-    private static final String CONTEXT_DIRECTORY =               "/.terraform-spring-boot/local/output/context/%s/context.json";
-    private static final String STATE_DIRECTORY =                 "/.terraform-spring-boot/local/state/%s/%s/%s/%s/terraformLibrary.tfPlan";
-    private static final String STATE_DIRECTORY_JSON =            "/.terraform-spring-boot/local/state/%s/%s/state/%s.json";
+    private static final String OUTPUT_DIRECTORY = "/.terraform-spring-boot/local/output/%s/%s/%s.tfoutput";
+    private static final String CONTENT_DIRECTORY = "/.terraform-spring-boot/local/content/%s/terraformContent.tar.gz";
+    private static final String CONTEXT_DIRECTORY = "/.terraform-spring-boot/local/output/context/%s/context.json";
+    private static final String STATE_DIRECTORY = "/.terraform-spring-boot/local/state/%s/%s/%s/%s/terraformLibrary.tfPlan";
+    private static final String STATE_DIRECTORY_JSON = "/.terraform-spring-boot/local/state/%s/%s/state/%s.json";
     private static final String NO_DATA_FOUND = "";
     private static final String NO_CONTEXT_FOUND = "{}";
-    private static final String LOCAL_BACKEND_DIRECTORY =         "/.terraform-spring-boot/local/backend/%s/%s/terraform.tfstate";
+    private static final String LOCAL_BACKEND_DIRECTORY = "/.terraform-spring-boot/local/backend/%s/%s/terraform.tfstate";
     private static final String LOCAL_HISTORY_BACKEND_DIRECTORY = "/.terraform-spring-boot/local/state/%s/%s/state/%s.raw.json";
 
     @Override

--- a/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
@@ -47,7 +47,7 @@ public class LocalStorageTypeServiceImpl implements StorageTypeService {
 
     @Override
     public byte[] getTerraformStateJson(String organizationId, String workspaceId, String stateFileName) {
-        log.info("Searching: /.terraform-spring-boot/local/tfstate/{}/{}/state/{}.json", organizationId, workspaceId, stateFileName);
+        log.info("Searching: /.terraform-spring-boot/local/state/{}/{}/state/{}.json", organizationId, workspaceId, stateFileName);
         String outputFilePath = String.format(STATE_DIRECTORY_JSON, organizationId, workspaceId, stateFileName);
         return getOutputBytes(outputFilePath);
     }

--- a/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
@@ -227,7 +227,7 @@ public class LocalStorageTypeServiceImpl implements StorageTypeService {
 
     public void migrateDirectory(File sourceDirectory, File targetDirectory) {
         try {
-            FileUtils.copyDirectory(sourceDirectory, targetDirectory);
+            FileUtils.moveToDirectory(sourceDirectory, targetDirectory, true);
             log.info("Moving folder {} to {} successfully!", sourceDirectory.getAbsolutePath(), targetDirectory.getAbsolutePath());
         } catch (IOException e) {
             log.info("An error occurred while copying the folder {}: {}",sourceDirectory.getAbsolutePath(), e.getMessage());

--- a/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
+++ b/api/src/main/java/org/terrakube/api/plugin/storage/local/LocalStorageTypeServiceImpl.java
@@ -211,15 +211,15 @@ public class LocalStorageTypeServiceImpl implements StorageTypeService {
     public boolean migrateToOrganization(String organizationId, String workspaceId, String migrateToOrganizationId) {
 
         String sourceOutputDirectory = String.format("%s/.terraform-spring-boot/local/output/%s/%s", FileUtils.getUserDirectoryPath(), organizationId, workspaceId);
-        String sourceOutputTarget = String.format("%s/.terraform-spring-boot/local/output/%s/%s", FileUtils.getUserDirectoryPath(), migrateToOrganizationId, workspaceId);
+        String sourceOutputTarget = String.format("%s/.terraform-spring-boot/local/output/%s", FileUtils.getUserDirectoryPath(), migrateToOrganizationId);
         migrateDirectory(new File(sourceOutputDirectory), new File(sourceOutputTarget));
 
         String stateDirectory = String.format("%s/.terraform-spring-boot/local/state/%s/%s", FileUtils.getUserDirectoryPath(), organizationId, workspaceId);
-        String stateTargetDirectory = String.format("%s/.terraform-spring-boot/local/state/%s/%s", FileUtils.getUserDirectoryPath(), migrateToOrganizationId, workspaceId);
+        String stateTargetDirectory = String.format("%s/.terraform-spring-boot/local/state/%s", FileUtils.getUserDirectoryPath(), migrateToOrganizationId);
         migrateDirectory(new File(stateDirectory), new File(stateTargetDirectory));
 
         String terraformStateDirectory = String.format("%s/.terraform-spring-boot/local/backend/%s/%s", FileUtils.getUserDirectoryPath(), organizationId, workspaceId);
-        String terraformStateTargetDirectory = String.format("%s/.terraform-spring-boot/local/backend/%s/%s", FileUtils.getUserDirectoryPath(), migrateToOrganizationId, workspaceId);
+        String terraformStateTargetDirectory = String.format("%s/.terraform-spring-boot/local/backend/%s", FileUtils.getUserDirectoryPath(), migrateToOrganizationId);
         migrateDirectory(new File(terraformStateDirectory), new File(terraformStateTargetDirectory));
 
         return true;

--- a/api/src/main/java/org/terrakube/api/rs/workspace/history/History.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/history/History.java
@@ -7,7 +7,6 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.terrakube.api.plugin.security.audit.GenericAuditFields;
 import org.terrakube.api.rs.IdConverter;
 import org.terrakube.api.rs.workspace.Workspace;
-import org.hibernate.annotations.Type;
 import org.terrakube.api.rs.workspace.history.archive.Archive;
 
 import jakarta.persistence.*;

--- a/api/src/main/java/org/terrakube/api/rs/workspace/history/archive/Archive.java
+++ b/api/src/main/java/org/terrakube/api/rs/workspace/history/archive/Archive.java
@@ -3,7 +3,6 @@ package org.terrakube.api.rs.workspace.history.archive;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.annotations.Type;
 import org.terrakube.api.rs.IdConverter;
 import org.terrakube.api.rs.workspace.history.History;
 

--- a/scripts/template/minio/docker-compose.yaml
+++ b/scripts/template/minio/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   minio:
-    image: docker.io/bitnami/minio:2022
+    image: docker.io/bitnami/minio:2025
     ports:
       - '9000:9000'
       - '9001:9001'


### PR DESCRIPTION
This will allow to move a workspace to a different organization doing the following request

```
curl --location --request POST 'https://terrakube-api.minikube.net/migrate/v1/workspace/5ed411ca-7ab8-4d2f-b591-02d0d5788afc/moveTo/3a130a1c-d96f-4f99-83b8-58d472567e3a' --header 'Content-Type: application/json' --header 'Authorization: Bearer XXXXXXX'
```

Fix #2085 