### PR TITLE
feat: Create workspace defaults values for better UX

### DIFF
--- a/ui/src/domain/Workspaces/Create.tsx
+++ b/ui/src/domain/Workspaces/Create.tsx
@@ -232,6 +232,9 @@ export const CreateWorkspace = () => {
   const loadOrgTemplates = () => {
     axiosInstance.get(`organization/${organizationId}/template`).then((response) => {
       setOrgTemplates(response.data.data);
+      if(response.data.data.length > 0) {
+        form.setFieldsValue({defaultTemplate: response.data.data[0].id});
+      }
     });
   };
 
@@ -277,7 +280,11 @@ export const CreateWorkspace = () => {
           if (!version.includes("-")) tfVersions.push(version);
         }
       }
-      setTerraformVersions(tfVersions.sort(compareVersions).reverse());
+      tfVersions.sort(compareVersions).reverse();
+      setTerraformVersions(tfVersions);
+      if (tfVersions.length > 0) {
+        form.setFieldsValue({terraformVersion: tfVersions[0]})
+      }
     });
   };
 
@@ -646,7 +653,7 @@ export const CreateWorkspace = () => {
                 rules={[{ required: true }]}
                 hidden={!versionControlFlow}
               >
-                <Input placeholder="(default branch)" />
+                <Input placeholder="Branch name" />
               </Form.Item>
               <Form.Item
                 name="folder"


### PR DESCRIPTION
This PR makes three changes to the "create workspace" UI:
- pick the latest tf version which seems like a sensible default
- pick the first template (one may argue that "Plan and Apply" would be a better default, but that would be a bigger change and really only applicable to new orgs?)
- change the text "(default branch)" which sort of implies that leaving it empty would give you the Git provider's notion of default branch