### PR TITLE
feat: Add sortable columns to variable tables in UI

### DIFF
--- a/ui/src/domain/Settings/GlobalVariables.tsx
+++ b/ui/src/domain/Settings/GlobalVariables.tsx
@@ -22,6 +22,8 @@ export const GlobalVariablesSettings = () => {
       dataIndex: "key",
       width: "40%",
       key: "key",
+      sorter: (a: Variable, b: Variable) => a.attributes.key.localeCompare(b.attributes.key),
+      defaultSortOrder: "ascend" as const,
       render: (_: any, record: Variable) => {
         return (
           <div>

--- a/ui/src/domain/Workspaces/Variables.tsx
+++ b/ui/src/domain/Workspaces/Variables.tsx
@@ -30,6 +30,8 @@ const VARIABLES_COLUMS = (
     dataIndex: "key",
     width: "30%",
     key: "key",
+    sorter: (a: FlatVariable, b: FlatVariable) => a.key.localeCompare(b.key),
+    defaultSortOrder: "ascend" as const,
     render: (_: string, record: FlatVariable) => {
       return (
         <div>
@@ -65,6 +67,7 @@ const VARIABLES_COLUMS = (
     dataIndex: "category",
     key: "category",
     width: "15%",
+    sorter: (a: FlatVariable, b: FlatVariable) => a.category.localeCompare(b.category),
     render: (_: string, record: FlatVariable) => {
       return record.category === "TERRAFORM" ? "terraform" : "env";
     },
@@ -110,6 +113,8 @@ const COLLECTION_VARIABLES_COLUMNS = () => [
     dataIndex: "key",
     width: "25%",
     key: "key",
+    sorter: (a: any, b: any) => a.key.localeCompare(b.key),
+    defaultSortOrder: "ascend" as const,
     render: (_: string, record: any) => {
       return (
         <div>
@@ -145,6 +150,7 @@ const COLLECTION_VARIABLES_COLUMNS = () => [
     dataIndex: "category",
     width: "15%",
     key: "category",
+    sorter: (a: any, b: any) => a.category.localeCompare(b.category),
     render: (_: string, record: any) => {
       return record.category === "TERRAFORM" ? "terraform" : "env";
     },
@@ -175,6 +181,8 @@ const GLOBAL_VARIABLES_COLUMNS = () => [
     dataIndex: "key",
     width: "40%",
     key: "key",
+    sorter: (a: FlatVariable, b: FlatVariable) => a.key.localeCompare(b.key),
+    defaultSortOrder: "ascend" as const,
     render: (_: string, record: FlatVariable) => {
       return (
         <div>
@@ -210,6 +218,7 @@ const GLOBAL_VARIABLES_COLUMNS = () => [
     dataIndex: "category",
     width: "20%",
     key: "category",
+    sorter: (a: FlatVariable, b: FlatVariable) => a.category.localeCompare(b.category),
     render: (_: string, record: FlatVariable) => {
       return record.category === "TERRAFORM" ? "terraform" : "env";
     },


### PR DESCRIPTION
We have a few workspaces with 70+ variables. The unsorted variables made maintenance a pain. I employed Claude to add sorting for me.

Adds default sorting by variable name (key) and enables sorting on category columns for all variable tables:
- Workspace variables table
- Collection variables table (read-only view in workspace)
- Global variables table (read-only view in workspace)
- Organization global variables table (settings)

Tables are sorted by key in ascending order by default. Users can click column headers to change sort order.

