### PR TITLE
Update dependencies and buildpack versions across modules

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -40,9 +40,9 @@
         <commons-io.version>2.19.0</commons-io.version>
         <kubernetes-client.version>7.3.0</kubernetes-client.version>
         <!--BUILDPACK DATA-->
-        <buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.384</buildpack.builder>
-        <buildpack.java>gcr.io/paketo-buildpacks/java:18.1.0</buildpack.java>
-        <buildpack.telemetry>gcr.io/paketo-buildpacks/opentelemetry:2.9.0</buildpack.telemetry>
+        <buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.414</buildpack.builder>
+        <buildpack.java>paketobuildpacks/java:18.7.0</buildpack.java>
+        <buildpack.telemetry>paketobuildpacks/opentelemetry:2.12.0</buildpack.telemetry>
     </properties>
     <build>
         <plugins>

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -36,9 +36,9 @@
 		<sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}
 		</sonar.coverage.jacoco.xmlReportPaths>
 		<!--BUILDPACK DATA-->
-		<buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.384</buildpack.builder>
-		<buildpack.java>gcr.io/paketo-buildpacks/java:18.1.0</buildpack.java>
-		<buildpack.telemetry>gcr.io/paketo-buildpacks/opentelemetry:2.9.0</buildpack.telemetry>
+		<buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.414</buildpack.builder>
+		<buildpack.java>paketobuildpacks/java:18.7.0</buildpack.java>
+		<buildpack.telemetry>paketobuildpacks/opentelemetry:2.12.0</buildpack.telemetry>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.10</version>
+        <version>3.3.11</version>
     </parent>
 
     <groupId>org.terrakube</groupId>

--- a/registry/pom.xml
+++ b/registry/pom.xml
@@ -29,9 +29,9 @@
         <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}
         </sonar.coverage.jacoco.xmlReportPaths>
         <!--BUILDPACK DATA-->
-        <buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.384</buildpack.builder>
-        <buildpack.java>gcr.io/paketo-buildpacks/java:18.1.0</buildpack.java>
-        <buildpack.telemetry>gcr.io/paketo-buildpacks/opentelemetry:2.9.0</buildpack.telemetry>
+        <buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.414</buildpack.builder>
+        <buildpack.java>paketobuildpacks/java:18.7.0</buildpack.java>
+        <buildpack.telemetry>paketobuildpacks/opentelemetry:2.12.0</buildpack.telemetry>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
Upgraded Spring Boot to 3.3.11 and updated buildpack dependencies, including builder, Java, and telemetry, to their latest versions. These changes ensure compatibility, improved performance, and access to the latest features.