### PR TITLE
feat: add CLI template check for job scheduling logic

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -117,7 +117,7 @@ public class ScheduleJob implements org.quartz.Job {
         log.info("Checking previous jobs....");
 
         boolean canProceed;
-        if (tclService.isTemplatePlanOnly(job.getTemplateReference())) {
+        if (tclService.isTemplatePlanOnly(job.getTemplateReference()) && !tclService.isCliTemplate(job.getTemplateReference())) {
             log.info("Job {} is plan-only (bypassQueue), checking for active apply/destroy", jobId);
             canProceed = !isActiveApplyOrDestroyRunning(job.getWorkspace(), job.getId());
             if (!canProceed) {

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/TclService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/TclService.java
@@ -8,6 +8,7 @@ import io.terrakube.api.repository.VcsRepository;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.job.step.Step;
+import io.terrakube.api.rs.template.Template;
 import io.terrakube.api.rs.vcs.Vcs;
 import io.terrakube.api.rs.vcs.VcsConnectionType;
 import lombok.AllArgsConstructor;
@@ -313,5 +314,21 @@ public class TclService {
             log.warn("Error checking if template {} is plan-only: {}", templateId, e.getMessage());
             return false;
         }
+    }
+
+    public boolean isCliTemplate(String templateReference) {
+        try {
+            Optional<Template> template = templateRepository.findById(UUID.fromString(templateReference));
+
+            if (template.isPresent()) {
+                Template temp = template.get();
+                return temp.getName().equals("Terraform-Plan/Apply-Cli") || temp.getName().equals("Terraform-Plan/Destroy-Cli");
+            }
+            else return false;
+        } catch(Exception e) {
+            log.warn("Error checking if template {} is cli: {}", templateReference, e.getMessage());
+        }
+
+        return false;
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
@@ -693,6 +693,7 @@ public class ScheduleJobTest {
         flow.setType(FlowType.terraformPlan.name());
 
         doReturn(true).when(tclService).isTemplatePlanOnly("plan-only-template");
+        doReturn(false).when(tclService).isCliTemplate("plan-only-template");
         doReturn(Optional.of(Collections.emptyList()))
                 .when(jobRepository)
                 .findByWorkspaceAndStatusInAndIdLessThan(
@@ -728,6 +729,7 @@ public class ScheduleJobTest {
         runningStep.setStepNumber(100);
 
         doReturn(true).when(tclService).isTemplatePlanOnly("plan-only-template");
+        doReturn(false).when(tclService).isCliTemplate("plan-only-template");
         doReturn(Optional.of(Collections.singletonList(runningJob)))
                 .when(jobRepository)
                 .findByWorkspaceAndStatusInAndIdLessThan(
@@ -765,6 +767,7 @@ public class ScheduleJobTest {
         flow.setType(FlowType.terraformPlan.name());
 
         doReturn(true).when(tclService).isTemplatePlanOnly("plan-only-template");
+        doReturn(false).when(tclService).isCliTemplate("plan-only-template");
         doReturn(Optional.of(Collections.singletonList(runningJob)))
                 .when(jobRepository)
                 .findByWorkspaceAndStatusInAndIdLessThan(


### PR DESCRIPTION
- Introduced `isCliTemplate` method in `TclService` to identify CLI-specific templates.
- Updated `ScheduleJob` to exclude CLI templates from plan-only job bypass logic.
- Added unit tests to validate new CLI template checks.

This will block  when using CLI driven workflows templates

Related to https://github.com/terrakube-io/terrakube/pull/2879