### PR TITLE
 feat: Adding vscode devcontainer support

### DIFF
--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -1,0 +1,59 @@
+##################
+#GENERAL SETTINGS#
+##################
+TK_VERSION=2.25.0
+DOMAIN=platform.local
+
+##################
+#NETWORK SETTINGS#
+##################
+EXTERNAL_NETWORK_NAME=terrakube-network
+TRAEFIK_IPV4_ADDRESS=10.25.25.253
+HOST_GATEWAY=10.25.25.253
+TRAEFIK_HTTP_PORT=80
+TRAEFIK_HTTPS_PORT=443
+DNS_IP_PUBLIC=
+
+##########
+#SECURITY#
+##########
+PAT_SECRET=ejZRSFgheUBOZXAyUURUITUzdmdINDNeUGpSWHlDM1g=
+INTERNAL_SECRET=S2JeOGNNZXJQTlpWNmhTITkha2NEKkt1VVBVQmFeQjM=
+
+#####
+#DEX#
+#####
+TK_DEX_VERSION=v2.42.0
+
+###################
+#OPEN LDAP SETTING#
+###################
+TK_LDAP_VERSION=2.6.9-debian-12-r10
+
+#######################
+#MINIO STORAGE BACKEND#
+#######################
+TK_MINIO_VERSION=2025
+TK_OUTPUT_ACCESS_KEY=minioadmin
+TK_OUTPUT_ENDPOINT=http://terrakube-minio:9000
+TK_OUTPUT_SECRET_KEY=minioadmin
+TK_OUTPUT_STORAGE_REGION=us-east-1
+TK_OUTPUT_BUCKET_NAME=sample
+TK_OUTPUT_BUCKET_REGION=us-east-1
+
+###################
+#DATABASE SETTINGS#
+###################
+TK_POSTGRESQL_VERSION=17
+TK_POSTGRESQL_USERNAME=terrakube
+TK_POSTGRESQL_PASSWORD=terrakubepassword
+TK_POSTGRESQL_DATABASE_NAME=terrakubedb
+
+################
+#REDIS SETTINGS#
+################
+TK_REDIS_CONTAINER_NAME=terrakube-redis
+TK_REDIS_PASSWORD=password123456
+TK_REDIS_VERSION=7.0.10
+
+

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,42 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+# Install necessary packages
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    curl \
+    git \
+    wget \
+    gnupg \
+    lsb-release \
+    ca-certificates \
+    apt-transport-https \
+    software-properties-common \
+    unzip \
+    zip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["sleep", "infinity"]
+
+#SHELL ["/bin/bash", "-c"]
+#
+#ARG HOME=/home/vscode
+#
+#USER vscode
+#WORKDIR $HOME
+#
+#ARG JDK_VERSION=21.0.7-librca
+#
+#RUN curl -fsSL "https://get.sdkman.io" | bash - \
+#    && source "$HOME/.sdkman/bin/sdkman-init.sh" \
+#    && sdk install java $JDK_VERSION \
+#    && sdk default java $JDK_VERSION \
+#    && sdk install maven
+#
+#ARG NODE_VERSION=20
+#ARG NVM_VERSION=v0.40.3
+#ENV NVM_DIR=$HOME/.nvm
+#
+## install nvm
+#RUN curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.sh" | bash - \
+#    && bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use $NODE_VERSION && npm install -g yarn"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,27 +16,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ENTRYPOINT ["sleep", "infinity"]
+COPY rootCA.pem /usr/local/share/ca-certificates/root.crt
 
-#SHELL ["/bin/bash", "-c"]
-#
-#ARG HOME=/home/vscode
-#
-#USER vscode
-#WORKDIR $HOME
-#
-#ARG JDK_VERSION=21.0.7-librca
-#
-#RUN curl -fsSL "https://get.sdkman.io" | bash - \
-#    && source "$HOME/.sdkman/bin/sdkman-init.sh" \
-#    && sdk install java $JDK_VERSION \
-#    && sdk default java $JDK_VERSION \
-#    && sdk install maven
-#
-#ARG NODE_VERSION=20
-#ARG NVM_VERSION=v0.40.3
-#ENV NVM_DIR=$HOME/.nvm
-#
-## install nvm
-#RUN curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.sh" | bash - \
-#    && bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use $NODE_VERSION && npm install -g yarn"
+RUN update-ca-certificates
+
+ENTRYPOINT ["sleep", "infinity"]

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -7,7 +7,7 @@ This directory contains the configuration for a development container that provi
 
 ## Features
 
-- Java 21 (Liberica)
+- Java 17 (Liberica)
 - Maven 3.9.9
 - Node.js 20.x with Yarn
 - VS Code extensions for Java, JavaScript/TypeScript
@@ -80,6 +80,14 @@ Update the /etc/hosts file adding the following entries:
    - Type "Remote-Containers: Reopen in Container" and press Enter
 
 3. Wait for the container to build and start. This may take a few minutes the first time.
+
+4. Start all Terrakube components
+
+   ![image](https://github.com/user-attachments/assets/34a4d4c9-d1b0-443f-834e-c4d76db26187)
+
+5. Terrakube should be availabe with the following url `https://terrakube.platform.local` using `admin@example.com` with password `admin`
+
+   ![image](https://github.com/user-attachments/assets/c92b5f7a-c484-47b5-bb31-4edd4513278e)
 
 ## Ports
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,90 +1,94 @@
 # Terrakube Development Container
 
-This directory contains configuration for a development container that provides a consistent development environment for working with Terrakube. The devcontainer includes all the necessary tools and dependencies to develop both the Java backend and JavaScript/TypeScript frontend components.
+This directory contains the configuration for a development container that provides a consistent environment for working with Terrakube. The devcontainer includes all the necessary tools and dependencies to develop both the Java backend, TypeScript frontend components and includes terraform CLI.
+
+> Make sure 
+> The below was tested using Ubuntu-based distribution, not sure if this will work with macos, windows or codespaces
 
 ## Features
 
-- Java 21 (Temurin/AdoptOpenJDK)
-- Maven 3.9.0
+- Java 21 (Liberica)
+- Maven 3.9.9
 - Node.js 20.x with Yarn
-- Docker CLI and Docker Compose
-- VS Code extensions for Java, JavaScript/TypeScript, and Docker development
-- GitHub CLI
+- VS Code extensions for Java, JavaScript/TypeScript
 
 ## Getting Started
 
 ### Prerequisites
 
 - [Visual Studio Code](https://code.visualstudio.com/)
-- [Docker](https://www.docker.com/products/docker-desktop)
 - [VS Code Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+
+#### Local Development Domains
+
+To use the devcontainer we need to setup the following domains in our local computer:
+
+```shell
+terrakube.platform.local
+terrakube-api.platform.local
+terrakube-registry.platform.local
+terrakube-dex.platform.local
+```
+
+#### HTTPS Local Certificates
+
+Install [mkcert](https://github.com/FiloSottile/mkcert#installation) to generate the local certificates.
+
+To generate local CA certificate execute the following:
+
+```shell
+mkcert -install
+Created a new local CA 💥
+The local CA is now installed in the system trust store! ⚡️
+The local CA is now installed in the Firefox trust store (requires browser restart)! 🦊
+```
+
+#### Create Docker Network for the devcontainer
+
+```bash
+docker network create terrakube-network -d bridge --subnet 10.25.25.0/24 --gateway 10.25.25.254
+```
+
+We will be using `10.25.25.253` for our the traefik gateway
+
+#### Local DNS entries
+
+Update the /etc/hosts file adding the following entries:
+
+```bash
+10.25.25.253 terrakube.platform.local
+10.25.25.253 terrakube-api.platform.local
+10.25.25.253 terrakube-registry.platform.local
+10.25.25.253 terrakube-dex.platform.local
+```
 
 ### Opening the Project in a Dev Container
 
-1. Clone the Terrakube repository:
+1. Clone the Terrakube repository and run the project:
    ```bash
    git clone https://github.com/AzBuilder/terrakube.git
-   cd terrakube
-   ```
-
-2. Open the project in VS Code:
-   ```bash
+   cd terrakube/.devcontainer
+   mkcert -key-file key.pem -cert-file cert.pem platform.local *.platform.local
+   CAROOT=$(mkcert -CAROOT)/rootCA.pem
+   cp $CAROOT rootCA.pem
+   cd ..
    code .
    ```
 
-3. When prompted to "Reopen in Container", click "Reopen in Container". Alternatively, you can:
+2. When prompted to "Reopen in Container", click "Reopen in Container". Alternatively, you can:
    - Press F1 or Ctrl+Shift+P
    - Type "Remote-Containers: Reopen in Container" and press Enter
 
-4. Wait for the container to build and start. This may take a few minutes the first time.
-
-## Development Workflow
-
-### Java Backend
-
-The Java backend is a Maven project. You can build and run it using the following commands:
-
-```bash
-# Build the project
-mvn clean install
-
-# Run the API server
-cd api
-mvn spring-boot:run
-```
-
-### JavaScript/TypeScript Frontend
-
-The frontend is a React application with TypeScript. You can start it using:
-
-```bash
-# Navigate to the UI directory
-cd ui
-
-# Install dependencies
-yarn install
-
-# Start the development server
-yarn start
-```
-
-## Using Docker Compose
-
-The project includes Docker Compose configurations for running the complete application stack. You can use:
-
-```bash
-# Navigate to the docker-compose directory
-cd docker-compose
-
-# Start the services
-docker-compose up -d
-```
+3. Wait for the container to build and start. This may take a few minutes the first time.
 
 ## Ports
 
 The devcontainer forwards the following ports:
-- 8080: Java API server
-- 3000: React development server
+- 8080: Terrakube API 
+- 8075: Terrakube Registry
+- 8090: Terrakube Executor
+- 3000: Terrakube UI
+- 80: Traefik Gateway
 
 ## Customization
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,93 @@
+# Terrakube Development Container
+
+This directory contains configuration for a development container that provides a consistent development environment for working with Terrakube. The devcontainer includes all the necessary tools and dependencies to develop both the Java backend and JavaScript/TypeScript frontend components.
+
+## Features
+
+- Java 21 (Temurin/AdoptOpenJDK)
+- Maven 3.9.0
+- Node.js 20.x with Yarn
+- Docker CLI and Docker Compose
+- VS Code extensions for Java, JavaScript/TypeScript, and Docker development
+- GitHub CLI
+
+## Getting Started
+
+### Prerequisites
+
+- [Visual Studio Code](https://code.visualstudio.com/)
+- [Docker](https://www.docker.com/products/docker-desktop)
+- [VS Code Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+
+### Opening the Project in a Dev Container
+
+1. Clone the Terrakube repository:
+   ```bash
+   git clone https://github.com/AzBuilder/terrakube.git
+   cd terrakube
+   ```
+
+2. Open the project in VS Code:
+   ```bash
+   code .
+   ```
+
+3. When prompted to "Reopen in Container", click "Reopen in Container". Alternatively, you can:
+   - Press F1 or Ctrl+Shift+P
+   - Type "Remote-Containers: Reopen in Container" and press Enter
+
+4. Wait for the container to build and start. This may take a few minutes the first time.
+
+## Development Workflow
+
+### Java Backend
+
+The Java backend is a Maven project. You can build and run it using the following commands:
+
+```bash
+# Build the project
+mvn clean install
+
+# Run the API server
+cd api
+mvn spring-boot:run
+```
+
+### JavaScript/TypeScript Frontend
+
+The frontend is a React application with TypeScript. You can start it using:
+
+```bash
+# Navigate to the UI directory
+cd ui
+
+# Install dependencies
+yarn install
+
+# Start the development server
+yarn start
+```
+
+## Using Docker Compose
+
+The project includes Docker Compose configurations for running the complete application stack. You can use:
+
+```bash
+# Navigate to the docker-compose directory
+cd docker-compose
+
+# Start the services
+docker-compose up -d
+```
+
+## Ports
+
+The devcontainer forwards the following ports:
+- 8080: Java API server
+- 3000: React development server
+
+## Customization
+
+You can customize the devcontainer by modifying:
+- `.devcontainer/devcontainer.json`: VS Code settings and extensions
+- `.devcontainer/Dockerfile`: Container image configuration

--- a/.devcontainer/config-ldap.ldif
+++ b/.devcontainer/config-ldap.ldif
@@ -1,0 +1,68 @@
+dn: dc=example,dc=org
+dc: example
+objectClass: dcObject
+objectClass: organization
+o: Example, Inc
+
+dn: ou=users,dc=example,dc=org
+ou: users
+objectClass: organizationalunit
+
+dn: cn=lester,ou=users,dc=example,dc=org
+objectClass: inetOrgPerson
+sn: Parkinson
+cn: Lester
+mail: admin@example.com
+userpassword: admin
+
+dn: cn=grady,ou=users,dc=example,dc=org
+objectClass: inetOrgPerson
+sn: Chambers
+cn: Grady
+mail: aws@example.com
+userpassword: azure
+
+dn: cn=saarah,ou=users,dc=example,dc=org
+objectClass: inetOrgPerson
+sn: Lott
+cn: Saarah
+mail: azure@example.com
+userpassword: aws
+
+dn: cn=eugene,ou=users,dc=example,dc=org
+objectClass: inetOrgPerson
+sn: Monaghan
+cn: Eugene
+mail: gcp@example.com
+userpassword: gcp
+
+# Group definitions.
+
+dn: ou=Groups,dc=example,dc=org
+objectClass: organizationalUnit
+ou: Groups
+
+dn: cn=TERRAKUBE_ADMIN,ou=Groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: TERRAKUBE_ADMIN
+member: cn=lester,ou=users,dc=example,dc=org
+
+dn: cn=TERRAKUBE_DEVELOPERS,ou=Groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: TERRAKUBE_DEVELOPERS
+member: cn=lester,ou=users,dc=example,dc=org
+
+dn: cn=AZURE_DEVELOPERS,ou=Groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: AZURE_DEVELOPERS
+member: cn=saarah,ou=users,dc=example,dc=org
+
+dn: cn=AWS_DEVELOPERS,ou=Groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: AWS_DEVELOPERS
+member: cn=grady,ou=users,dc=example,dc=org
+
+dn: cn=GCP_DEVELOPERS,ou=Groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: GCP_DEVELOPERS
+member: cn=eugene,ou=users,dc=example,dc=org

--- a/.devcontainer/config-ldap.yaml
+++ b/.devcontainer/config-ldap.yaml
@@ -64,7 +64,7 @@ connectors:
         nameAttr: cn
 
 staticClients:
-  - id: terrakube-app
+  - id: example-app
     redirectURIs:
       - "https://terrakube.platform.local"
       - "https://terrakube-api.platform.local"

--- a/.devcontainer/config-ldap.yaml
+++ b/.devcontainer/config-ldap.yaml
@@ -1,0 +1,77 @@
+issuer: https://terrakube-dex.platform.local/dex
+
+storage:
+  type: memory
+web:
+  http: 0.0.0.0:5556
+  allowedOrigins: ["*"]
+
+oauth2:
+  responseTypes: ["code", "token", "id_token"]
+
+connectors:
+  - type: ldap
+    name: OpenLDAP
+    id: ldap
+    config:
+      # The following configurations seem to work with OpenLDAP:
+      #
+      # 1) Plain LDAP, without TLS:
+      host: terrakube-ldap-service:1389
+      insecureNoSSL: true
+      insecureSkipVerify: true
+      #
+      # 2) LDAPS without certificate validation:
+      #host: localhost:636
+      #insecureNoSSL: false
+      #insecureSkipVerify: true
+      #
+      # 3) LDAPS with certificate validation:
+      #host: YOUR-HOSTNAME:636
+      #insecureNoSSL: false
+      #insecureSkipVerify: false
+      #rootCAData: 'CERT'
+      # ...where CERT="$( base64 -w 0 your-cert.crt )"
+
+      # This would normally be a read-only user.
+      bindDN: cn=admin,dc=example,dc=org
+      bindPW: admin
+
+      usernamePrompt: Email Address
+
+      userSearch:
+        baseDN: ou=users,dc=example,dc=org
+        filter: "(objectClass=person)"
+        username: mail
+        # "DN" (case sensitive) is a special attribute name. It indicates that
+        # this value should be taken from the entity's DN not an attribute on
+        # the entity.
+        idAttr: DN
+        emailAttr: mail
+        nameAttr: cn
+
+      groupSearch:
+        baseDN: ou=Groups,dc=example,dc=org
+        filter: "(objectClass=groupOfNames)"
+
+        userMatchers:
+          # A user is a member of a group when their DN matches
+          # the value of a "member" attribute on the group entity.
+          - userAttr: DN
+            groupAttr: member
+
+        # The group name should be the "cn" value.
+        nameAttr: cn
+
+staticClients:
+  - id: terrakube-app
+    redirectURIs:
+      - "https://terrakube.platform.local"
+      - "https://terrakube-api.platform.local"
+      - "https://terrakube-dex.platform.local"
+      - "/device/callback"
+      - "http://localhost:10000/login"
+      - "http://localhost:10001/login"
+    name: "Example App"
+    #secret: ZXhhbXBsZS1hcHAtc2VjcmV0
+    public: true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "name": "Terrakube Development",
   "dockerComposeFile": "docker-compose.yml",
   "service": "terrakube-dev",
-  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "workspaceFolder": "/workspaces/terrakube",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,12 +26,12 @@
   // "forwardPorts": [3000, 5432],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  // "postCreateCommand": "mvn dependency:resolve && cd ui && yarn install",
+  "postCreateCommand": "/workspaces/terrakube/scripts/setupDevelopmentEnvironment.sh",
 
   // Configure tool-specific properties.
   // "customizations": {},
 
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   "remoteUser": "vscode",
-  "forwardPorts": [8080, 3000, 8075, 8090]
+  "forwardPorts": [8080, 3000, 8075, 8090, 10000, 10001]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,8 @@
     "ghcr.io/devcontainers/features/node:1": {
       "version": "20",
       "installYarnUsingApt": true
-    }
+    },
+    "ghcr.io/devcontainers/features/terraform:1": {}
   },
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node-postgres
+{
+  "name": "Terrakube Development",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "terrakube-dev",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "installMaven": true,
+      "mavenVersion": "3.9.9",
+      "jdkDistro": "Liberica",
+      "version": "21.0.7-librca"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20",
+      "installYarnUsingApt": true
+    }
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // This can be used to network with other containers or with the host.
+  // "forwardPorts": [3000, 5432],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "mvn dependency:resolve && cd ui && yarn install",
+
+  // Configure tool-specific properties.
+  // "customizations": {},
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  "remoteUser": "vscode",
+  "forwardPorts": [8080, 3000, 8075, 8090]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
       "installMaven": true,
       "mavenVersion": "3.9.9",
       "jdkDistro": "Liberica",
-      "version": "21.0.7-librca"
+      "version": "17.0.15-librca"
     },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "20",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,282 @@
+### DNS ####
+
+x-terrakube_dns: &terrakube_dns
+  - ${DNS_IP_PUBLIC:-1.1.1.1}
+
+#### Extra Hosts #####
+
+x-terrakube_hosts: &terrakube_hosts
+  - "terrakube-api.${DOMAIN}:${HOST_GATEWAY}"
+  - "terrakube-dex.${DOMAIN}:${HOST_GATEWAY}"
+  - "terrakube-executor.${DOMAIN}:${HOST_GATEWAY}"
+  - "terrakube.${DOMAIN}:${HOST_GATEWAY}"
+  - "terrakube-registry.${DOMAIN}:${HOST_GATEWAY}"
+
+#### Container Environment Variables #####
+
+x-api: &api_env
+  ApiDataSourceType: POSTGRESQL
+  DatasourceHostname: postgresql-service
+  DatasourceDatabase: ${TK_POSTGRESQL_DATABASE_NAME}
+  DatasourceUser: ${TK_POSTGRESQL_USERNAME}
+  DatasourcePassword: ${TK_POSTGRESQL_PASSWORD}
+  GroupValidationType: DEX
+  UserValidationType: DEX
+  AuthenticationValidationType: DEX
+  TerrakubeHostname: terrakube-api.${DOMAIN}
+  AzBuilderExecutorUrl: http://terrakube-executor:8090/api/v1/terraform-rs
+  PatSecret: ${PAT_SECRET}
+  InternalSecret: ${INTERNAL_SECRET}
+  DexIssuerUri: https://terrakube-dex.${DOMAIN}/dex
+  StorageType: AWS
+  AwsStorageAccessKey: $TK_OUTPUT_ACCESS_KEY
+  AwsStorageSecretKey: $TK_OUTPUT_SECRET_KEY
+  AwsStorageBucketName: $TK_OUTPUT_BUCKET_NAME
+  AwsStorageRegion: $TK_OUTPUT_STORAGE_REGION
+  AwsEndpoint: $TK_OUTPUT_ENDPOINT
+  TerrakubeUiURL: https://terrakube.${DOMAIN}
+  spring_profiles_active: demo
+  DexClientId: terrakube-app
+  CustomTerraformReleasesUrl: "https://releases.hashicorp.com/terraform/index.json"
+  TerrakubeRedisHostname: ${TK_REDIS_CONTAINER_NAME}
+  TerrakubeRedisPort: 6379
+  TerrakubeRedisPassword: ${TK_REDIS_PASSWORD}
+  SERVICE_BINDING_ROOT: /mnt/platform/bindings
+
+x-executor: &executor_env
+  TerrakubeEnableSecurity: "true"
+  InternalSecret: ${INTERNAL_SECRET}
+  TerraformStateType: AwsTerraformStateImpl
+  AwsTerraformStateAccessKey: $TK_OUTPUT_ACCESS_KEY
+  AwsTerraformStateSecretKey: $TK_OUTPUT_SECRET_KEY
+  AwsTerraformStateBucketName: $TK_OUTPUT_BUCKET_NAME
+  AwsTerraformStateRegion: ${TK_OUTPUT_BUCKET_REGION}
+  AwsEndpoint: $TK_OUTPUT_ENDPOINT
+  TerraformOutputType: AwsTerraformOutputImpl
+  AwsTerraformOutputAccessKey: $TK_OUTPUT_ACCESS_KEY
+  AwsTerraformOutputSecretKey: $TK_OUTPUT_SECRET_KEY
+  AwsTerraformOutputBucketName: $TK_OUTPUT_BUCKET_NAME
+  AwsTerraformOutputRegion: ${TK_OUTPUT_BUCKET_REGION}
+  AzBuilderApiUrl: https://terrakube-api.${DOMAIN}
+  ExecutorFlagBatch: "false"
+  ExecutorFlagDisableAcknowledge: "false"
+  TerrakubeToolsRepository: https://github.com/AzBuilder/terrakube-extensions.git
+  TerrakubeToolsBranch: main
+  TerrakubeRegistryDomain: terrakube-registry.${DOMAIN}
+  TerrakubeApiUrl: https://terrakube-api.${DOMAIN}
+  CustomTerraformReleasesUrl: "https://releases.hashicorp.com/terraform/index.json"
+  TerrakubeRedisHostname: ${TK_REDIS_CONTAINER_NAME}
+  TerrakubeRedisPort: 6379
+  TerrakubeRedisPassword: ${TK_REDIS_PASSWORD}
+  SERVICE_BINDING_ROOT: /mnt/platform/bindings
+
+x-registry: &registry_env
+  AzBuilderRegistry: https://terrakube-registry.${DOMAIN}
+  AzBuilderApiUrl: https://terrakube-api.${DOMAIN}
+  AuthenticationValidationTypeRegistry: DEX
+  TerrakubeEnableSecurity: "true"
+  DexIssuerUri: https://terrakube-dex.${DOMAIN}/dex
+  TerrakubeUiURL: https://terrakube.${DOMAIN}
+  PatSecret: ${PAT_SECRET}
+  InternalSecret: ${INTERNAL_SECRET}
+  RegistryStorageType: AwsStorageImpl
+  AwsStorageAccessKey: $TK_OUTPUT_ACCESS_KEY
+  AwsStorageSecretKey: $TK_OUTPUT_SECRET_KEY
+  AwsStorageBucketName: $TK_OUTPUT_BUCKET_NAME
+  AwsStorageRegion: $TK_OUTPUT_STORAGE_REGION
+  AwsEndpoint: $TK_OUTPUT_ENDPOINT
+  AppClientId: terrakube-app
+  AppIssuerUri: https://terrakube-dex.${DOMAIN}/dex
+  SERVICE_BINDING_ROOT: /mnt/platform/bindings
+
+x-ldap: &ldap_env
+  LDAP_TLS_VERIFY_CLIENT: try
+  LDAP_ADMIN_USERNAME: "admin"
+  LDAP_ADMIN_PASSWORD: "admin"
+  LDAP_ROOT: "dc=example,dc=org"
+  LDAP_CUSTOM_LDIF_DIR: "/ldifs"
+
+x-minio: &minio_env
+  MINIO_ROOT_USER: ${TK_OUTPUT_ACCESS_KEY}
+  MINIO_ROOT_PASSWORD: ${TK_OUTPUT_SECRET_KEY}
+  MINIO_DEFAULT_BUCKETS: ${TK_OUTPUT_BUCKET_NAME}
+
+x-ui: &ui_env
+  REACT_APP_TERRAKUBE_API_URL: https://terrakube-api.${DOMAIN}/api/v1/
+  REACT_APP_CLIENT_ID: terrakube-app
+  REACT_APP_AUTHORITY: https://terrakube-dex.${DOMAIN}/dex
+  REACT_APP_REDIRECT_URI: https://terrakube.${DOMAIN}
+  REACT_APP_REGISTRY_URI: https://terrakube-registry.${DOMAIN}
+  REACT_APP_SCOPE: email openid profile offline_access groups
+  JAVA_TOOL_OPTIONS: -Dcom.sun.security.enableAIAcaIssuers=true
+
+x-traefik_env: &traefik_env
+  TRAEFIK_API_DASHBOARD: "false"
+  TRAEFIK_ENTRYPOINTS_WEB: "true"
+  TRAEFIK_ENTRYPOINTS_WEB_ADDRESS: ":${TRAEFIK_HTTP_PORT}"
+  TRAEFIK_ENTRYPOINTS_WEB_HTTP_ENCODEQUERYSEMICOLONS: "true"
+  TRAEFIK_ENTRYPOINTS_WEBSECURE_HTTP_ENCODEQUERYSEMICOLONS: "true"
+  TRAEFIK_ENTRYPOINTS_WEBSECURE: "true"
+  TRAEFIK_ENTRYPOINTS_WEBSECURE_ADDRESS: ":${TRAEFIK_HTTPS_PORT}"
+  TRAEFIK_PROVIDERS_DOCKER: "true"
+  TRAEFIK_PROVIDERS_DOCKER_EXPOSEDBYDEFAULT: "false"
+  TRAEFIK_PROVIDERS_FILE_FILENAME: /etc/traefik_dynamic.yml
+
+## Terrakube Components
+x-traefik_dev_labels: &traefik_dev_labels
+  traefik.enable: true
+  ## Terrakube API
+  ## Terrakube API HTTPS
+  traefik.http.routers.terrakube-api-https.rule: Host(`terrakube-api.${DOMAIN}`)
+  traefik.http.routers.terrakube-api-https.entrypoints: websecure
+  traefik.http.routers.terrakube-api-https.tls: true
+  traefik.http.routers.terrakube-api-https.middlewares: terrakube-dex-allow-origin
+  traefik.http.services.terrakube-api-https.loadbalancer.server.port: 8080
+  ## Terrakube API HTTPS
+  traefik.http.routers.terrakube-api-http.rule: Host(`terrakube-api.${DOMAIN}`)
+  traefik.http.routers.terrakube-api-http.entrypoints: web
+  traefik.http.routers.terrakube-api-http.middlewares: terrakube-api-redirect-https
+  traefik.http.middlewares.terrakube-api-redirect-https.redirectscheme.scheme: https
+  ## Terrakube Executor
+  ## Terrakube executor HTTPS
+  traefik.http.routers.terrakube-executor-https.rule: Host(`terrakube-executor.${DOMAIN}`)
+  traefik.http.routers.terrakube-executor-https.entrypoints: websecure
+  traefik.http.routers.terrakube-executor-https.tls: true
+  traefik.http.routers.terrakube-executor-https.middlewares: terrakube-dex-allow-origin
+  traefik.http.services.terrakube-executor-https.loadbalancer.server.port: 8090
+  ## Redirect to HTTPS
+  traefik.http.routers.terrakube-executor-http.rule: Host(`terrakube-executor.${DOMAIN}`)
+  traefik.http.routers.terrakube-executor-http.entrypoints: web
+  traefik.http.routers.terrakube-executor-http.middlewares: terrakube-executor-redirect-https
+  traefik.http.middlewares.terrakube-executor-redirect-https.redirectscheme.scheme: https
+  ## Terrakube UI
+  ## Terrakube UI HTTPS
+  traefik.http.routers.terrakube-ui-https.rule: Host(`terrakube.${DOMAIN}`)
+  traefik.http.routers.terrakube-ui-https.entrypoints: websecure
+  traefik.http.routers.terrakube-ui-https.middlewares: terrakube-dex-allow-origin
+  traefik.http.routers.terrakube-ui-https.tls: true
+  traefik.http.services.terrakube-ui-https.loadbalancer.server.port: 3000
+  ## Redirect to HTTPS
+  traefik.http.routers.terrakube-ui-http.rule: Host(`terrakube.${DOMAIN}`)
+  traefik.http.routers.terrakube-ui-http.entrypoints: web
+  traefik.http.routers.terrakube-ui-http.middlewares: terrakube-ui-redirect-https
+  traefik.http.middlewares.terrakube-ui-redirect-https.redirectscheme.scheme: https
+  ## Terrakube registry
+  ## Terrakube registry HTTPS
+  traefik.http.routers.terrakube-registry-https.rule: Host(`terrakube-registry.${DOMAIN}`)
+  traefik.http.routers.terrakube-registry-https.entrypoints: websecure
+  traefik.http.routers.terrakube-registry-https.tls: true
+  traefik.http.routers.terrakube-registry-https.middlewares: terrakube-dex-allow-origin
+  traefik.http.services.terrakube-registry-https.loadbalancer.server.port: 8075
+  ## Redirect to HTTPS
+  traefik.http.routers.terrakube-registry-http.rule: Host(`terrakube-registry.${DOMAIN}`)
+  traefik.http.routers.terrakube-registry-http.entrypoints: web
+  traefik.http.routers.terrakube-registry-http.middlewares: terrakube-registry-redirect-https
+  traefik.http.middlewares.terrakube-registry-redirect-https.redirectscheme.scheme: https
+
+x-traefik_dex_labels: &traefik_dex_labels
+  traefik.enable: true
+  ## Terrakube DEX HTTPS
+  traefik.http.routers.terrakube-dex-https.rule: Host(`terrakube-dex.${DOMAIN}`)
+  traefik.http.routers.terrakube-dex-https.entrypoints: websecure
+  traefik.http.routers.terrakube-dex-https.middlewares: terrakube-dex-allow-origin
+  traefik.http.routers.terrakube-dex-https.tls: true
+  traefik.http.services.terrakube-dex-https.loadbalancer.server.port: 5556
+  ## Redirect to HTTPS
+  traefik.http.routers.terrakube-dex-http.rule: Host(`terrakube-dex.${DOMAIN}`)
+  traefik.http.routers.terrakube-dex-http.entrypoints: web
+  traefik.http.routers.terrakube-dex-http.middlewares: terrakube-dex-redirect-https
+  traefik.http.middlewares.terrakube-dex-redirect-https.redirectscheme.scheme: https
+  ## Allow CORs from Terrakube UI
+  traefik.http.middlewares.terrakube-dex-allow-origin.headers.accesscontrolallowmethods: GET, PATCH, PUT, POST, DELETE, HEAD, OPTIONS
+  traefik.http.middlewares.terrakube-dex-allow-origin.headers.accesscontrolallowheaders: >
+    Content-Type, Accept, Authorization, X-Requested-With, Origin, *
+  traefik.http.middlewares.terrakube-dex-allow-origin.headers.accesscontrolalloworiginlist: https://terrakube.${DOMAIN}
+  traefik.http.middlewares.terrakube-dex-allow-origin.headers.accesscontrolallowcredentials: true
+  traefik.http.middlewares.terrakube-dex-allow-origin.headers.accessControlExposeHeaders: >
+    Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified,
+    Pragma, x-amz-server-side-encryption, x-amz-request-id, x-amz-id-2, ETag, x-terraform-get
+  traefik.http.middlewares.terrakube-dex-allow-origin.headers.accesscontrolmaxage: 86400
+  traefik.http.middlewares.terrakube-dex-allow-origin.headers.addvaryheader: true
+
+### Containers
+services:
+  traefik:
+    image: traefik:latest
+    container_name: terrakube-traefik
+    # Give Traefik a reserved IP address in your external network, pick something towards the end of the network to avoid conflicts
+    networks:
+      default:
+        ipv4_address: $TRAEFIK_IPV4_ADDRESS
+    environment: *traefik_env
+    dns: *terrakube_dns
+    ports:
+      - $TRAEFIK_HTTP_PORT:80
+      - $TRAEFIK_HTTPS_PORT:443
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./traefik_dynamic.yml:/etc/traefik_dynamic.yml
+      - ./key.pem:/letsencrypt/privkey.pem:ro
+      - ./cert.pem:/letsencrypt/fullchain.pem:ro
+    restart: unless-stopped
+  terrakube-dev:
+    dns: *terrakube_dns
+    extra_hosts: *terrakube_hosts
+    labels: *traefik_dev_labels
+    ports:
+      - 8080
+      - 8075
+      - 8090
+      - 3000
+    container_name: terrakube-dev
+    build:
+      context: .
+      dockerfile: Dockerfile
+  terrakube-dex:
+    image: ghcr.io/dexidp/dex:${TK_DEX_VERSION}
+    extra_hosts: *terrakube_hosts
+    labels: *traefik_dex_labels
+    container_name: terrakube-dex
+    volumes:
+      - ./config-ldap.yaml:/etc/dex/config.docker.yaml
+  ldap-service:
+    image: bitnami/openldap:${TK_LDAP_VERSION}
+    container_name: terrakube-ldap-service
+    environment: *ldap_env
+    volumes:
+      - ./config-ldap.ldif:/ldifs/config-ldap.ldif
+  minio:
+    container_name: terrakube-minio
+    image: docker.io/bitnami/minio:${TK_MINIO_VERSION}
+    environment: *minio_env
+    volumes:
+      - 'minio_data:/data'
+  redis-service:
+    image: bitnami/redis:${TK_REDIS_VERSION}
+    container_name: ${TK_REDIS_CONTAINER_NAME}
+    environment:
+      - REDIS_REPLICATION_MODE=master
+      - REDIS_PASSWORD=${TK_REDIS_PASSWORD}
+      - REDIS_MASTER_PASSWORD=${TK_REDIS_PASSWORD}
+      - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
+    volumes:
+      - 'redis_data:/bitnami/redis/data'
+  postgresql-service:
+    image: docker.io/bitnami/postgresql:${TK_POSTGRESQL_VERSION}
+    container_name: postgresql-service
+    environment:
+      - POSTGRESQL_USERNAME=${TK_POSTGRESQL_USERNAME}
+      - POSTGRESQL_PASSWORD=${TK_POSTGRESQL_PASSWORD}
+      - POSTGRESQL_DATABASE=${TK_POSTGRESQL_DATABASE_NAME}
+    volumes:
+      - postgresql_data:/bitnami/postgresql
+volumes:
+  minio_data:
+  redis_data:
+  postgresql_data:
+    driver: local
+# External network is required, import its name below
+networks:
+  default:
+    name: $EXTERNAL_NETWORK_NAME
+    external: true

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -126,35 +126,38 @@ x-traefik_env: &traefik_env
 x-traefik_dev_labels: &traefik_dev_labels
   traefik.enable: true
   ## Terrakube API
-  ## Terrakube API HTTPS
+  ## Terrakube API HTTP
   traefik.http.routers.terrakube-api-https.rule: Host(`terrakube-api.${DOMAIN}`)
   traefik.http.routers.terrakube-api-https.entrypoints: websecure
   traefik.http.routers.terrakube-api-https.tls: true
   traefik.http.routers.terrakube-api-https.middlewares: terrakube-dex-allow-origin
+  traefik.http.routers.terrakube-api-https.service: terrakube-api-https
   traefik.http.services.terrakube-api-https.loadbalancer.server.port: 8080
   ## Terrakube API HTTPS
   traefik.http.routers.terrakube-api-http.rule: Host(`terrakube-api.${DOMAIN}`)
   traefik.http.routers.terrakube-api-http.entrypoints: web
   traefik.http.routers.terrakube-api-http.middlewares: terrakube-api-redirect-https
   traefik.http.middlewares.terrakube-api-redirect-https.redirectscheme.scheme: https
-  ## Terrakube Executor
-  ## Terrakube executor HTTPS
-  traefik.http.routers.terrakube-executor-https.rule: Host(`terrakube-executor.${DOMAIN}`)
-  traefik.http.routers.terrakube-executor-https.entrypoints: websecure
-  traefik.http.routers.terrakube-executor-https.tls: true
-  traefik.http.routers.terrakube-executor-https.middlewares: terrakube-dex-allow-origin
-  traefik.http.services.terrakube-executor-https.loadbalancer.server.port: 8090
-  ## Redirect to HTTPS
-  traefik.http.routers.terrakube-executor-http.rule: Host(`terrakube-executor.${DOMAIN}`)
-  traefik.http.routers.terrakube-executor-http.entrypoints: web
-  traefik.http.routers.terrakube-executor-http.middlewares: terrakube-executor-redirect-https
-  traefik.http.middlewares.terrakube-executor-redirect-https.redirectscheme.scheme: https
+
+#  ## Terrakube Executor
+#  ## Terrakube executor HTTPS
+#  traefik.http.routers.terrakube-executor-https.rule: Host(`terrakube-executor.${DOMAIN}`)
+#  traefik.http.routers.terrakube-executor-https.entrypoints: websecure
+#  traefik.http.routers.terrakube-executor-https.tls: true
+#  traefik.http.routers.terrakube-executor-https.middlewares: terrakube-dex-allow-origin
+#  traefik.http.services.terrakube-executor-https.loadbalancer.server.port: 8090
+#  ## Redirect to HTTPS
+#  traefik.http.routers.terrakube-executor-http.rule: Host(`terrakube-executor.${DOMAIN}`)
+#  traefik.http.routers.terrakube-executor-http.entrypoints: web
+#  traefik.http.routers.terrakube-executor-http.middlewares: terrakube-executor-redirect-https
+#  traefik.http.middlewares.terrakube-executor-redirect-https.redirectscheme.scheme: https
   ## Terrakube UI
   ## Terrakube UI HTTPS
   traefik.http.routers.terrakube-ui-https.rule: Host(`terrakube.${DOMAIN}`)
   traefik.http.routers.terrakube-ui-https.entrypoints: websecure
   traefik.http.routers.terrakube-ui-https.middlewares: terrakube-dex-allow-origin
   traefik.http.routers.terrakube-ui-https.tls: true
+  traefik.http.routers.terrakube-ui-https.service: terrakube-ui-https
   traefik.http.services.terrakube-ui-https.loadbalancer.server.port: 3000
   ## Redirect to HTTPS
   traefik.http.routers.terrakube-ui-http.rule: Host(`terrakube.${DOMAIN}`)
@@ -167,6 +170,7 @@ x-traefik_dev_labels: &traefik_dev_labels
   traefik.http.routers.terrakube-registry-https.entrypoints: websecure
   traefik.http.routers.terrakube-registry-https.tls: true
   traefik.http.routers.terrakube-registry-https.middlewares: terrakube-dex-allow-origin
+  traefik.http.routers.terrakube-registry-https.service: terrakube-registry-https
   traefik.http.services.terrakube-registry-https.loadbalancer.server.port: 8075
   ## Redirect to HTTPS
   traefik.http.routers.terrakube-registry-http.rule: Host(`terrakube-registry.${DOMAIN}`)
@@ -232,6 +236,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    volumes:
+      - ..:/workspaces/terrakube:cached
   terrakube-dex:
     image: ghcr.io/dexidp/dex:${TK_DEX_VERSION}
     extra_hosts: *terrakube_hosts

--- a/.devcontainer/env-config.js
+++ b/.devcontainer/env-config.js
@@ -1,0 +1,8 @@
+window._env_ = {
+    REACT_APP_TERRAKUBE_API_URL: "https://terrakube-api.platform.local/api/v1/",
+    REACT_APP_CLIENT_ID: "terrakube-app",
+    REACT_APP_AUTHORITY: "https://terrakube-dex.platform.local/dex",
+    REACT_APP_REDIRECT_URI: "https://terrakube.platform.local",
+    REACT_APP_REGISTRY_URI: "https://terrakube-registry.platform.local",
+    REACT_APP_SCOPE: "email openid profile offline_access groups",
+}

--- a/.devcontainer/traefik_dynamic.yml
+++ b/.devcontainer/traefik_dynamic.yml
@@ -1,0 +1,6 @@
+tls:
+  stores:
+    default:
+      defaultCertificate:
+        certFile: /letsencrypt/fullchain.pem
+        keyFile: /letsencrypt/privkey.pem

--- a/.devcontainer/type
+++ b/.devcontainer/type
@@ -1,0 +1,1 @@
+ca-certificates

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 *.tar.gz
 *.rar
 *.pem
+*.der
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-    "recommendations": ["rangav.vscode-thunder-client", "esbenp.prettier-vscode", "vscjava.vscode-java-pack"]
+    "recommendations": ["HashiCorp.terraform", "dbaeumer.vscode-eslint", "vscjava.vscode-java-pack"]
   }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,4 @@
 {
     "java.configuration.updateBuildConfiguration": "interactive",
-    "thunder-client.workspaceRelativePath": "",
-    "thunder-client.saveToWorkspace": true,
     "java.compile.nullAnalysis.mode": "automatic"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "setup-java",
             "type": "shell",
-            "command": "echo 1",
+            "command": "  if [ \"$USER\" = \"gitpod\" ]; then source \"$HOME/.sdkman/bin/sdkman-init.sh\" && sdk install java 21.0.6-tem && sdk install maven 3.9.0; else echo \"Using JDK from devcontainer setup\"; fi",
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -15,7 +15,7 @@
         {
             "label": "yarn-install",
             "type": "shell",
-            "command": "cd ui && yarn install",
+            "command": "  if [ \"$USER\" = \"gitpod\" ]; then cd ui && yarn install; else echo \"Using Node from devcontainer setup\"; fi",
             "group": {
                 "kind": "build",
                 "isDefault": true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "setup-java",
             "type": "shell",
-            "command": "source \"$HOME/.sdkman/bin/sdkman-init.sh\" && sdk install java 21.0.6-tem && sdk install maven 3.9.0",
+            "command": "echo 1",
             "group": {
                 "kind": "build",
                 "isDefault": true

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The key features of Terrakube are:
 <img src="https://github.com/AzBuilder/terrakube/assets/27365102/9e0421be-576c-4206-a29a-c1d62238681e" width="1080"/>  <br/>
 
 - **Custom Workflows:** Enhance your IaC workflow with OPA, Infracost, or any other tool of your choice. You can use Terrakube extensions to integrate them seamlessly, or create your own custom integration using the Terrakube API. This way, you can automate compliance checks, cost estimates, security scans, and more for your Terraform projects.
-  
+
 - **Access Control:** You can use [DEX](https://github.com/dexidp/dex) to authenticate in Terrakube with various identity providers, such as Azure Active Directory, Amazon Cognito, Github, SAML, and more. You can also leverage your existing groups to assign granular permissions to Workspaces, Modules, VCS, and other resources.
 
 - **Remote Backend:** Terrakube supports both `remote backend` and `cloud` block so you can run your workflow directly from the Terraform / OpenTofu CLI.
@@ -51,13 +51,14 @@ The key features of Terrakube are:
 - [Install Terrakube using Docker Compose](https://docs.terrakube.io/getting-started/docker-compose)
 - [Test Terrakube using Minikube](https://docs.terrakube.io/getting-started/deployment/minikube-+-https)
 - [Test Terrakube using Gitpod](https://docs.terrakube.io/getting-started/getting-started)
+- [Develop Terrakube using VS Code Devcontainers](.devcontainer/README.md)
 
 ### Documentation
 To learn more about Terrakube [go to the complete documentation.](https://docs.terrakube.io/) 
 
 ### Contributing 
 Terrakube welcomes any idea or feedback from the community. If you want to contribute to this project, please read our [Contribution Guide](CONTRIBUTING.md) for more details.
-  
+
 ### Sponsors
 
 | Sponsor  | Thanks |

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -49,7 +49,7 @@ Update the /etc/hosts file adding the following entries:
 git clone https://github.com/AzBuilder/terrakube.git
 cd terrakube/docker-compose
 mkcert -key-file key.pem -cert-file cert.pem platform.local *.platform.local
-
+CAROOT=$(mkcert -CAROOT)/rootCA.pem
 cp $CAROOT rootCA.pem
 docker compose up -d --force-recreate
 ```

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -49,7 +49,7 @@ Update the /etc/hosts file adding the following entries:
 git clone https://github.com/AzBuilder/terrakube.git
 cd terrakube/docker-compose
 mkcert -key-file key.pem -cert-file cert.pem platform.local *.platform.local
-CAROOT=$(mkcert -CAROOT)/rootCA.pem
+
 cp $CAROOT rootCA.pem
 docker compose up -d --force-recreate
 ```

--- a/scripts/setupDevelopmentEnvironment.sh
+++ b/scripts/setupDevelopmentEnvironment.sh
@@ -7,11 +7,13 @@ function generateApiVars(){
     AzBuilderExecutorUrl="$(gp url 8090)/api/v1/terraform-rs"
     DexIssuerUri="$(gp url 5556)/dex"
     TerrakubeUiURL=$(gp url 3000)
+    TerrakubeRedisHostname=localhost
   else
     TerrakubeHostname="https://terrakube-api.platform.local"
     AzBuilderExecutorUrl="http://localhost:8090/api/v1/terraform-rs"
     DexIssuerUri="https://terrakube-dex.platform.local/dex"
     TerrakubeUiURL="https://terrakube-ui.platform.local"
+    TerrakubeRedisHostname=terrakube-redis
   fi
 
   ApiDataSourceType="H2"
@@ -44,7 +46,7 @@ function generateApiVars(){
   echo "DexClientId=$DexClientId" >> .envApi
   echo "CustomTerraformReleasesUrl=\"https://releases.hashicorp.com/terraform/index.json\"" >> .envApi
   echo "CustomTofuReleasesUrl=\"https://api.github.com/repos/opentofu/opentofu/releases\"" >> .envApi
-  echo "TerrakubeRedisHostname=localhost" >> .envApi
+  echo "TerrakubeRedisHostname=$TerrakubeRedisHostname" >> .envApi
   echo "TerrakubeRedisPort=6379" >> .envApi
   echo "TerrakubeRedisSSL=false" >> .envApi
   echo "#TerrakubeRedisUsername=default" >> .envApi

--- a/scripts/setupDevelopmentEnvironment.sh
+++ b/scripts/setupDevelopmentEnvironment.sh
@@ -8,10 +8,10 @@ function generateApiVars(){
     DexIssuerUri="$(gp url 5556)/dex"
     TerrakubeUiURL=$(gp url 3000)
   else
-    TerrakubeHostname="http://localhost:8080"
+    TerrakubeHostname="https://terrakube-api.platform.local"
     AzBuilderExecutorUrl="http://localhost:8090/api/v1/terraform-rs"
-    DexIssuerUri="http://localhost:5556/dex"
-    TerrakubeUiURL="http://localhost:3000"
+    DexIssuerUri="https://terrakube-dex.platform.local/dex"
+    TerrakubeUiURL="https://terrakube-ui.platform.local"
   fi
 
   ApiDataSourceType="H2"
@@ -54,16 +54,16 @@ function generateApiVars(){
   echo "#TERRAKUBE_ADMIN_GROUP=$TERRAKUBE_ADMIN_GROUP" >> .envApi
 }
 
-function generateRegistryVars(){
+function generateExecutorVars(){
   USER=$(whoami)
   if [ "$USER" = "gitpod" ]; then
     AzBuilderApiUrl=$(gp url 8080)
     TerrakubeRegistryDomain=$(gp url 8075 | sed "s+https://++g")
     TerrakubeApiUrl=$(gp url 8080)
   else
-    AzBuilderApiUrl="http://localhost:8080"
-    TerrakubeRegistryDomain="http://localhost:8075"
-    TerrakubeApiUrl="htp://localhost:8080"
+    AzBuilderApiUrl="https://terrakube-api.platform.local"
+    TerrakubeRegistryDomain="https://terrakube-registry.platform.local"
+    TerrakubeApiUrl="htps://terrakube-api.platform.local"
   fi
 
   TerrakubeEnableSecurity=true
@@ -100,7 +100,7 @@ function generateRegistryVars(){
   echo "JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS" >> .envExecutor
 }
 
-function generateExecutorVars(){
+function generateRegistryVars(){
   USER=$(whoami)
   if [ "$USER" = "gitpod" ]; then
     AzBuilderRegistry=$(gp url 8075)
@@ -109,11 +109,11 @@ function generateExecutorVars(){
     TerrakubeUiURL=$(gp url 3000)
     AppIssuerUri="$(gp url 5556)/dex"
   else
-    AzBuilderRegistry="http://localhost:8075"
-    AzBuilderApiUrl="http://localhost:8080"
-    DexIssuerUri="http://localhost:5556/dex"
-    TerrakubeUiURL="http://localhost:3000"
-    AppIssuerUri="http://localhost:5556/dex"
+    AzBuilderRegistry="https://terrakube-registry.platform.local"
+    AzBuilderApiUrl="https://terrakube-api.platform.local"
+    DexIssuerUri="https://terrakube-dex.platform.local/dex"
+    TerrakubeUiURL="https://terrakube-ui.platform.local"
+    AppIssuerUri="https://terrakube-dex.platform.local/dex"
   fi
 
   AuthenticationValidationTypeRegistry=DEX
@@ -149,10 +149,10 @@ function generateUiVars(){
     REACT_CONFIG_REGISTRY_URI=$(gp url 8075)  
     REACT_CONFIG_AUTHORITY="$(gp url 5556)/dex"
   else
-    REACT_CONFIG_TERRAKUBE_URL="http://localhost:8080/api/v1/"
-    REACT_CONFIG_REDIRECT="http://localhost:3000"
-    REACT_CONFIG_REGISTRY_URI="http://localhost:8075"
-    REACT_CONFIG_AUTHORITY="http://localhost:5556/dex"
+    REACT_CONFIG_TERRAKUBE_URL="https://terrakube-api.platform.local/api/v1/"
+    REACT_CONFIG_REDIRECT="https://terrakube-ui.platform.local"
+    REACT_CONFIG_REGISTRY_URI="https://terrakube-registry.platform.local"
+    REACT_CONFIG_AUTHORITY="https://terrkube-dex.platform.local/dex"
   fi
 
   REACT_CONFIG_CLIENT_ID="example-app"

--- a/scripts/setupDevelopmentEnvironment.sh
+++ b/scripts/setupDevelopmentEnvironment.sh
@@ -65,8 +65,8 @@ function generateExecutorVars(){
     TerrakubeRedisHostname=localhost
   else
     AzBuilderApiUrl="https://terrakube-api.platform.local"
-    TerrakubeRegistryDomain="https://terrakube-registry.platform.local"
-    TerrakubeApiUrl="htps://terrakube-api.platform.local"
+    TerrakubeRegistryDomain="terrakube-registry.platform.local"
+    TerrakubeApiUrl="https://terrakube-api.platform.local"
     TerrakubeRedisHostname=terrakube-redis
   fi
 

--- a/scripts/setupDevelopmentEnvironment.sh
+++ b/scripts/setupDevelopmentEnvironment.sh
@@ -279,12 +279,12 @@ function generateWorkspaceInformation(){
   if [ "$USER" != "gitpod" ] && [ "$USER" == "vscode" ]; then
     openssl x509 -outform der -in /workspaces/terrakube/.devcontainer/rootCA.pem -out /workspaces/terrakube/.devcontainer/rootCA.der
     
-    if keytool -list -cacerts -storepass "123456" | grep -q "custom-ca"; then
+    if keytool -list -cacerts -storepass "changeit" | grep -q "custom-ca"; then
       echo "Alias $ALIAS exists. Deleting it first..."
-      keytool -delete -alias "custom-ca" -cacerts -storepass "123456" -noprompt
+      keytool -delete -alias "custom-ca" -cacerts -storepass "changeit" -noprompt
     fi
 
-    keytool -import -alias custom-ca -cacerts -file /workspaces/terrakube/.devcontainer/rootCA.der -storepass "123456" -noprompt
+    keytool -import -alias custom-ca -cacerts -file /workspaces/terrakube/.devcontainer/rootCA.der -storepass "changeit" -noprompt
   fi
 
 generateApiVars

--- a/ui/vite.config.mts
+++ b/ui/vite.config.mts
@@ -6,6 +6,8 @@ import tsconfigPaths from "vite-tsconfig-paths";
 export default defineConfig(() => {
   return {
     server: {
+      host: true,
+      allowedHosts: true,
       port: 3000,
     },
     build: {


### PR DESCRIPTION
This will allow to develop Terrakube using devcontainers with vscode  instead of using gitpod

For more details check the following:

`.devcontainers/README.MD`

> The below was tested using ubuntu-based distribution, not sure if it will require changes to run in macos, windows or codespaces

![image](https://github.com/user-attachments/assets/b5a3b68e-8243-4420-9944-d67d383b118a)

It will allow to easily test or modify all the components

![image](https://github.com/user-attachments/assets/b72c6dbc-5142-489f-82cf-8852563a2487)

It will also allow to use https to test all the terraform cli features like for example the registry support

![image](https://github.com/user-attachments/assets/49221464-ddd2-414b-ba9d-5a40a359fb0e)

It will allow to run terraform login from inside the container

![image](https://github.com/user-attachments/assets/ce3324ec-8c75-4f63-95ca-7095da3f15d1)
