### PR TITLE
fix: restrict Terraform Cloud importer to approved URLs

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/importer/tfcloud/controller/TfCloudController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/importer/tfcloud/controller/TfCloudController.java
@@ -1,33 +1,53 @@
 package io.terrakube.api.plugin.importer.tfcloud.controller;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import io.terrakube.api.plugin.importer.tfcloud.WorkspaceImport;
 import io.terrakube.api.plugin.importer.tfcloud.WorkspaceImportRequest;
 import io.terrakube.api.plugin.importer.tfcloud.services.WorkspaceService;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/importer/tfcloud")
+@Slf4j
 public class TfCloudController {
 
     private final WorkspaceService service;
+    private static final String INVALID_URL_MESSAGE = "Invalid Importer URL, only approved URL are allowed please check with your Terrakube admin";
 
     public TfCloudController(WorkspaceService service) {
         this.service = service;
     }
 
+    @Value("${io.terrakube.importer.allowedUrl}")
+    private String allowedUrls;
+
     @GetMapping("/workspaces")
-    public List<WorkspaceImport.WorkspaceData> getWorkspaces(@RequestHeader("X-TFC-Url") String apiUrl,@RequestHeader("X-TFC-Token") String apiToken,
+    public ResponseEntity<?> getWorkspaces(@RequestHeader("X-TFC-Url") String apiUrl,@RequestHeader("X-TFC-Token") String apiToken,
             @RequestParam String organization) {
-        return service.getWorkspaces(apiToken,apiUrl, organization);
+        log.info("Allowed URLs getWorkspaces: {}", allowedUrls);
+        String[] listUrls = this.allowedUrls.split(",");
+        for(String url:listUrls){
+            if(apiUrl.startsWith(url)){
+                return ResponseEntity.ok(service.getWorkspaces(apiToken,apiUrl, organization));
+            }
+        }
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(INVALID_URL_MESSAGE);
+
     }
 
     @PostMapping("/workspaces")
     public ResponseEntity<?> importWorkspaces(@RequestHeader("X-TFC-Url") String apiUrl,@RequestHeader("X-TFC-Token") String apiToken,@RequestBody WorkspaceImportRequest request) {
-        String result = service.importWorkspace(apiToken,apiUrl,request);
-        return ResponseEntity.ok().body(result);
+        log.info("Allowed URLs Import Workspaces: {}", allowedUrls);
+        String[] listUrls = this.allowedUrls.split(",");
+        for(String url:listUrls){
+            if(apiUrl.startsWith(url)){
+                String result = service.importWorkspace(apiToken,apiUrl,request);
+                return ResponseEntity.ok().body(result);
+            }
+        }
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(INVALID_URL_MESSAGE);
     }
 
 }

--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -205,4 +205,9 @@ io.terrakube.dynamic.credentials.hostname=${DynamicCredentialHostname:}
 io.terrakube.dynamic.credentials.public-key-path=${DynamicCredentialPublicKeyPath:}
 io.terrakube.dynamic.credentials.private-key-path=${DynamicCredentialPrivateKeyPath:}
 
+######################
+#IMPORTER ALLOWED URL#
+######################
+io.terrakube.importer.allowedUrl=${ImporterAllowedUrl:https://app.terraform.io}
+
 # logging.level.org.springframework.security=DEBUG

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -209,6 +209,11 @@ io.terrakube.dynamic.credentials.ttl=${DynamicCredentialTtl:30}
 io.terrakube.dynamic.credentials.public-key-path=${DynamicCredentialPublicKeyPath:}
 io.terrakube.dynamic.credentials.private-key-path=${DynamicCredentialPrivateKeyPath:}
 
+######################
+#IMPORTER ALLOWED URL#
+######################
+io.terrakube.importer.allowedUrl=${ImporterAllowedUrl:https://app.terraform.io}
+
 # logging.level.org.springframework=DEBUG
 # logging.level.io.terrakube=DEBUG
 # logging.level.com.yahoo.elide=DEBUG

--- a/api/src/test/java/io/terrakube/api/ImporterTests.java
+++ b/api/src/test/java/io/terrakube/api/ImporterTests.java
@@ -1,0 +1,43 @@
+package io.terrakube.api;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static io.restassured.RestAssured.given;
+
+public class ImporterTests extends ServerApplicationTests {
+
+    @Test
+    void forbiddenGetImporterWorkspaces() {
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .header("X-TFC-Url", "https://fake.com")
+                .header("X-TFC-Token", "12345")
+                .header("Content-Type", "application/json")
+                .queryParam("organization", "my-org")
+                .when()
+                .get("/importer/tfcloud/workspaces")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.FORBIDDEN.value());
+    }
+
+    @Test
+    void forbiddenPostImporterWorkspaces() {
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .header("X-TFC-Url", "https://fake.com")
+                .header("X-TFC-Token", "12345")
+                .header("Content-Type", "application/json")
+                .body("{}")
+                .when()
+                .post("/importer/tfcloud/workspaces")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.FORBIDDEN.value());
+    }
+}

--- a/ui/src/domain/Workspaces/Import.tsx
+++ b/ui/src/domain/Workspaces/Import.tsx
@@ -13,7 +13,7 @@ import {
   Steps,
   Table,
   message,
-  theme,
+  theme, Alert,
 } from "antd";
 import parse from "html-react-parser";
 import { ValidateErrorEntity } from "rc-field-form/lib/interface";
@@ -406,6 +406,13 @@ export const ImportWorkspace = () => {
           <h2>Import Workspaces</h2>
           <div className="App-text">
             Easily transfer workspaces from Terraform Cloud and Terraform Enterprise to Terrakube.
+            <Alert
+                title="Warning"
+                description="Only approved URLs can be used when using Terraform Enterprise to import workspaces. Please verify with your Terrakube administrator if you encounter any issues."
+                type="warning"
+                showIcon
+                style={{ marginBottom: "20px" }}
+            />
           </div>
           <Content hidden={stepsHidden}>
             <Steps direction="horizontal" size="small" current={current} onChange={handleChange}>


### PR DESCRIPTION
* fix: restrict Terraform Cloud importer to approved URLs

- Added `io.terrakube.importer.allowedUrl` configuration to define approved URLs.
- Updated `TfCloudController` to validate API URL against allowed list.
- Display warning in UI for unapproved URL usage.

* test: add tests to verify forbidden access to Terraform Cloud importer endpoints

- Introduced `ImporterTests` to validate `403 Forbidden` responses for both `GET` and `POST` endpoints on `/importer/tfcloud/workspaces` without proper authorization.