### PR TITLE
fix: terraform login protocol authentication with expired token

### DIFF
--- a/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
+++ b/api/src/main/java/org/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManagerResolver;
 import org.springframework.security.config.Customizer;
@@ -28,6 +29,18 @@ import java.util.List;
 public class DexWebSecurityAdapter {
 
         @Bean
+        @Order(0)
+        public SecurityFilterChain filterChainTerraformLogin(HttpSecurity http) throws Exception {
+                return http.securityMatchers(
+                                requestMatcherConfigurer ->
+                                        requestMatcherConfigurer
+                                                .requestMatchers(HttpMethod.GET, "/.well-known/terraform.json")
+                        ).authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                        .build();
+        }
+
+        @Bean
+        @Order(1)
         public SecurityFilterChain filterChain(HttpSecurity http,
                         @Value("${org.terrakube.token.issuer-uri}") String issuerUri,
                         @Value("${org.terrakube.token.pat}") String patJwtSecret,

--- a/registry/src/main/java/org/terrakube/registry/configuration/authentication/dex/DexWebSecurityAdapter.java
+++ b/registry/src/main/java/org/terrakube/registry/configuration/authentication/dex/DexWebSecurityAdapter.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManagerResolver;
 import org.springframework.security.config.Customizer;
@@ -27,7 +28,20 @@ import java.util.List;
 @EnableMethodSecurity(prePostEnabled = true, securedEnabled = true, jsr250Enabled = true)
 public class DexWebSecurityAdapter {
 
+
     @Bean
+    @Order(0)
+    public SecurityFilterChain filterChainTerraformLogin(HttpSecurity http) throws Exception {
+        return http.securityMatchers(
+                        requestMatcherConfigurer ->
+                                requestMatcherConfigurer
+                                        .requestMatchers(HttpMethod.GET, "/.well-known/**")
+                ).authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .build();
+    }
+
+    @Bean
+    @Order(1)
     public SecurityFilterChain filterChain(HttpSecurity http, @Value("${org.terrakube.token.issuer-uri}") String issuerUri, @Value("${org.terrakube.token.pat}") String patJwtSecret, @Value("${org.terrakube.token.internal}") String internalJwtSecret) throws Exception {
         http.cors(Customizer.withDefaults())
                 .authorizeHttpRequests(authz -> authz


### PR DESCRIPTION
This will fix the issue when running the `terraform login ` command with an expired token inside the `credentials.tfrc.json`

Fix #903