### PR TITLE
fix: update TOFU_DIRECTORY path to include version folder in BashEngine (#2854)

### DIFF
--- a/executor/src/main/java/io/terrakube/executor/service/scripts/bash/BashEngine.java
+++ b/executor/src/main/java/io/terrakube/executor/service/scripts/bash/BashEngine.java
@@ -35,7 +35,7 @@ import static com.diogonunes.jcolor.Attribute.*;
 public class BashEngine implements CommandExecution {
     private static final String USER_BASH_SCRIPT = "/userScript.sh";
     private static final String TERRAFORM_DIRECTORY="/.terraform-spring-boot/terraform/";
-    private static final String TOFU_DIRECTORY="/.terraform-spring-boot/tofu/";
+    private static final String TOFU_DIRECTORY="/.terraform-spring-boot/tofu/v";
 
     private final ExecutorService executor = Executors.newWorkStealingPool();
 


### PR DESCRIPTION
backported to 2.29.X branch