### PR TITLE
fix: hide PageWrapper children while loading is true

### DIFF
--- a/ui/src/modules/layout/PageWrapper/PageWrapper.tsx
+++ b/ui/src/modules/layout/PageWrapper/PageWrapper.tsx
@@ -66,13 +66,14 @@ export default function PageWrapper({
 
           {error && <Alert className="page-wrapper-alert" message={error.title} type="error" showIcon banner />}
 
-          {loading && (
+          {loading ? (
             <Flex align="center" className="page-wrapper-loader" vertical gap="middle">
               <Spin tip="Loading" size="large" />
               <Typography.Text>{loadingText || "Loading..."}</Typography.Text>
             </Flex>
+          ) : (
+            children
           )}
-          {children}
         </div>
       </div>
     </Content>


### PR DESCRIPTION
Hello @alfespa17, @jcanizalez,

Previously, PageWrapper would render both the loading spinner and the page content (`children`) at the same time. This caused components like empty tables or uninitialized UI elements to appear prematurely while data was still being fetched.

This update changes the logic so that children are only rendered after `loading` is false. While loading, only the spinner and optional `loadingText` are shown. This improves perceived performance and avoids UI flickering or confusion during API requests.

Also simplifies usage by allowing consumers to rely fully on the `loading` prop without wrapping content in custom `isLoading ? ... : ...` checks.

![Screenshot at May 09 12-42-09](https://github.com/user-attachments/assets/54b238b0-a18a-4226-81e1-a2d859eb47e7)
