### PR TITLE
feat: add support for executing onFailure scripts for failed Terraform operations

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
@@ -15,6 +15,7 @@ import java.util.List;
 @Setter
 public class ExecutorContext {
     private List<Command> commandList;
+    private List<Command> onFailureList;
     private String type;
     private String organizationId;
     private String workspaceId;

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -142,6 +142,7 @@ public class ExecutorService {
         executorContext.setEnvironmentVariables(environmentVariables);
 
         executorContext.setCommandList(flow.getCommands());
+        executorContext.setOnFailureList(flow.getOnFailure());
         executorContext.setType(flow.getType());
         executorContext.setIgnoreError(flow.isIgnoreError());
         executorContext.setTerraformVersion(job.getWorkspace().getTerraformVersion());

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/model/Flow.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/model/Flow.java
@@ -18,6 +18,7 @@ public class Flow {
     private String error;
     private int step;
     List<Command> commands;
+    List<Command> onFailure;
 
     List<ScheduleTemplate> templates;
 

--- a/executor/src/main/java/io/terrakube/executor/service/mode/TerraformJob.java
+++ b/executor/src/main/java/io/terrakube/executor/service/mode/TerraformJob.java
@@ -13,6 +13,7 @@ import java.util.List;
 public class TerraformJob {
 
     private List<Command> commandList;
+    private List<Command> onFailureList;
     private String type;
     private String organizationId;
     private String workspaceId;

--- a/executor/src/main/java/io/terrakube/executor/service/mode/online/OnlineModeServiceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/mode/online/OnlineModeServiceImpl.java
@@ -2,6 +2,7 @@ package io.terrakube.executor.service.mode.online;
 
 import io.terrakube.executor.service.mode.TerraformJob;
 import io.terrakube.executor.service.executor.ExecutorJob;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/terraform-rs")
+@Slf4j
 public class OnlineModeServiceImpl {
 
     @Autowired
@@ -19,6 +21,7 @@ public class OnlineModeServiceImpl {
     @ResponseStatus(HttpStatus.ACCEPTED)
 
     public ResponseEntity<TerraformJob> terraformJob(@RequestBody TerraformJob terraformJob) {
+        log.debug("Received terraform job {}", terraformJob);
         executorJob.createJob(terraformJob);
         return new ResponseEntity<TerraformJob>(terraformJob, HttpStatus.ACCEPTED);
     }

--- a/executor/src/main/java/io/terrakube/executor/service/scripts/ScriptEngineService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/scripts/ScriptEngineService.java
@@ -52,6 +52,7 @@ public class ScriptEngineService {
         AtomicBoolean executeSuccess = new AtomicBoolean(true);
         TreeMap<Integer, Command> commandOrder = new TreeMap<>();
         if (commands != null) {
+            log.debug("Executing scripts: {}", commands);
             commands.forEach(command -> {
                 commandOrder.put(command.getPriority(), command);
             });


### PR DESCRIPTION
- Introduced `onFailureList` in `TerraformJob` and related classes to handle failure scenarios.
- Added logic to execute `onFailure` scripts when Terraform plan or apply fails.
- Improved logging to debug and warn about failure script execution.

This will allow to add a template like this:

```yaml
flow:
- type: "terraformPlan"
  name: "Plan"
  step: 100
  onFailure:
  - runtime: "BASH"
    priority: 100
    script: |
      echo "There is an error while executing terraform plan"
  
```

Example in the UI.

<img width="1295" height="891" alt="imagen" src="https://github.com/user-attachments/assets/4abae09a-4699-4740-b4db-a53823eb06a9" />


fix #2793 