### PR TITLE
feat: Enhance module version fetching with GraphQL and caching support

### DIFF
--- a/registry/src/main/java/io/terrakube/registry/configuration/CacheConfig.java
+++ b/registry/src/main/java/io/terrakube/registry/configuration/CacheConfig.java
@@ -13,7 +13,7 @@ public class CacheConfig {
 
     @Bean
     public CacheManager cacheManager() {
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager("getAvailableVersions");
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("getAvailableVersions", "getModuleVersionPath");
         cacheManager.setCaffeine(Caffeine.newBuilder()
                 .expireAfterWrite(10    , TimeUnit.MINUTES)
                 .maximumSize(1000));

--- a/registry/src/main/java/io/terrakube/registry/service/search/CommonSearchService.java
+++ b/registry/src/main/java/io/terrakube/registry/service/search/CommonSearchService.java
@@ -1,0 +1,46 @@
+package io.terrakube.registry.service.search;
+
+import io.terrakube.client.TerrakubeClient;
+import io.terrakube.client.model.graphql.GraphQLRequest;
+import io.terrakube.client.model.graphql.GraphQLResponse;
+import io.terrakube.client.model.graphql.queries.search.organization.OrganizationNode;
+import io.terrakube.client.model.graphql.queries.search.organization.SearchOrganizationResponse;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+@AllArgsConstructor
+@Slf4j
+@Service
+public class CommonSearchService {
+
+    TerrakubeClient terrakubeClient;
+
+    public static final String SEARCH_ORGANIZATION_GRAPHQL="{ \n" +
+            "  organization(filter: \"name==%s\") {\n" +
+            "    edges {\n" +
+            "      node {\n" +
+            "        id\n" +
+            "        name\n" +
+            "      }\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+    public String getOrganizationId(String organizationName) {
+        GraphQLRequest query = new GraphQLRequest();
+        query.setQuery(String.format(SEARCH_ORGANIZATION_GRAPHQL, organizationName));
+        AtomicReference<String> organizationId = new AtomicReference<>();
+        GraphQLResponse<SearchOrganizationResponse> response = terrakubeClient.searchOrganization(query);
+        response.getData().getOrganization().getEdges().forEach(organizationEdge -> {
+            OrganizationNode organizationNode = organizationEdge.getNode();
+            log.info("API response: Organization: {} Id: {}", organizationNode.getName(), organizationNode.getId());
+            organizationId.set(organizationNode.getId());
+        });
+
+        return organizationId.get();
+    }
+
+}

--- a/registry/src/test/java/io/terrakube/registry/ModuleTests.java
+++ b/registry/src/test/java/io/terrakube/registry/ModuleTests.java
@@ -1,156 +1,87 @@
 package io.terrakube.registry;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.containing;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static io.restassured.RestAssured.when;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.hasSize;
+
 public class ModuleTests extends OpenRegistryApplicationTests{
-    private static final String ORGANIZATION_SEARCH="/api/v1/organization";
+    private static final String GRAPHQL_ENDPOINT="/graphql/api/v1";
     private static final String ORGANIZATION_SEARCH_BODY="{\n" +
-            "    \"data\": [\n" +
-            "        {\n" +
-            "            \"type\": \"organization\",\n" +
-            "            \"id\": \"b8938f8f-92c7-40fc-90ce-e4725ee8e985\",\n" +
-            "            \"attributes\": {\n" +
-            "                \"description\": \"Sample Organization\",\n" +
-            "                \"name\": \"moduleOrganization\"\n" +
-            "            },\n" +
-            "            \"relationships\": {\n" +
-            "                \"job\": {\n" +
-            "                    \"data\": []\n" +
-            "                },\n" +
-            "                \"module\": {\n" +
-            "                    \"data\": [\n" +
-            "                        {\n" +
-            "                            \"type\": \"module\",\n" +
-            "                            \"id\": \"3f6cd63e-e73a-4a17-b98d-a7f7b6c691a6\"\n" +
-            "                        }\n" +
-            "                    ]\n" +
-            "                },\n" +
-            "                \"provider\": {\n" +
-            "                    \"data\": []\n" +
-            "                },\n" +
-            "                \"workspace\": {\n" +
-            "                    \"data\": []\n" +
+            "    \"data\": {\n" +
+            "        \"organization\": {\n" +
+            "            \"edges\": [\n" +
+            "                {\n" +
+            "                    \"node\": {\n" +
+            "                        \"id\": \"d9b58bd3-f3fc-4056-a026-1163297e80a8\",\n" +
+            "                        \"name\": \"aws\"\n" +
+            "                    }\n" +
             "                }\n" +
-            "            }\n" +
+            "            ]\n" +
             "        }\n" +
-            "    ]\n" +
+            "    }\n" +
             "}";
-    private static final String MODULE_SEARCH="/api/v1/organization/b8938f8f-92c7-40fc-90ce-e4725ee8e985/module";
     private static final String MODULE_SEARCH_BODY="{\n" +
-            "    \"data\": [\n" +
-            "        {\n" +
-            "            \"type\": \"module\",\n" +
-            "            \"id\": \"3f6cd63e-e73a-4a17-b98d-a7f7b6c691a6\",\n" +
-            "            \"attributes\": {\n" +
-            "                \"description\": \"sample Module\",\n" +
-            "                \"name\": \"sampleModule\",\n" +
-            "                \"provider\": \"sampleProvider\",\n" +
-            "                \"registryPath\": \"sampleOrganization/sampleModule/sampleProvider\",\n" +
-            "                \"source\": \"https://github.com/AzBuilder/terraform-sample-repository.git\",\n" +
-            "                \"sourceSample\": \"https://github.com/AzBuilder/terraform-sample-repository.git\",\n" +
-            "                \"latestVersion\": \"0.0.2\"\n" +
-            "            },\n" +
-            "            \"relationships\": {\n" +
-            "                \"organization\": {\n" +
-            "                    \"data\": {\n" +
-            "                        \"type\": \"organization\",\n" +
-            "                        \"id\": \"b8938f8f-92c7-40fc-90ce-e4725ee8e985\"\n" +
-            "                      }\n" +
-            "                  },\n" +
-            "                \"vcs\": {\n" +
-            "                    \"data\": null\n" +
-            "                   },\n" +
-            "                \"version\": {\n" +
-            "                    \"data\": [{\n" +
-            "                         \"type\": \"module_version\",\n" +
-            "                         \"id\": \"223788aa-498b-4f29-82fc-04587a0fcae8\"\n" +
-            "                       },\n" +
-            "                       {\n" +
-            "                          \"type\": \"module_version\",\n" +
-            "                          \"id\": \"7f1243ef-cce0-4d6e-8b99-e6c121311b58\"\n" +
-            "                       }]\n" +
-            "                 }\n" +
-            "              }\n" +
+            "    \"data\": {\n" +
+            "        \"organization\": {\n" +
+            "            \"edges\": [\n" +
+            "                {\n" +
+            "                    \"node\": {\n" +
+            "                        \"id\": \"3a130a1c-d96f-4f99-83b8-58d472567e3a\",\n" +
+            "                        \"name\": \"aws\",\n" +
+            "                        \"module\": {\n" +
+            "                            \"edges\": [\n" +
+            "                                {\n" +
+            "                                    \"node\": {\n" +
+            "                                        \"id\": \"25778e8a-6989-4792-9f38-17bb3f09543b\",\n" +
+            "                                        \"name\": \"vpc\",\n" +
+            "                                        \"provider\": \"aws\",\n" +
+            "                                        \"version\": {\n" +
+            "                                            \"edges\": [\n" +
+            "                                                {\n" +
+            "                                                    \"node\": {\n" +
+            "                                                        \"id\": \"4d85165f-0e99-4d45-bdcc-6b6bf4577f27\",\n" +
+            "                                                        \"version\": \"v3.3.0\",\n" +
+            "                                                        \"commit\": \"67ee4ac34b0f04a92d4ae11011920328fdb830df\"\n" +
+            "                                                    }\n" +
+            "                                                }\n" +
+            "                                            ]\n" +
+            "                                        }\n" +
+            "                                    }\n" +
+            "                                }\n" +
+            "                            ]\n" +
+            "                        }\n" +
+            "                    }\n" +
+            "                }\n" +
+            "            ]\n" +
             "        }\n" +
-            "    ]\n" +
+            "    }\n" +
             "}";
-    private static final String MODULE_VERSION_PATH = "/api/v1/organization/b8938f8f-92c7-40fc-90ce-e4725ee8e985/module/3f6cd63e-e73a-4a17-b98d-a7f7b6c691a6/version";
-    private static final String MODULE_VERSION_BODY = """
-                {
-                        "data": [{
-                                "type": "module_version",
-                                "id": "223788aa-498b-4f29-82fc-04587a0fcae8",
-                                "attributes": {
-                                        "version": "0.0.2",
-                                        "commit": "2b2f528116878f440e16ae061efd7572fe02f487"
-                                },
-                                "relationships": {
-                                        "module": {
-                                                "data": {
-                                                        "type": "module",
-                                                        "id": "3f6cd63e-e73a-4a17-b98d-a7f7b6c691a6"
-                                                }
-                                        }
-                                }
-                        },
-                        {
-                                "type": "module_version",
-                                "id": "7f1243ef-cce0-4d6e-8b99-e6c121311b58",
-                                "attributes": {
-                                        "version": "v0.0.1",
-                                        "commit": "518e2b32a0846095e2dede7661abc3f71bd44cc4"
-                                },
-                                "relationships": {
-                                        "module": {
-                                                "data": {
-                                                        "type": "module",
-                                                        "id": "3f6cd63e-e73a-4a17-b98d-a7f7b6c691a6"
-                                                }
-                                        }
-                                }
-                        }]
-                }
-        """;
 
     @Test
     void moduleApiGetTestStep1() {
         wireMockServer.resetAll();
         
-        stubFor(get(urlPathEqualTo(ORGANIZATION_SEARCH))
-                .withQueryParam("filter[organization]", containing("name==moduleOrganization"))
+        stubFor(post(urlPathEqualTo(GRAPHQL_ENDPOINT))
+                .withRequestBody(not(containing("module(filter: \"name==vpc;provider==aws\")")))
                 .willReturn(aResponse()
                         .withStatus(HttpStatus.SC_OK)
                         .withBody(ORGANIZATION_SEARCH_BODY)));
 
-        stubFor(get(urlPathEqualTo(MODULE_SEARCH))
-                .withQueryParam("filter[module]", containing("name==sampleModule;provider==sampleProvider"))
+        stubFor(post(urlPathEqualTo(GRAPHQL_ENDPOINT))
+                .withRequestBody(containing("provider"))
                 .willReturn(aResponse()
                         .withStatus(HttpStatus.SC_OK)
                         .withBody(MODULE_SEARCH_BODY)));
 
-        stubFor(get(urlPathEqualTo(MODULE_VERSION_PATH))
-                .willReturn(aResponse()
-                        .withStatus(HttpStatus.SC_OK)
-                        .withBody(MODULE_VERSION_BODY)));
-
         when()
-                .get("/terraform/modules/v1/moduleOrganization/sampleModule/sampleProvider/versions")
+                .get("/terraform/modules/v1/aws/vpc/aws/versions")
                 .then()
                 .log().all()
                 .body("modules",hasSize(1))
-                .body("modules[0].versions",hasSize(2))
-                .body("modules[0].versions[0].version",equalTo("0.0.2"))
-                .body("modules[0].versions[1].version",equalTo("v0.0.1"))
+                .body("modules[0].versions",hasSize(1))
                 .log().all()
                 .statusCode(HttpStatus.SC_OK);
     }


### PR DESCRIPTION
- Replaced REST API calls with GraphQL queries for fetching module versions.
- Introduced `CommonSearchService` to handle organization-related queries.
- Enhanced `ModuleServiceImpl.getAvailableVersions` with atomic counters for accurate logging.
- Extended Caffeine caching configuration to include `getModuleVersionPath`.

Related to #2666