### PR TITLE
fix: filter out null workspace references to prevent invalid data handling

### DIFF
--- a/ui/src/domain/Settings/VariableCollections.tsx
+++ b/ui/src/domain/Settings/VariableCollections.tsx
@@ -107,7 +107,9 @@ export const VariableCollectionsSettings = () => {
         collection.relationships = {
           ...collection.relationships,
           workspaces: {
-            data: workspacesResponse.data.data || [],
+              data: (workspacesResponse.data.data || []).filter(
+                  (item: any) => item.relationships?.workspace?.data?.id != null
+              ),
           },
         };
 


### PR DESCRIPTION
- Updated `VariableCollections.tsx` to exclude null workspace relationships from data.
- Adjusted `CreateEditCollection.tsx` to filter out null workspace references before mapping workspace IDs and deleting old references.

fix #2660 