### PR TITLE
fix: handle thread interruption in LogsServiceApi methods

### DIFF
--- a/executor/src/main/java/io/terrakube/executor/service/logs/LogsServiceApi.java
+++ b/executor/src/main/java/io/terrakube/executor/service/logs/LogsServiceApi.java
@@ -39,6 +39,7 @@ public class LogsServiceApi implements ProcessLogs {
             logQueue.put(logEntry);
         } catch (InterruptedException addLogException) {
             log.error("Failed to add log to queue", addLogException);
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -74,6 +75,7 @@ public class LogsServiceApi implements ProcessLogs {
                 logQueue.putFirst(failedBatch.get(i));
             } catch (InterruptedException e) {
                 log.error("Thread interrupted while re-queuing logs", e);
+                Thread.currentThread().interrupt();
             }
         }
     }


### PR DESCRIPTION
- Added `Thread.currentThread().interrupt()` to preserve interrupt status after catching `InterruptedException`.