### PR TITLE
feat: Prioritize DefaultCredentialsProvider to support STS on custom endpoints

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/storage/configuration/StorageTypeAutoConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/plugin/storage/configuration/StorageTypeAutoConfiguration.java
@@ -62,7 +62,13 @@ public class StorageTypeAutoConfiguration {
                 break;
             case AWS:
                 S3Client s3client;
-                if (awsStorageTypeProperties.getEndpoint() != null && !awsStorageTypeProperties.getEndpoint().isEmpty()) {
+                if (awsStorageTypeProperties.isEnableRoleAuthentication()) {
+                    log.info("Creating AWS SDK with default credentials");
+                    s3client = S3Client.builder()
+                            .region(Region.of(awsStorageTypeProperties.getRegion()))
+                            .credentialsProvider(DefaultCredentialsProvider.create())
+                            .build();
+                } else if (awsStorageTypeProperties.getEndpoint() != null && !awsStorageTypeProperties.getEndpoint().isEmpty()) {
                     log.info("Creating AWS SDK with custom endpoint and custom credentials");
 
                     S3Configuration serviceConfiguration = S3Configuration.builder()
@@ -78,19 +84,11 @@ public class StorageTypeAutoConfiguration {
                             .build();
 
                 } else {
-                    if (awsStorageTypeProperties.isEnableRoleAuthentication()) {
-                        log.info("Creating AWS SDK with default credentials");
-                        s3client = S3Client.builder()
-                                .region(Region.of(awsStorageTypeProperties.getRegion()))
-                                .credentialsProvider(DefaultCredentialsProvider.create())
-                                .build();
-                    } else {
-                        log.info("Creating AWS SDK with custom credentials");
-                        s3client = S3Client.builder()
-                                .region(Region.of(awsStorageTypeProperties.getRegion()))
-                                .credentialsProvider(StaticCredentialsProvider.create(getAwsBasicCredentials(awsStorageTypeProperties)))
-                                .build();
-                    }
+                    log.info("Creating AWS SDK with custom credentials");
+                    s3client = S3Client.builder()
+                            .region(Region.of(awsStorageTypeProperties.getRegion()))
+                            .credentialsProvider(StaticCredentialsProvider.create(getAwsBasicCredentials(awsStorageTypeProperties)))
+                            .build();
                 }
 
                 storageTypeService = AwsStorageTypeServiceImpl.builder()

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
@@ -76,7 +76,13 @@ public class TerraformStateAutoConfiguration {
                 case AwsTerraformStateImpl:
                     S3Client s3client = null;
 
-                    if (awsTerraformStateProperties.getEndpoint() != null && !awsTerraformStateProperties.getEndpoint().isEmpty()) {
+                    if (awsTerraformStateProperties.isEnableRoleAuthentication()) {
+                        log.info("Creating AWS SDK with default credentials");
+                        s3client = S3Client.builder()
+                                .region(Region.of(awsTerraformStateProperties.getRegion()))
+                                .credentialsProvider(DefaultCredentialsProvider.create())
+                                .build();
+                    } else if (awsTerraformStateProperties.getEndpoint() != null && !awsTerraformStateProperties.getEndpoint().isEmpty()) {
                         log.info("Creating AWS with custom endpoint and custom credentials");
 
                         S3Configuration serviceConfiguration = S3Configuration.builder()
@@ -91,19 +97,11 @@ public class TerraformStateAutoConfiguration {
                                 .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
                                 .build();
                     } else {
-                        if (awsTerraformStateProperties.isEnableRoleAuthentication()){
-                            log.info("Creating AWS SDK with default credentials");
-                            s3client = S3Client.builder()
-                                    .credentialsProvider(DefaultCredentialsProvider.create())
-                                    .region(Region.of(awsTerraformStateProperties.getRegion()))
-                                    .build();
-                        } else {
-                            log.info("Creating AWS SDK with custom credentials");
-                            s3client = S3Client.builder()
-                                    .region(Region.of(awsTerraformStateProperties.getRegion()))
-                                    .credentialsProvider(StaticCredentialsProvider.create(getAwsBasicCredentials(awsTerraformStateProperties)))
-                                    .build();
-                        }
+                        log.info("Creating AWS SDK with custom credentials");
+                        s3client = S3Client.builder()
+                                .region(Region.of(awsTerraformStateProperties.getRegion()))
+                                .credentialsProvider(StaticCredentialsProvider.create(getAwsBasicCredentials(awsTerraformStateProperties)))
+                                .build();
                     }
 
 


### PR DESCRIPTION
Fixes: #2768

- Updates s3client initialization to prioritize DefaultCredentialsProvider regardless of the endpoint configuration.
  - This enables STS authentication for third-party S3 services like MinIO.