### PR TITLE
feat: Avoid null execution_mode and clarify it is informational

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/importer/tfcloud/services/WorkspaceService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/importer/tfcloud/services/WorkspaceService.java
@@ -27,8 +27,7 @@ import io.terrakube.api.rs.workspace.history.History;
 import io.terrakube.api.rs.workspace.parameters.Category;
 import io.terrakube.api.rs.workspace.parameters.Variable;
 import io.terrakube.api.rs.workspace.tag.WorkspaceTag;
-
-
+import io.terrakube.api.rs.ExecutionMode;
 import io.terrakube.api.rs.tag.Tag;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
@@ -335,7 +334,7 @@ public class WorkspaceService {
         workspace.setName(workspaceImportRequest.getName());
         workspace.setDescription(workspaceImportRequest.getDescription());
         workspace.setTerraformVersion(workspaceImportRequest.getTerraformVersion());
-        workspace.setExecutionMode(workspaceImportRequest.getExecutionMode().equals("local") ? "local" : "remote");
+        workspace.setExecutionMode(workspaceImportRequest.getExecutionMode().equals("local") ? ExecutionMode.local : ExecutionMode.remote);
 
         // If the workspace has a VCS, set it
         if (workspaceImportRequest.getVcsId() != null && !workspaceImportRequest.getVcsId().isEmpty()) {

--- a/api/src/main/java/io/terrakube/api/rs/ExecutionMode.java
+++ b/api/src/main/java/io/terrakube/api/rs/ExecutionMode.java
@@ -1,0 +1,6 @@
+package io.terrakube.api.rs;
+
+public enum ExecutionMode {
+    local,
+    remote,
+}

--- a/api/src/main/java/io/terrakube/api/rs/Organization.java
+++ b/api/src/main/java/io/terrakube/api/rs/Organization.java
@@ -103,7 +103,8 @@ public class Organization {
     private List<Tag> tag;
 
     @Column(name = "execution_mode")
-    private String executionMode;
+    @Enumerated(EnumType.STRING)
+    private ExecutionMode executionMode = ExecutionMode.remote;
 
     @Column(name = "icon")
     private String icon;

--- a/api/src/main/java/io/terrakube/api/rs/hooks/workspace/WorkspaceManageHook.java
+++ b/api/src/main/java/io/terrakube/api/rs/hooks/workspace/WorkspaceManageHook.java
@@ -39,7 +39,7 @@ public class WorkspaceManageHook implements LifeCycleHook<Workspace> {
             case CREATE:
                 switch (transactionPhase) {
                     case PRECOMMIT:
-                        if (workspace.getExecutionMode() == null || workspace.getExecutionMode().isEmpty()) {
+                        if (workspace.getExecutionMode() == null) {
                             log.debug("setting default execution mode");
                             workspace.setExecutionMode(workspace.getOrganization().getExecutionMode());
                         }

--- a/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
@@ -2,6 +2,7 @@ package io.terrakube.api.rs.workspace;
 
 import com.yahoo.elide.annotation.*;
 import io.terrakube.api.plugin.security.audit.GenericAuditFields;
+import io.terrakube.api.rs.ExecutionMode;
 import io.terrakube.api.rs.IdConverter;
 import io.terrakube.api.rs.Organization;
 import io.terrakube.api.rs.agent.Agent;
@@ -95,7 +96,8 @@ public class Workspace extends GenericAuditFields {
     private String terraformVersion;
 
     @Column(name = "execution_mode")
-    private String executionMode;
+    @Enumerated(EnumType.STRING)
+    private ExecutionMode executionMode;
 
     @ManyToOne
     private Organization organization;

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -90,4 +90,5 @@
     <include file="/db/changelog/local/changelog-2.28.0-workspace-last-status.xml" />
     <include file="/db/changelog/local/changelog-2.28.0-project-support.xml" />
     <include file="/db/changelog/local/changelog-2.29.0-branch-size.xml" />
+    <include file="/db/changelog/local/changelog-2.29.0-execution-mode.xml" />
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.29.0-execution-mode.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.29.0-execution-mode.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-29-0-2" author="bittrance@gmail.com">
+        <update tableName="organization">
+            <column name="execution_mode" value="remote"/>
+            <where>execution_mode IS NULL</where>
+        </update>
+        <update tableName="workspace">
+            <column name="execution_mode" value="remote"/>
+            <where>execution_mode IS NULL</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/ui/src/domain/Settings/General.tsx
+++ b/ui/src/domain/Settings/General.tsx
@@ -140,7 +140,7 @@ export const GeneralSettings = () => {
             <Form.Item name="description" label="Description">
               <Input.TextArea />
             </Form.Item>
-            <Form.Item name="executionMode" label="Default Execution Mode">
+            <Form.Item name="executionMode" label="Default Execution Mode for New Workspaces (informational only)">
               <Radio.Group>
                 <Space direction="vertical">
                   <Radio value="remote">

--- a/ui/src/domain/Workspaces/Create.tsx
+++ b/ui/src/domain/Workspaces/Create.tsx
@@ -61,6 +61,7 @@ export const CreateWorkspace = () => {
     token: { colorBgContainer },
   } = theme.useToken();
   const [organizationName, setOrganizationName] = useState<string | null>();
+  const [executionMode, setExecutionMode] = useState<string | null>();
   const [terraformVersions, setTerraformVersions] = useState<string[]>([]);
   const [vcs, setVCS] = useState<VcsModel[]>([]);
   const [sshKeys, setSSHKeys] = useState<SshKey[]>([]);
@@ -259,6 +260,7 @@ export const CreateWorkspace = () => {
     setStep4Hidden(false);
     setSSHKeysVisible(false);
     setRequiredVcsPush(false);
+    setExecutionMode("local");
     form.setFieldsValue({ source: "empty", branch: "remote-content" });
   };
 
@@ -306,6 +308,7 @@ export const CreateWorkspace = () => {
               branch: values.branch,
               iacType: iacType.id,
               defaultTemplate: values.defaultTemplate,
+              executionMode: executionMode,
             },
             relationships: {},
           },

--- a/ui/src/domain/Workspaces/Details.tsx
+++ b/ui/src/domain/Workspaces/Details.tsx
@@ -713,7 +713,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
                         </span>
                         <span>
                           <ThunderboltOutlined /> Execution Mode:{" "}
-                          <a onClick={handleClickSettings}>{executionMode}</a>{" "}
+                          {executionMode}{" "}
                         </span>
                         <span>
                           <PlayCircleOutlined /> Auto apply: <a>Off</a>{" "}

--- a/ui/src/domain/Workspaces/Settings/General.tsx
+++ b/ui/src/domain/Workspaces/Settings/General.tsx
@@ -267,9 +267,9 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace 
             name="executionMode"
             label="Execution Mode"
             extra={
-              "Use this option with terraform remote state/cloud block if you want to execute " +
-              getIaCNameById(selectedIac || workspaceData.attributes?.iacType) +
-              " CLI remotely and just upload the state to Terrakube"
+              "Local indicates users should run " + getIaCNameById(selectedIac || workspaceData.attributes?.iacType) + " " +
+              "locally with remote state/cloud block and just upload the state to Terrakube. Remote " +
+              "indicates Terrakube will run plans and apply. Informational only."
             }
           >
             <Select


### PR DESCRIPTION
The execution_mode concept was somewhat confusing and if you create an org, it will default to `null` execution_mode, which then propagates to workspaces, showing empty on the workspace details page.

This PR ensures orgs default to remote (which is how null is interpreted in practice) and that the UI propagates this to workspaces on creation (but CLI-driven workspaces are set as local, regardless of org setting). In order to reduce data model complexity, we also rewrite all nulls to `remote`. Also, clarify that this field is not used programmatically.

This is not the most important PR in the history of Terrakube. Since it is somewhat invasive and we are getting close to a 2.29 release, it might make sense to save this one till after the release?