### PR TITLE
fix: Set webhook priority to 0 for old workspaces (#2185)

### DIFF
--- a/api/src/main/java/org/terrakube/api/rs/webhook/WebhookEvent.java
+++ b/api/src/main/java/org/terrakube/api/rs/webhook/WebhookEvent.java
@@ -40,7 +40,7 @@ public class WebhookEvent extends GenericAuditFields {
     @Enumerated(EnumType.STRING)
     private WebhookEventType event;
     
-    private int priority;
+    private int priority = 0;
     
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private Webhook webhook;

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -82,4 +82,5 @@
     <include file="/db/changelog/local/changelog-2.26.0-add-workspace-column-fix.xml" />
     <include file="/db/changelog/local/changelog-2.26.0-size-access-token.xml" />
     <include file="/db/changelog/local/changelog-2.26.0-organization-icon.xml" />
+    <include file="/db/changelog/local/changelog-2.26.1-webhook-data-fix.xml" />
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.26.1-webhook-data-fix.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.26.1-webhook-data-fix.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-26-1-fix" author="alfespa17@gmail.com">
+        <sql dbms="postgresql, mssql">
+           update webhook_event set priority=0 where priority is null
+        </sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
* fix: Set webhook priority to 0 for old workspaces