### PR TITLE
feat: Openbao/Vault dynamic credentials support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,6 +25,12 @@ RUN curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor 
     apt-get install -y mssql-tools18 unixodbc-dev && \
     ln -s /opt/mssql-tools18/bin/* /usr/local/bin/
 
+RUN wget -O - https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(grep -oP '(?<=UBUNTU_CODENAME=).*' /etc/os-release || lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list && \
+    apt update && \
+    apt install vault && \
+    setcap -r /usr/bin/vault
+
 COPY rootCA.pem /usr/local/share/ca-certificates/root.crt
 
 RUN update-ca-certificates

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,11 +25,14 @@ RUN curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor 
     apt-get install -y mssql-tools18 unixodbc-dev && \
     ln -s /opt/mssql-tools18/bin/* /usr/local/bin/
 
-RUN wget -O - https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(grep -oP '(?<=UBUNTU_CODENAME=).*' /etc/os-release || lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list && \
-    apt update && \
-    apt install vault && \
-    setcap -r /usr/bin/vault
+#RUN wget -O - https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
+#    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(grep -oP '(?<=UBUNTU_CODENAME=).*' /etc/os-release || lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list && \
+#    apt update && \
+#    apt install vault && \
+#    setcap -r /usr/bin/vault
+
+RUN wget https://github.com/openbao/openbao/releases/download/v2.2.2/bao_2.2.2_linux_amd64.deb && \
+    dpkg -i bao_2.2.2_linux_amd64.deb
 
 COPY rootCA.pem /usr/local/share/ca-certificates/root.crt
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -254,6 +254,12 @@ services:
     environment: *ldap_env
     volumes:
       - ./config-ldap.ldif:/ldifs/config-ldap.ldif
+  vault-service:
+    image: hashicorp/vault:latest
+    extra_hosts: *terrakube_hosts
+    container_name: terrakube-vault-service
+    environment:
+      - VAULT_DEV_ROOT_TOKEN_ID=dev-only-token
   minio:
     container_name: terrakube-minio
     image: docker.io/bitnami/minio:${TK_MINIO_VERSION}

--- a/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -272,6 +272,11 @@ public class ExecutorService {
                     workspaceEnvVariables);
         }
 
+        if (workspaceEnvVariables.containsKey("ENABLE_DYNAMIC_CREDENTIALS_VAULT")) {
+            workspaceEnvVariables = dynamicCredentialsService.generateDynamicCredentialsVault(job,
+                    workspaceEnvVariables);
+        }
+
         if (workspaceEnvVariables.containsKey("ENABLE_DYNAMIC_CREDENTIALS_AWS")) {
             workspaceEnvVariables = dynamicCredentialsService.generateDynamicCredentialsAws(job, workspaceEnvVariables);
         }

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -56,6 +56,23 @@ public class DynamicCredentialsService {
         return workspaceEnvVariables;
     }
 
+    @Transactional
+    public HashMap<String, String> generateDynamicCredentialsVault(Job job, HashMap<String, String> workspaceEnvVariables) {
+        String jwtToken = generateJwt(
+                job.getOrganization().getName(),
+                job.getWorkspace().getName(),
+                workspaceEnvVariables.get("WORKLOAD_IDENTITY_AUDIENCE_VAULT"),
+                job.getOrganization().getId().toString(),
+                job.getWorkspace().getId().toString(),
+                job.getId()
+        );
+
+        log.info("VAULT_TOKEN: {}", jwtToken);
+        workspaceEnvVariables.put("VAULT_TOKEN", jwtToken);
+
+        return workspaceEnvVariables;
+    }
+
     private String generateJwt(String organizationName, String workspaceName, String tokenAudience, String organizationId, String workspaceId, int jobId) {
         String jwtToken = "";
         if (privateKeyPath != null && !privateKeyPath.isEmpty()) {

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -97,8 +97,8 @@ public class DynamicCredentialsService {
             log.error("Error processing vault token", e);
         }
 
-        log.info("TERRAKUBE_VAULT_TOKEN: {}", jwtToken);
-        log.info("VAULT_TOKEN: {}", vaultToken);
+        log.debug("TERRAKUBE_VAULT_TOKEN: {}", jwtToken);
+        log.debug("VAULT_TOKEN: {}", vaultToken);
         workspaceEnvVariables.put("VAULT_TOKEN", vaultToken);
 
         return workspaceEnvVariables;

--- a/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/org/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -90,7 +90,7 @@ public class DynamicCredentialsService {
             String url = String.format("%s/v1/auth/jwt/login",vaultAddress);
             String vaultResponse = restTemplate.postForObject(url, request, String.class);
 
-            log.info("Vault Response: {}", vaultResponse);
+            log.debug("Vault Response: {}", vaultResponse);
             JsonNode rootNode = objectMapper.readTree(vaultResponse);
             vaultToken = rootNode.get("auth").get("client_token").asText();
         } catch (Exception e) {

--- a/scripts/setupDevelopmentEnvironment.sh
+++ b/scripts/setupDevelopmentEnvironment.sh
@@ -133,8 +133,8 @@ function generateApiVars(){
   echo "TerrakubeRedisPort=6379" >> .envApi
   echo "TerrakubeRedisSSL=false" >> .envApi
   echo "#TerrakubeRedisUsername=default" >> .envApi
-  echo "DynamicCredentialPublicKeyPath=/workspace/terrakube/public.pem" >> .envApi
-  echo "DynamicCredentialPrivateKeyPath=/workspace/terrakube/private.pem" >> .envApi
+  echo "DynamicCredentialPublicKeyPath=/workspaces/terrakube/public.pem" >> .envApi
+  echo "DynamicCredentialPrivateKeyPath=/workspaces/terrakube/private.pem" >> .envApi
   echo "TerrakubeRedisPassword=password123456" >> .envApi
   echo "#TERRAKUBE_ADMIN_GROUP=$TERRAKUBE_ADMIN_GROUP" >> .envApi
 }

--- a/terrakube-policy.hcl
+++ b/terrakube-policy.hcl
@@ -1,0 +1,19 @@
+# Allow tokens to query themselves
+path "auth/token/lookup-self" {
+  capabilities = ["read"]
+}
+
+# Allow tokens to renew themselves
+path "auth/token/renew-self" {
+  capabilities = ["update"]
+}
+
+# Allow tokens to revoke themselves
+path "auth/token/revoke-self" {
+  capabilities = ["update"]
+}
+
+# Configure the actual secrets the token should have access to
+path "shared/data/kv/creds" {
+  capabilities = ["read"]
+}

--- a/vault-jwt-auth-role.json
+++ b/vault-jwt-auth-role.json
@@ -1,12 +1,11 @@
 {
   "policies": ["tfc-policy"],
+  "role_type": "jwt",
   "bound_audiences": ["vault.workload.identity"],
   "bound_claims_type": "glob",
+  "user_claim": "terrakube_workspace_name",
   "bound_claims": {
-    "sub":
-    "organization:simple:workspace:vault"
+    "sub":"organization:simple:workspace:vault"
   },
-  "user_claim": "terraform_full_workspace",
-  "role_type": "jwt",
   "token_ttl": "20m"
 }

--- a/vault-jwt-auth-role.json
+++ b/vault-jwt-auth-role.json
@@ -1,0 +1,12 @@
+{
+  "policies": ["tfc-policy"],
+  "bound_audiences": ["vault.workload.identity"],
+  "bound_claims_type": "glob",
+  "bound_claims": {
+    "sub":
+    "organization:simple:workspace:vault"
+  },
+  "user_claim": "terraform_full_workspace",
+  "role_type": "jwt",
+  "token_ttl": "20m"
+}

--- a/vault/README.md
+++ b/vault/README.md
@@ -2,17 +2,17 @@
 ## Steps
 
 ```
-vault server -dev -dev-root-token-id="dev-only-token" & 
+bao server -dev -dev-root-token-id="dev-only-token" & 
 export VAULT_ADDR='http://localhost:8200'
-vault login dev-only-token
-vault auth enable userpass
-vault write auth/userpass/users/terrakube password=p@ssw0rd
-vault auth enable approle
-vault write auth/approle/role/terrakube-role secret_id_ttl=10m token_ttl=20m token_max_ttl=30m
-vault secrets enable -path shared -version 2 kv
-vault kv put -mount shared kv/creds username=terrakube password=p@ssw0rd
-vault auth enable jwt
-vault write auth/jwt/config oidc_discovery_url="https://terrakube-api.platform.local" bound_issuer="https://terrakube-api.platform.local" 
-vault policy write tfc-policy terrakube-policy.hcl
-vault write auth/jwt/role/tfc-role @vault-jwt-auth-role.json
+bao login dev-only-token
+bao auth enable userpass
+bao write auth/userpass/users/terrakube password=p@ssw0rd
+bao auth enable approle
+bao write auth/approle/role/terrakube-role secret_id_ttl=10m token_ttl=20m token_max_ttl=30m
+bao secrets enable -path shared -version 2 kv
+bao kv put -mount shared kv/creds username=terrakube password=p@ssw0rd
+bao auth enable jwt
+bao write auth/jwt/config oidc_discovery_url="https://terrakube-api.platform.local" bound_issuer="https://terrakube-api.platform.local" 
+bao policy write tfc-policy terrakube-policy.hcl
+bao write auth/jwt/role/tfc-role @vault-jwt-auth-role.json
 ```

--- a/vault/README.md
+++ b/vault/README.md
@@ -1,0 +1,18 @@
+
+## Steps
+
+```
+vault server -dev -dev-root-token-id="dev-only-token" & 
+export VAULT_ADDR='http://localhost:8200'
+vault login dev-only-token
+vault auth enable userpass
+vault write auth/userpass/users/terrakube password=p@ssw0rd
+vault auth enable approle
+vault write auth/approle/role/terrakube-role secret_id_ttl=10m token_ttl=20m token_max_ttl=30m
+vault secrets enable -path shared -version 2 kv
+vault kv put -mount shared kv/creds username=terrakube password=p@ssw0rd
+vault auth enable jwt
+vault write auth/jwt/config oidc_discovery_url="https://terrakube-api.platform.local" bound_issuer="https://terrakube-api.platform.local" 
+vault policy write tfc-policy terrakube-policy.hcl
+vault write auth/jwt/role/tfc-role @vault-jwt-auth-role.json
+```

--- a/vault/backend.tf
+++ b/vault/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  cloud {
+    hostname = "terrakube-api.platform.local"
+    organization = "simple"
+    workspaces {
+      name = "vault"
+    }
+  }
+}

--- a/vault/main.tf
+++ b/vault/main.tf
@@ -2,17 +2,12 @@ provider vault {
   address = "http://localhost:8200"
   skip_tls_verify = true
   skip_child_token = true
-  
-}
-
-data "vault_kv_secret_v2" "username" {
-  mount = "shared/data/kv/creds"
-  name  = "username"
-}
+  token = ""
+  }
 
 data "vault_kv_secret_v2" "password" {
-  mount = "shared/data/kv/creds"
-  name  = "password"
+  mount = "shared"
+  name  = "kv/creds"
 }
 
 

--- a/vault/main.tf
+++ b/vault/main.tf
@@ -1,8 +1,6 @@
 provider vault {
-  address = "http://localhost:8200"
   skip_tls_verify = true
   skip_child_token = true
-  token = ""
   }
 
 data "vault_kv_secret_v2" "password" {

--- a/vault/main.tf
+++ b/vault/main.tf
@@ -1,0 +1,18 @@
+provider vault {
+  address = "http://localhost:8200"
+  skip_tls_verify = true
+  skip_child_token = true
+  
+}
+
+data "vault_kv_secret_v2" "username" {
+  mount = "shared/data/kv/creds"
+  name  = "username"
+}
+
+data "vault_kv_secret_v2" "password" {
+  mount = "shared/data/kv/creds"
+  name  = "password"
+}
+
+


### PR DESCRIPTION
This PR add support to read values from Openbao/Vault using dynamic credentials to authenticate

Example:

Running openbao in development mode

```shell
bao server -dev -dev-root-token-id="dev-only-token" 
```

Use the following openbao policy 

```terraform
# Allow tokens to query themselves
path "auth/token/lookup-self" {
  capabilities = ["read"]
}

# Allow tokens to renew themselves
path "auth/token/renew-self" {
  capabilities = ["update"]
}

# Allow tokens to revoke themselves
path "auth/token/revoke-self" {
  capabilities = ["update"]
}

# Configure the actual secrets the token should have access to
path "shared/data/kv/creds" {
  capabilities = ["read"]
}
```

JWT Role
```json
{
  "policies": ["tfc-policy"],
  "role_type": "jwt",
  "bound_audiences": ["vault.workload.identity"],
  "bound_claims_type": "glob",
  "user_claim": "terrakube_workspace_name",
  "bound_claims": {
    "sub":"organization:simple:workspace:vault"
  },
  "token_ttl": "20m"
}
```

Adding test values, policy and jwt role to openbao with the following:
```shell
export VAULT_ADDR='http://localhost:8200'
bao login dev-only-token
bao auth enable userpass
bao write auth/userpass/users/terrakube password=p@ssw0rd
bao auth enable approle
bao write auth/approle/role/terrakube-role secret_id_ttl=10m token_ttl=20m token_max_ttl=30m
bao secrets enable -path shared -version 2 kv
bao kv put -mount shared kv/creds username=terrakube password=p@ssw0rd
bao auth enable jwt
bao write auth/jwt/config oidc_discovery_url="https://terrakube-api.platform.local" bound_issuer="https://terrakube-api.platform.local" 
bao policy write tfc-policy terrakube-policy.hcl
bao write auth/jwt/role/tfc-role @vault-jwt-auth-role.json
```

At the workspace level we need to define the following environment variables:

```shell
ENABLE_DYNAMIC_CREDENTIALS_VAULT=1
WORKLOAD_IDENTITY_VAULT_AUDIENCE=vault.workload.identity
VAULT_ADDR=http://localhost:8200
WORKLOAD_IDENTITY_VAULT_ROLE=tfc-role
```

![image](https://github.com/user-attachments/assets/ac15200f-5728-4a81-8aa6-69de5ad7bbb0)

Now running cli driven workflow with the following terraform code to test

```terraform
terraform {
  cloud {
    hostname = "terrakube-api.platform.local"
    organization = "simple"
    workspaces {
      name = "vault"
    }
  }
}

provider vault {
  skip_tls_verify = true
  skip_child_token = true
  }

data "vault_kv_secret_v2" "password" {
  mount = "shared"
  name  = "kv/creds"
}
```

It will show the following:

```shell
user@pop-os:~/git/terrakube/vault$ terraform plan

Running plan in Terraform Cloud. Output will stream here. Pressing Ctrl-C
will stop streaming the logs, but will not stop the plan running remotely.

Preparing the remote plan...

To view this run in a browser, visit:
https://terrakube-api.platform.local/app/simple/vault/runs/run-1

Waiting for the plan to start...

***************************************
Running Terraform PLAN
***************************************
data.vault_kv_secret_v2.password: Reading...
data.vault_kv_secret_v2.password: Read complete after 0s [id=shared/data/kv/creds]

No changes. Your infrastructure matches the configuration.
```

Fix #122 

