### PR TITLE
fix: Remove padding from jwks endpoint

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/JwksController.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/JwksController.java
@@ -54,7 +54,7 @@ public class JwksController {
 
             RSAPublicKey rsa = (RSAPublicKey) keyFactory.generatePublic(keySpec);
             String exponent = Base64.getUrlEncoder().encodeToString(rsa.getPublicExponent().toByteArray());
-            String modulus = Base64.getUrlEncoder().encodeToString(rsa.getModulus().toByteArray());
+            String modulus = Base64.getUrlEncoder().withoutPadding().encodeToString(rsa.getModulus().toByteArray());
             log.info("RSA Exponent: {}", exponent);
             log.info("RSA Modulus: {}", modulus);
 


### PR DESCRIPTION
This is related to this comment https://github.com/openbao/openbao/issues/1475#issuecomment-3001504664

Before the change there is a "=" at the end of property "n"

```json
{
  "keys": [
    {
      "kty": "RSA",
      "use": "sig",
      "n": "APOXbjzPkcpGrh2oLKVyV91FoLsa94TVMoZXEN2cgNvAe3_A1_hRgDBblLU_DUTSu3Douhds-23CakRQgE6PMPl9DveQ086wJxQJ1zXKKRHZIKIguXxRHJb8-8J3Eh-UN1NIUiq6azSa4yoc8b2nRLCJ-LzSNMWvzxzeOfDFORdVSjNO53IGG7XaJ8A3kne2S7WlNzFxCRHWz4NFzVcrfwwGkL7qIhl6lnpikNClLMYw54ztfae5CO1Xj0o4Jgf5zUCClwSlZrk-VQw32ivZWQpmpwMRvCTl1y9Eqr8bkBrf31JkgWH-WhngJ7h1RtKV0FHHswBR_Edq4oSxZZRa28s=",
      "e": "AQAB",
      "kid": "03446895-220d-47e1-9564-4eeaa3691b42",
      "alg": "RS256"
    }
  ]
}
```

After the change the "=" is no longer included

```json
{
  "keys": [
    {
      "kty": "RSA",
      "use": "sig",
      "n": "APOXbjzPkcpGrh2oLKVyV91FoLsa94TVMoZXEN2cgNvAe3_A1_hRgDBblLU_DUTSu3Douhds-23CakRQgE6PMPl9DveQ086wJxQJ1zXKKRHZIKIguXxRHJb8-8J3Eh-UN1NIUiq6azSa4yoc8b2nRLCJ-LzSNMWvzxzeOfDFORdVSjNO53IGG7XaJ8A3kne2S7WlNzFxCRHWz4NFzVcrfwwGkL7qIhl6lnpikNClLMYw54ztfae5CO1Xj0o4Jgf5zUCClwSlZrk-VQw32ivZWQpmpwMRvCTl1y9Eqr8bkBrf31JkgWH-WhngJ7h1RtKV0FHHswBR_Edq4oSxZZRa28s",
      "e": "AQAB",
      "kid": "03446895-220d-47e1-9564-4eeaa3691b42",
      "alg": "RS256"
    }
  ]
}
```