### PR TITLE
fix: correct VCS type for GitLab Enterprise Edition menu option (#2875)

### DIFF
--- a/ui/src/domain/Settings/AddVCS.tsx
+++ b/ui/src/domain/Settings/AddVCS.tsx
@@ -102,7 +102,7 @@ export const AddVCS = ({ setMode, loadVCS }: Props) => {
       label: "Gitlab Enterprise Edition",
       key: "3",
       onClick: () => {
-        handleVCSClick(VcsTypeExtended.GITHUB_ENTERPRISE);
+        handleVCSClick(VcsTypeExtended.GITLAB_ENTERPRISE);
       },
     },
   ];


### PR DESCRIPTION
backported to 2.29.X branch