### PR TITLE
feat: Update Traefik to v2, implement job deletion, and upgrade dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
     "ghcr.io/devcontainers/features/java:1": {
       "installMaven": false,
       "jdkDistro": "Liberica",
-      "version": "17.0.15-librca"
+      "version": "25.0.1-librca"
     },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "22",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -206,7 +206,7 @@ x-traefik_dex_labels: &traefik_dex_labels
 ### Containers
 services:
   traefik:
-    image: traefik:latest
+    image: traefik:v2
     container_name: terrakube-traefik
     # Give Traefik a reserved IP address in your external network, pick something towards the end of the network to avoid conflicts
     networks:

--- a/api/src/main/java/io/terrakube/api/repository/JobRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/JobRepository.java
@@ -19,6 +19,8 @@ public interface JobRepository extends JpaRepository<Job, Integer> {
     Optional<List<Job>> findAllByWorkspaceAndStatusNotInOrderByIdAsc(Workspace workspace, List<JobStatus> status);
     List<Job> findAllByWorkspaceAndStatusInOrderByIdDesc(Workspace workspace, List<JobStatus> jobStatuses);
     Optional<List<Job>> findByWorkspaceAndStatusNotInAndIdLessThan(Workspace workspace, List<JobStatus> jobStatuses, int jobId);
+    Optional<List<Job>> findByWorkspaceAndStatusInAndIdLessThanOrderByIdDesc(Workspace workspace, List<JobStatus> jobStatuses, int jobId);
+
 
     Optional<Job> findFirstByWorkspaceAndAndStatusInOrderByIdAsc(Workspace workspace, List<JobStatus> jobStatuses);
     Optional<Job> findFirstByWorkspaceAndStatusInOrderByIdAsc(Workspace workspace, List<JobStatus> jobStatuses);

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -214,7 +214,7 @@ x-traefik_registry_labels: &traefik_registry_labels
 ### Containers
 services:
   traefik:
-    image: traefik:latest
+    image: traefik:v2
     container_name: terrakube-traefik
     # Give Traefik a reserved IP address in your external network, pick something towards the end of the network to avoid conflicts
     networks:


### PR DESCRIPTION
- Updated Traefik Docker image to `v2` in Docker Compose and devcontainer configurations for improved compatibility.
- Added `deleteOldJobs` method to remove older jobs exceeding the configured retention limit.
- Upgraded Java JDK in devcontainer to `25.0.1-librca` for latest runtime support.

fix #2124 

Added a new environment variable called "KEEP_JOB_HISTORY"

When using the above terrakube will keep the last job and additional job number from the above environment variable

<img width="1860" height="721" alt="imagen" src="https://github.com/user-attachments/assets/1eb57abd-7dc2-412f-a59a-459d18063226" />

For example for this workspace it will always keep the latest job a 2 additional history records
