### PR TITLE
fix: Add last job status and date tracking for workspaces

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/init/InitWorkspaceStatus.java
+++ b/api/src/main/java/io/terrakube/api/plugin/init/InitWorkspaceStatus.java
@@ -1,0 +1,47 @@
+package io.terrakube.api.plugin.init;
+
+import io.terrakube.api.repository.JobRepository;
+import io.terrakube.api.repository.OrganizationRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.workspace.Workspace;
+import jakarta.annotation.PostConstruct;
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@AllArgsConstructor
+@Service
+@Slf4j
+public class InitWorkspaceStatus {
+
+    private final OrganizationRepository organizationRepository;
+    private final WorkspaceRepository workspaceRepository;
+    private final JobRepository jobRepository;
+
+    @PostConstruct
+    @Transactional
+    public void initWorkspaceStatus() {
+        organizationRepository.findAll().forEach(organization -> {
+            Optional<List<Workspace>> listOptional = workspaceRepository.findWorkspacesByOrganization(organization);
+            listOptional.ifPresent(workspaces -> workspaces.forEach(workspace -> {
+                Optional<Job> lastJob = jobRepository.findFirstByWorkspaceOrderByIdDesc(workspace);
+                if( lastJob.isPresent()){
+                    Job job = lastJob.get();
+                    workspace.setLastJobStatus(job.getStatus());
+                    workspace.setLastJobDate(job.getUpdatedDate());
+                    workspaceRepository.save(workspace);
+                } else {
+                    workspace.setLastJobStatus(JobStatus.NeverExecuted);
+                    workspaceRepository.save(workspace);
+                    log.warn("Workspace {} has no jobs to update status", workspace.getName());
+                }
+            }));
+        });
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -152,7 +152,15 @@ public class ScheduleJob implements org.quartz.Job {
                     log.info("Job {} Status {}", job.getId(), job.getStatus());
                     break;
             }
+            updateWorkspaceStatus(job);
         }
+    }
+
+    private void updateWorkspaceStatus(Job job) {
+        log.info("Updating last status for workspace {} to {}", job.getWorkspace().getName(), job.getStatus());
+        job.getWorkspace().setLastJobStatus(job.getStatus());
+        job.getWorkspace().setLastJobDate(new Date(System.currentTimeMillis()));
+        workspaceRepository.save(job.getWorkspace());
     }
 
     private void executePendingJob(Job job, JobExecutionContext jobExecutionContext) {
@@ -280,6 +288,7 @@ public class ScheduleJob implements org.quartz.Job {
         jobRepository.save(job);
         ephemeralExecutorService.deleteEphemeralJob(job);
         updateJobStatusOnVcs(job, JobStatus.completed);
+        updateWorkspaceStatus(job);
         log.info("Update Job {} to completed", job.getId());
     }
 

--- a/api/src/main/java/io/terrakube/api/repository/JobRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/JobRepository.java
@@ -22,4 +22,5 @@ public interface JobRepository extends JpaRepository<Job, Integer> {
 
     Optional<Job> findFirstByWorkspaceAndAndStatusInOrderByIdAsc(Workspace workspace, List<JobStatus> jobStatuses);
     Optional<Job> findFirstByWorkspaceAndStatusInOrderByIdAsc(Workspace workspace, List<JobStatus> jobStatuses);
+    Optional<Job> findFirstByWorkspaceOrderByIdDesc(Workspace workspace);
 }

--- a/api/src/main/java/io/terrakube/api/repository/WorkspaceRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/WorkspaceRepository.java
@@ -1,5 +1,6 @@
 package io.terrakube.api.repository;
 
+import io.terrakube.api.rs.Organization;
 import io.terrakube.api.rs.workspace.Workspace;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,5 +13,7 @@ public interface WorkspaceRepository extends JpaRepository<Workspace, UUID> {
     Workspace getByOrganizationNameAndName(String organizationName, String workspaceName);
 
     Optional<List<Workspace>> findWorkspacesByOrganizationNameAndNameStartingWith(String organizationName, String workspaceNameStartingWidth);
+
+    Optional<List<Workspace>> findWorkspacesByOrganization(Organization organization);
 
 }

--- a/api/src/main/java/io/terrakube/api/rs/job/JobStatus.java
+++ b/api/src/main/java/io/terrakube/api/rs/job/JobStatus.java
@@ -12,5 +12,6 @@ public enum JobStatus {
     rejected,
     cancelled,
     failed,
-    unknown
+    unknown,
+    NeverExecuted
 }

--- a/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
@@ -1,9 +1,12 @@
 package io.terrakube.api.rs.workspace;
 
 import java.sql.Types;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
+import io.terrakube.api.rs.job.JobStatus;
+import jakarta.persistence.*;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.SQLRestriction;
 import io.terrakube.api.plugin.security.audit.GenericAuditFields;
@@ -31,16 +34,6 @@ import com.yahoo.elide.annotation.LifeCycleHookBinding;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -77,6 +70,12 @@ public class Workspace extends GenericAuditFields {
 
     @Column(name = "folder")
     private String folder;
+
+    @Column(name = "last_job_status")
+    private JobStatus lastJobStatus = JobStatus.NeverExecuted;
+
+    @Column(name = "last_job_date")
+    private Date lastJobDate;
 
     @Column(name = "locked")
     private boolean locked;

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -86,4 +86,5 @@
     <include file="/db/changelog/local/changelog-2.27.0-quartz-job-class-migration.xml" />
     <include file="/db/changelog/local/changelog-2.27.1-module-versions.xml"/>
     <include file="/db/changelog/local/changelog-2.27.2-delete-legacy-module-refresh.xml"/>
+    <include file="/db/changelog/local/changelog-2.28.0-workspace-last-status.xml" />
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.28.0-workspace-last-status.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.28.0-workspace-last-status.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-28-0-1" author="alfespa17@gmail.com">
+        <addColumn tableName="workspace">
+            <column name="last_job_status" type="varchar(36)">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+        <addColumn tableName="workspace" >
+            <column name="last_job_date" type="datetime"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/ui/src/modules/workspaces/workspaceService.ts
+++ b/ui/src/modules/workspaces/workspaceService.ts
@@ -21,6 +21,8 @@ async function listWorkspaces(organizationId: string): Promise<ApiResponse<ListW
                       branch
                       terraformVersion
                       iacType
+                      lastJobStatus
+                      lastJobDate
                       workspaceTag {
                         edges { 
                           node {
@@ -28,15 +30,6 @@ async function listWorkspaces(organizationId: string): Promise<ApiResponse<ListW
                             tagId
                           }
                         } 
-                      }
-                      job(sort: "id") {
-                        edges {
-                          node {
-                            id
-                            status
-                            updatedDate
-                          }
-                        }
                       }
                     }
                   }
@@ -69,11 +62,12 @@ async function listWorkspaces(organizationId: string): Promise<ApiResponse<ListW
   const includes = tempData.data.organization.edges[0].node.workspace.edges;
 
   const workspaces = includes.map((element: any) => {
-    const lastJob = element.node.job.edges?.slice(-1)?.pop()?.node;
-    const lastStatus = lastJob?.status ?? "NeverExecuted";
+    console.log(element.node.name + " " + element.node.lastJobStatus + " " + element.node.lastJobDate);
+    const lastStatus = element.node.lastJobStatus;
+    const lastJobDate = element.node.lastJobDate;
     const ws: WorkspaceListItem = {
       id: element.node.id,
-      lastRun: lastJob?.updatedDate,
+      lastRun: lastJobDate,
       lastStatus,
       name: element.node.name,
       description: element.node.description,


### PR DESCRIPTION
- Introduced `lastJobStatus` and `lastJobDate` fields in the `workspace` table.
- Updated job lifecycle hooks to update workspace status and date.
- Added an initialization script to populate last job data for existing workspaces.
- Simplified workspace service to rely on these new fields instead of querying job lists.

fix #2295 