### PR TITLE
fix: update TOFU_DIRECTORY path to include version folder in BashEngine

### DIFF
--- a/executor/src/main/java/io/terrakube/executor/service/scripts/bash/BashEngine.java
+++ b/executor/src/main/java/io/terrakube/executor/service/scripts/bash/BashEngine.java
@@ -35,7 +35,7 @@ import static com.diogonunes.jcolor.Attribute.*;
 public class BashEngine implements CommandExecution {
     private static final String USER_BASH_SCRIPT = "/userScript.sh";
     private static final String TERRAFORM_DIRECTORY="/.terraform-spring-boot/terraform/";
-    private static final String TOFU_DIRECTORY="/.terraform-spring-boot/tofu/";
+    private static final String TOFU_DIRECTORY="/.terraform-spring-boot/tofu/v";
 
     private final ExecutorService executor = Executors.newWorkStealingPool();
 


### PR DESCRIPTION
This PR change the logic for the path https://github.com/terrakube-io/terraform-spring-boot/pull/80

Example:

<img width="555" height="141" alt="imagen" src="https://github.com/user-attachments/assets/7b1b01dd-0aeb-44b2-ad90-3477b2d22df1" />


Now it should work when using the following template for example:

```yaml
flow:
  - type: "terraformPlan"
    step: 100
    commands:
      - runtime: "BASH"
        priority: 200
        after: true
        script: |
          echo $PATH
          tofu -version
          tofu -help
```

Test example:

<img width="554" height="848" alt="imagen" src="https://github.com/user-attachments/assets/275d58d3-9a9f-4141-ae24-06b7b52b5730" />

fix #2853 
