### PR TITLE
feat: Update JDK to version 25 across workflows and projects

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'liberica'
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
@@ -50,10 +50,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'liberica'
       - name: Cache Maven packages
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-m2
 
-    - name: Set up JDK 22
+    - name: Set up JDK 25
       uses: actions/setup-java@v4
       with:
-        java-version: '22'
+        java-version: '25'
         distribution: 'liberica'
 
     - uses: actions/setup-node@v4

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -14,7 +14,7 @@
     <name>Terrakube API</name>
     <description>Spring Boot Terrakube API</description>
     <properties>
-        <java.version>17</java.version>
+        <java.version>25</java.version>
         <elide.version>7.1.15</elide.version>
         <handlebars.version>4.3.1</handlebars.version>
         <azure.version>6.0.0</azure.version>
@@ -25,10 +25,9 @@
         <jgit.version>7.4.0.202509020913-r</jgit.version>
         <bouncy.castle>1.82</bouncy.castle>
         <rest-assured.version>5.5.6</rest-assured.version>
-        <!--groovy.version>4.0.20</groovy.version-->
         <postgresql.version>42.7.8</postgresql.version>
         <snakeyaml.version>2.5</snakeyaml.version>
-        <quartz.version>2.5.0</quartz.version>
+        <quartz.version>2.5.1</quartz.version>
         <aws-sdk.version>2.39.2</aws-sdk.version>
         <gcp-libraries-bom.version>26.72.0</gcp-libraries-bom.version>
         <jjwt.version>0.13.0</jjwt.version>
@@ -62,7 +61,7 @@
                         </bindings>
                         <env>
                             <BP_OPENTELEMETRY_ENABLED>true</BP_OPENTELEMETRY_ENABLED>
-                            <BP_JVM_VERSION>17</BP_JVM_VERSION>
+                            <BP_JVM_VERSION>25</BP_JVM_VERSION>
                         </env>
                     </image>
                 </configuration>
@@ -73,6 +72,26 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-XX:+EnableDynamicAgentLoading</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/api/src/test/java/io/terrakube/api/CollectionTests.java
+++ b/api/src/test/java/io/terrakube/api/CollectionTests.java
@@ -1,26 +1,24 @@
 package io.terrakube.api;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.MockitoAnnotations;
-import org.springframework.http.HttpStatus;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorContext;
 import io.terrakube.api.plugin.scheduler.job.tcl.model.Flow;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.team.Team;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
 
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static io.restassured.RestAssured.given;
 import static org.mockito.Mockito.when;
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 public class CollectionTests extends ServerApplicationTests {
-
-    private static final String EXECUTOR_ENDPOINT="http://localhost:9999/fake/executor";
 
 
     @BeforeEach
@@ -229,9 +227,12 @@ public class CollectionTests extends ServerApplicationTests {
     @Test
     void testCollectionPriorityAsOrgMember() {
 
+        String EXECUTOR_ENDPOINT="http://localhost:" + wireMockServer.port() + "/fake/executor";
+
         wireMockServer.resetAll();
 
         stubFor(post(urlPathEqualTo("/fake/executor/api/v1/terraform-rs"))
+                .withPort(wireMockServer.port())
                 .willReturn(aResponse()
                         .withStatus(org.apache.http.HttpStatus.SC_ACCEPTED)));
 

--- a/api/src/test/java/io/terrakube/api/VcsBitbucketTests.java
+++ b/api/src/test/java/io/terrakube/api/VcsBitbucketTests.java
@@ -15,11 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.mockito.Mockito.when;
 
 public class VcsBitbucketTests extends ServerApplicationTests{
@@ -300,6 +296,8 @@ public class VcsBitbucketTests extends ServerApplicationTests{
                 "   }\n" +
                 "}";
 
+        payload = payload.replace("9999", String.valueOf(wireMockServer.port()));
+
         String diffResponse = "diff --git a/main.tf b/main.tf\n" +
                 "index f7884af..66c627b 100644\n" +
                 "--- a/main.tf\n" +
@@ -315,6 +313,7 @@ public class VcsBitbucketTests extends ServerApplicationTests{
                 " }\n";
 
         stubFor(get(urlPathEqualTo("/2.0/repositories/dummyuser/simple-terraform/diff/dummyuser/simple-terraform:383254320963%0Df7647c752c7e"))
+                .withPort(wireMockServer.port())
                 .withQueryParam("from_pullrequest_id", equalTo("1"))
                 .withQueryParam("topic", equalTo("true"))
                 .willReturn(aResponse()
@@ -975,6 +974,8 @@ public class VcsBitbucketTests extends ServerApplicationTests{
                 "   }\n" +
                 "}";
 
+        payload = payload.replace("9999", String.valueOf(wireMockServer.port()));
+
         String diffResponse = "diff --git a/main.tf b/main.tf\n" +
                 "index f7884af..66c627b 100644\n" +
                 "--- a/main.tf\n" +
@@ -990,6 +991,7 @@ public class VcsBitbucketTests extends ServerApplicationTests{
                 " }\n";
 
         stubFor(get(urlPathEqualTo("/2.0/repositories/dummyuser/simple-terraform/diff/c7eae9b0c5450123c943a4baf7c357fc2564c316..71085ceb4314ac77d1a36ab687b3e067814c9395"))
+                .withPort(wireMockServer.port())
                 .willReturn(aResponse()
                         .withStatus(HttpStatus.OK.value())
                         .withBody(diffResponse)));

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -14,7 +14,7 @@
 	<name>Terrakube Executor</name>
 	<description>Terrakube Spring Boot Executor</description>
 	<properties>
-		<java.version>17</java.version>
+		<java.version>25</java.version>
 		<commons-text.version>1.14.0</commons-text.version>
 		<terraform-spring-boot-starter.version>1.2.2</terraform-spring-boot-starter.version>
 		<terrakube-client-starter.version>1.4.0</terrakube-client-starter.version>
@@ -222,7 +222,7 @@
                     	</bindings>
                     <env>
                         <BP_OPENTELEMETRY_ENABLED>true</BP_OPENTELEMETRY_ENABLED>
-						<BP_JVM_VERSION>17</BP_JVM_VERSION>
+						<BP_JVM_VERSION>25</BP_JVM_VERSION>
                     </env>
                 	</image>
 				</configuration>
@@ -234,6 +234,26 @@
                     </execution>
                 </executions>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-XX:+EnableDynamicAgentLoading</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
 

--- a/registry/pom.xml
+++ b/registry/pom.xml
@@ -14,8 +14,8 @@
     <name>Terrakube Terraform Registry</name>
     <description>Open Source Terraform Registry for Terrakube</description>
     <properties>
+        <java.version>25</java.version>
         <azure.version>6.0.0</azure.version>
-        <java.version>17</java.version>
         <lombok.version>1.18.42</lombok.version>
         <terrakube-client-starter.version>1.4.0</terrakube-client-starter.version>
         <jgit.version>7.4.0.202509020913-r</jgit.version>
@@ -51,7 +51,7 @@
                         </bindings>
                         <env>
                             <BP_OPENTELEMETRY_ENABLED>true</BP_OPENTELEMETRY_ENABLED>
-                            <BP_JVM_VERSION>17</BP_JVM_VERSION>
+                            <BP_JVM_VERSION>25</BP_JVM_VERSION>
                         </env>
                     </image>
                 </configuration>
@@ -62,6 +62,26 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-XX:+EnableDynamicAgentLoading</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
- Upgraded Java JDK version to 25 in workflows (`release.yml`, `pull_request.yml`) and project configurations (`pom.xml`).
- Added Maven plugins for dynamic agent loading and annotation processing.
- Refactored test cases to dynamically configure WireMock server ports.