### PR TITLE
feat: Job UI improvements

### DIFF
--- a/ui/src/config/axiosConfig.ts
+++ b/ui/src/config/axiosConfig.ts
@@ -21,7 +21,7 @@ axiosInstance.interceptors.request.use(
     return config;
   },
   function (error) {
-    Promise.reject(error);
+    return Promise.reject(error);
   }
 );
 
@@ -33,7 +33,7 @@ axiosGraphQL.interceptors.request.use(
     return config;
   },
   function (error) {
-    Promise.reject(error);
+    return Promise.reject(error);
   }
 );
 

--- a/ui/src/domain/Jobs/Create.tsx
+++ b/ui/src/domain/Jobs/Create.tsx
@@ -1,4 +1,4 @@
-import { DeleteOutlined, InfoCircleOutlined, PlusOutlined } from "@ant-design/icons";
+import { DeleteOutlined, InfoCircleOutlined, PlayCircleOutlined } from "@ant-design/icons";
 import { Button, Form, Input, Modal, Select, Space, message, Typography } from "antd";
 import { useEffect, useState } from "react";
 import { ORGANIZATION_ARCHIVE, WORKSPACE_ARCHIVE } from "../../config/actionTypes";
@@ -21,6 +21,7 @@ export const CreateJob = ({ changeJob }: Props) => {
   const organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
   const [visible, setVisible] = useState(false);
   const [form] = Form.useForm<CreateJobForm>();
+  const [defaultTemplate, setDefaultTemplate] = useState();
   const [templates, setTemplates] = useState<Template[]>([]);
   const [branchName, setBranchName] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -36,8 +37,10 @@ export const CreateJob = ({ changeJob }: Props) => {
 
   const loadBranch = () => {
     axiosInstance.get(`organization/${organizationId}/workspace/${workspaceId}`).then((response) => {
-      const branchName = response.data.data.attributes.branch;
-      setBranchName(branchName);
+      console.log(response.data);
+      const { branch, defaultTemplate } = response.data.data.attributes;
+      setDefaultTemplate(defaultTemplate);
+      setBranchName(branch);
     });
   };
 
@@ -99,14 +102,14 @@ export const CreateJob = ({ changeJob }: Props) => {
         onClick={() => {
           setVisible(true);
         }}
-        icon={<PlusOutlined />}
+        icon={<PlayCircleOutlined />}
       >
-        New job
+        Run now
       </Button>
 
       <Modal
         open={visible}
-        title="Start a new job"
+        title="Run job"
         okText="Start"
         cancelText="Cancel"
         onCancel={onCancel}
@@ -130,7 +133,11 @@ export const CreateJob = ({ changeJob }: Props) => {
             </Typography.Text>
           </div>
           <Form form={form} layout="vertical" name="create-org" validateMessages={validateMessages}>
-            <Form.Item name="templateId" label="Choose job type" rules={[{ required: true }]}>
+            <Form.Item
+              name="templateId"
+              label="Choose job type"
+              rules={[{ required: true }]}
+              initialValue={defaultTemplate}>
               {loading || !templates ? (
                 <p>Data loading...</p>
               ) : (

--- a/ui/src/domain/Jobs/Details.tsx
+++ b/ui/src/domain/Jobs/Details.tsx
@@ -8,7 +8,6 @@ import {
   ExclamationCircleOutlined,
   LoadingOutlined,
   MinusCircleOutlined,
-  PlayCircleOutlined,
   StopOutlined,
   SyncOutlined,
   UserOutlined,
@@ -85,6 +84,9 @@ export const DetailsJob = ({ jobId }: Props) => {
       .then(() => {
         message.success("Job Cancelled Succesfully");
         loadJob();
+      })
+      .catch((error) => {
+        message.error("Could not cancel job: " + error.response.data.errors[0].detail);
       });
   };
 
@@ -124,8 +126,11 @@ export const DetailsJob = ({ jobId }: Props) => {
           "Content-Type": "application/vnd.api+json",
         },
       })
-      .then((response) => {
-        console.log(response);
+      .then(() => {
+        message.success("Approve successful");
+      })
+      .catch((error) => {
+        message.error("Could not approve: " + error.response.data.errors[0].detail);
       });
   };
 
@@ -146,8 +151,11 @@ export const DetailsJob = ({ jobId }: Props) => {
           "Content-Type": "application/vnd.api+json",
         },
       })
-      .then((response) => {
-        console.log(response);
+      .then(() => {
+        message.success("Discard successful");
+      })
+      .catch((error) => {
+        message.error("Could not discard: " + error.response.data.errors[0].detail);
       });
   };
 

--- a/ui/src/domain/Workspaces/Details.tsx
+++ b/ui/src/domain/Workspaces/Details.tsx
@@ -408,15 +408,14 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
         },
       })
       .then((response) => {
-        if (response.status === 204) {
-          loadWorkspace(true);
-          var newstatus = locked ? "unlocked" : "locked";
-          message.success("Workspace " + newstatus + " successfully");
-        } else {
-          var newstatus = locked ? "unlock" : "lock";
-          message.error("Workspace " + newstatus + " failed");
-        }
-      });
+        loadWorkspace(true);
+        var newstatus = locked ? "unlocked" : "locked";
+        message.success("Workspace " + newstatus + " successfully");
+      })
+      .catch((error) => {
+        var newstatus = locked ? "unlock" : "lock";
+        message.error("Workspace " + newstatus + " failed: " + error.response.data.errors[0].detail);
+      })
   };
 
   return (
@@ -714,9 +713,6 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
                         <span>
                           <ThunderboltOutlined /> Execution Mode:{" "}
                           {executionMode}{" "}
-                        </span>
-                        <span>
-                          <PlayCircleOutlined /> Auto apply: <a>Off</a>{" "}
                         </span>
                         <Divider />
                         <h4>Tags</h4>

--- a/ui/src/domain/Workspaces/Settings/General.tsx
+++ b/ui/src/domain/Workspaces/Settings/General.tsx
@@ -169,11 +169,6 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace 
           layout="vertical"
           name="form-settings"
         >
-          <Form.Item name="id" label="ID">
-            <Typography.Paragraph copyable={{ tooltips: false }}>
-              <span className="App-text"> {id}</span>
-            </Typography.Paragraph>
-          </Form.Item>
           <Form.Item
             name="name"
             rules={[


### PR DESCRIPTION
Assorted improvements:
- axiosInstance now propagates request-side errors (i.e. where the HTTP request cannot be performed at all)
- switch from plus to arrow on run button and switch to "run" since the UI refers to historical job executions as "Runs"
- default template is now used when running jobs
- various post and patch requests will now display their errors as toasts
- remove ID from general settings as it is already visible above
- remove the auto-apply setting since it is hard-coded; auto-apply is anyway dependent on which job type you pick when running