### PR TITLE
Optionally install AWS cli on executor in build script

### DIFF
--- a/scripts/build/terrakubeBuild.sh
+++ b/scripts/build/terrakubeBuild.sh
@@ -13,7 +13,11 @@ mvn -pl "api,registry,executor" versions:set-property -Dproperty=revision -DnewV
 mvn -pl "api,registry,executor" spring-boot:build-image -B  --file pom.xml
 
 # Install other dependencies to use with Terrakube Extensions in terrakube executor creating a temporal image
-docker run --user="root" --entrypoint launcher $(docker images executor -q) "apt-get update && apt-get install git jq curl -y"
+if [ "$INSTALL_AWS_CLI" = "true" ]; then
+  docker run --user="root" --entrypoint launcher $(docker images executor -q) "apt-get update && apt-get install git jq curl unzip -y && curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && unzip awscliv2.zip && ./aws/install"
+else
+  docker run --user="root" --entrypoint launcher $(docker images executor -q) "apt-get update && apt-get install git jq curl -y"
+fi
 
 # Rollback to original entry point
 docker commit --change='ENTRYPOINT ["/cnb/process/web"]' --change='USER cnb' $(docker ps -lq) executortemp


### PR DESCRIPTION
Add the option to install the aws cli in the executor as part of the image building script.

The aws cli could be required when running certain commands on the executor and when running a script via a terraform null_resource with local_exec to interact with aws resources.