### PR TITLE
deps: bump Spring Boot and Buildpack versions in POM files

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -40,9 +40,9 @@
         <commons-io.version>2.21.0</commons-io.version>
         <kubernetes-client.version>7.4.0</kubernetes-client.version>
         <!--BUILDPACK DATA-->
-        <buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.487</buildpack.builder>
-        <buildpack.java>paketobuildpacks/java:20.1.0</buildpack.java>
-        <buildpack.telemetry>paketobuildpacks/opentelemetry:2.17.0</buildpack.telemetry>
+        <buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.519</buildpack.builder>
+        <buildpack.java>paketobuildpacks/java:20.5.0</buildpack.java>
+        <buildpack.telemetry>paketobuildpacks/opentelemetry:2.20.0</buildpack.telemetry>
     </properties>
     <build>
         <plugins>

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -36,9 +36,9 @@
 		<sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}
 		</sonar.coverage.jacoco.xmlReportPaths>
 		<!--BUILDPACK DATA-->
-        <buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.487</buildpack.builder>
-        <buildpack.java>paketobuildpacks/java:20.1.0</buildpack.java>
-        <buildpack.telemetry>paketobuildpacks/opentelemetry:2.17.0</buildpack.telemetry>
+		<buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.519</buildpack.builder>
+		<buildpack.java>paketobuildpacks/java:20.5.0</buildpack.java>
+		<buildpack.telemetry>paketobuildpacks/opentelemetry:2.20.0</buildpack.telemetry>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.7</version>
+        <version>3.5.9</version>
     </parent>
 
     <groupId>io.terrakube</groupId>

--- a/registry/pom.xml
+++ b/registry/pom.xml
@@ -30,9 +30,9 @@
         <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}
         </sonar.coverage.jacoco.xmlReportPaths>
         <!--BUILDPACK DATA-->
-        <buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.487</buildpack.builder>
-        <buildpack.java>paketobuildpacks/java:20.1.0</buildpack.java>
-        <buildpack.telemetry>paketobuildpacks/opentelemetry:2.17.0</buildpack.telemetry>
+        <buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.519</buildpack.builder>
+        <buildpack.java>paketobuildpacks/java:20.5.0</buildpack.java>
+        <buildpack.telemetry>paketobuildpacks/opentelemetry:2.20.0</buildpack.telemetry>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
- Updated Spring Boot version to 3.5.9.
- Upgraded Buildpack dependencies:
  - Builder: `paketobuildpacks/builder-jammy-base` to 0.4.519.
  - Java: `paketobuildpacks/java` to 20.5.0.
  - Telemetry: `paketobuildpacks/opentelemetry` to 2.20.0.