### PR TITLE
feat: update `override_branch` column type to `varchar(128)` in `job` table

### DIFF
--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -89,4 +89,5 @@
     <include file="/db/changelog/local/changelog-2.27.3-module-latest-field.xml"/>
     <include file="/db/changelog/local/changelog-2.28.0-workspace-last-status.xml" />
     <include file="/db/changelog/local/changelog-2.28.0-project-support.xml" />
+    <include file="/db/changelog/local/changelog-2.29.0-branch-size.xml" />
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.29.0-branch-size.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.29.0-branch-size.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-29-0-1" author="alfespa17@gmail.com">
+        <modifyDataType
+                columnName="override_branch"
+                newDataType="varchar(128)"
+                tableName="job"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Adding script to change column size

```
2025-12-13T01:17:40.411Z  INFO 6500 --- [           main] i.t.a.p.s.StreamingConfiguration         : Redis User: NULL username, Hostname: terrakube-redis, Port: 6379, Ssl: false
2025-12-13T01:17:40.524Z  INFO 6500 --- [           main] i.t.a.p.d.DataSourceAutoConfiguration    : DataSourceType: POSTGRESQL
2025-12-13T01:17:40.525Z  INFO 6500 --- [           main] i.t.a.p.d.DataSourceAutoConfiguration    : postgresql datasource using SSL Mode: disable
2025-12-13T01:17:41.322Z  INFO 6500 --- [           main] liquibase.changelog                      : Reading from public.databasechangelog
2025-12-13T01:17:41.983Z  INFO 6500 --- [           main] liquibase.lockservice                    : Successfully acquired change log lock
2025-12-13T01:17:41.984Z  INFO 6500 --- [           main] liquibase.command                        : Using deploymentId: 5588660584
2025-12-13T01:17:41.986Z  INFO 6500 --- [           main] liquibase.changelog                      : Reading from public.databasechangelog
2025-12-13T01:17:42.013Z  INFO 6500 --- [           main] liquibase.ui                             : Running Changeset: db/changelog/local/changelog-2.29.0-branch-size.xml::2-29-0-1::alfespa17@gmail.com
2025-12-13T01:17:42.035Z  INFO 6500 --- [           main] liquibase.changelog                      : job.override_branch datatype was changed to varchar(128)
2025-12-13T01:17:42.040Z  INFO 6500 --- [           main] liquibase.changelog                      : ChangeSet db/changelog/local/changelog-2.29.0-branch-size.xml::2-29-0-1::alfespa17@gmail.com ran successfully in 13ms
```

Previous size was only 64 characters

https://github.com/terrakube-io/terrakube/blob/a2abbe42b5c76201da5b272c9de9a911953261fd/api/src/main/resources/db/changelog/local/changelog-2.19.0-override-vcs.xml#L12

fix #2771 