### PR TITLE
fix: correct VCS type for GitLab Enterprise Edition menu option

### DIFF
--- a/ui/src/domain/Settings/AddVCS.tsx
+++ b/ui/src/domain/Settings/AddVCS.tsx
@@ -102,7 +102,7 @@ export const AddVCS = ({ setMode, loadVCS }: Props) => {
       label: "Gitlab Enterprise Edition",
       key: "3",
       onClick: () => {
-        handleVCSClick(VcsTypeExtended.GITHUB_ENTERPRISE);
+        handleVCSClick(VcsTypeExtended.GITLAB_ENTERPRISE);
       },
     },
   ];


### PR DESCRIPTION
There is a typo when setting the correct value for Gitlab Enterprise.

Now when creating the vcs connection it will create the correct type for GITLAB enterprise

<img width="601" height="815" alt="Image" src="https://github.com/user-attachments/assets/4f764ec2-678d-471b-9ccb-93851371044f" />

The URL will match the correct  format;

```
switch (vcs) {
      case "GITLAB":
      case "GITLAB_ENTERPRISE":
        if (endpoint != null)
          return `${endpoint}/oauth/authorize?client_id=${clientId}&response_type=code&scope=api&&redirect_uri=${callbackUrl}`;
```

<img width="1401" height="123" alt="Image" src="https://github.com/user-attachments/assets/652accf4-146a-491c-bf77-49b3de0e1597" />

<img width="1528" height="576" alt="Image" src="https://github.com/user-attachments/assets/40db96c7-7588-465f-8697-1611518c9d7b" />

fix #2852 