### PR TITLE
fix:add_azure_sp_mi_to_case

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/module/ModuleRefreshJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/module/ModuleRefreshJob.java
@@ -157,7 +157,7 @@ public class ModuleRefreshJob implements Job {
                 case GITLAB:
                     credentialsProvider = new UsernamePasswordCredentialsProvider("oauth2", vcs.getAccessToken());
                     break;
-                case AZURE_DEVOPS:
+                case AZURE_DEVOPS, AZURE_SP_MI:
                     credentialsProvider = new UsernamePasswordCredentialsProvider("dummy", vcs.getAccessToken());
                     break;
                 default:

--- a/executor/src/main/java/io/terrakube/executor/service/scripts/ScriptEngineService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/scripts/ScriptEngineService.java
@@ -128,7 +128,7 @@ public class ScriptEngineService {
                     credentialsProvider = new UsernamePasswordCredentialsProvider("x-token-auth",
                             privateRepositoryToken);
                     break;
-                case "AZURE_DEVOPS":
+                case "AZURE_DEVOPS", "AZURE_SP_MI":
                     credentialsProvider = new UsernamePasswordCredentialsProvider("dummy", privateRepositoryToken);
                     break;
                 case "GITHUB":


### PR DESCRIPTION
Added AZURE_SP_MI to the case statements for ModuleRefeshJob.java and ScriptEngineService.java so that the AZURE_SP_MI VCS type can be used with them. 

