### PR TITLE
Wait for terraform state pull to complete

### DIFF
--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -355,6 +355,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         Boolean showJsonState = terraformClient.show(terraformProcessData, applyJSON, applyJSON).get();
         Boolean showRawState = terraformClient.statePull(terraformProcessData, rawStateJSON, rawStateJSON).get();
 
+        Thread.sleep(5000);
+
         if (Boolean.TRUE.equals(showRawState)) {
             terraformJob.setRawState(rawStateJSON.toString());
         }


### PR DESCRIPTION
We have identified a strange issue where the output of the terraform state pull command does not get fully produced before it is set on the terraformJob, therefore truncating the rawStateJSON.

This happens especially often when the state of the workspace is very large.

One issue from a while ago discusses a similar problem: https://github.com/hashicorp/terraform/issues/293, but it is unclear why it is occuring here.

Adding a 5 second wait has resolved the issue and the state doesn't get truncated.