### PR TITLE
fix: Upgrade version to fix out of memory error

### DIFF
--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<commons-text.version>1.14.0</commons-text.version>
-		<terraform-spring-boot-starter.version>1.2.1</terraform-spring-boot-starter.version>
+		<terraform-spring-boot-starter.version>1.2.2</terraform-spring-boot-starter.version>
 		<terrakube-client-starter.version>1.1.0</terrakube-client-starter.version>
 		<commons-io.version>2.20.0</commons-io.version>
 		<commons-codec>1.19.0</commons-codec>


### PR DESCRIPTION
Updated the version of terraform-spring-boot-starter from 1.2.1 to 1.2.2.

Fix memory issue when downloading tofu releases because the response is bigger than 10 mb

```
Error fetching terraform releases 200 OK from GET http://terrakube-api-service:8080/tofu/index.json, but response failed with cause: reactor.netty.ReactorNetty$InternalNettyException: java.lang.OutOfMemoryError: Cannot reserve 65536 bytes of direct buffer memory (allocated: 10469424, limit: 10485760)
[threadPoolTaskExecutor-1] ERROR org.springframework.aop.interceptor.SimpleAsyncUncaughtExceptionHandler - Unexpected exception occurred invoking async method: public void io.terrakube.executor.service.executor.ExecutorJobImpl.createJob(io.terrakube.executor.service.mode.TerraformJob)
java.lang.NullPointerException: Cannot invoke "java.util.List.size()" because "this.tofuReleases" is null
	at io.terrakube.terraform.TerraformDownloader.getTofuReleases(TerraformDownloader.java:180)
	at io.terrakube.terraform.TerraformDownloader.<init>(TerraformDownloader.java:77)
	at io.terrakube.terraform.TerraformClient.createTerraformDownloader(TerraformClient.java:446)
	at io.terrakube.terraform.TerraformClient.getTerraformLauncher(TerraformClient.java:283)
	at io.terrakube.terraform.TerraformClient.run(TerraformClient.java:209)
	at io.terrakube.terraform.TerraformClient.destroy(TerraformClient.java:177)
	at io.terrakube.executor.service.terraform.TerraformExecutorServiceImpl.destroy(TerraformExecutorServiceImpl.java:255)
	at io.terrakube.executor.service.executor.ExecutorJobImpl.createJob(ExecutorJobImpl.java:61)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:360)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.aop.interceptor.AsyncExecutionInterceptor.lambda$invoke$0(AsyncExecutionInterceptor.java:114)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
[reactor-http-epoll-3] ERROR reactor.core.publisher.Operators - Operator called default onErrorDropped
reactor.netty.ReactorNetty$InternalNettyException: java.lang.OutOfMemoryError: Cannot reserve 65536 bytes of direct buffer memory (allocated: 10469424, limit: 10485760)
	Suppressed: The stacktrace has been enhanced by Reactor, refer to additional information below:
```