### PR TITLE
feat: Ask Kubernetes to delete ephemeral jobs on completion

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -136,7 +136,6 @@ public class ScheduleJob implements org.quartz.Job {
                 case completed:
                     redisTemplate.delete(String.valueOf(job.getId()));
                     removeJobContext(job, jobExecutionContext);
-                    ephemeralExecutorService.deleteEphemeralJob(job);
                     updateJobStatusOnVcs(job, JobStatus.completed);
                     deleteOldJobs(job);
                     break;
@@ -148,7 +147,6 @@ public class ScheduleJob implements org.quartz.Job {
                     updateJobStepsWithStatus(job.getId(), JobStatus.failed);
                     updateJobStatusOnVcs(job, JobStatus.failed);
                     removeJobContext(job, jobExecutionContext);
-                    ephemeralExecutorService.deleteEphemeralJob(job);
                     deleteOldJobs(job);
                     break;
                 default:
@@ -314,7 +312,6 @@ public class ScheduleJob implements org.quartz.Job {
     private void completeJob(Job job) {
         job.setStatus(JobStatus.completed);
         jobRepository.save(job);
-        ephemeralExecutorService.deleteEphemeralJob(job);
         updateJobStatusOnVcs(job, JobStatus.completed);
         updateWorkspaceStatus(job);
         log.info("Update Job {} to completed", job.getId());


### PR DESCRIPTION
Kubernetes Jobs have an option to set a retention after which they are automatically deleted, called `ttlSecondsAfterFinished`. Using on this feature makes the code simpler, but it also removes speculative deletes from code paths in `ScheduleJob` where we did not actually know whether the job was an ephemeral job and so could fail because the service account had no perms on Jobs:
```
Failure executing: GET at: [https://10.96.0.1:443/apis/batch/v1/namespaces/terrakube/jobs/job-2.](https://10.96.0.1/apis/batch/v1/namespaces/terrakube/jobs/job-2.) Message: jobs.batch "job-2" is forbidden: User "system:serviceaccount:terrakube:default" cannot get resource "jobs" in API group "batch" in the namespace "terrakube". Received status: Status(apiVersion=v1, code=403, details=StatusDetails(causes=[], group=batch, kind=jobs, name=job-2, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=jobs.batch "job-2" is forbidden: User "system:serviceaccount:terrakube:default" cannot get resource "jobs" in API group "batch" in the namespace "terrakube", metadata=ListMeta(_continue=null, remainingItemCount=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=Forbidden, status=Failure, additionalProperties={}).
```
At present, this was merely an annoying log entry, but I want next to propagate errors properly through `ScheduleJob/ExecutorService/...` so that they can be communicated to the user. In this case, the job may equally have been ephemeral and the role misconfigured, which should be communicated to the user.