### PR TITLE
fix: strip leading sign byte from modulus, exponent for JWK comliance

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/token/dynamic/JwksController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/token/dynamic/JwksController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPublicKey;
@@ -42,6 +43,18 @@ public class JwksController {
 
     }
 
+    private String toUnsignedBase64(BigInteger value) {
+        byte[] array = value.toByteArray();
+
+        if (array.length > 1 && array[0] == 0) {
+            byte[] unsignedArray = new byte[array.length - 1];
+            System.arraycopy(array, 1, unsignedArray, 0, unsignedArray.length);
+            array = unsignedArray;
+        }
+
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(array);
+    }
+
     private JwkData getJwkData() throws NoSuchAlgorithmException, InvalidKeySpecException {
         String publicKey = dynamicCredentialsService.getPublicKey();
 
@@ -53,8 +66,8 @@ public class JwksController {
             X509EncodedKeySpec keySpec = new X509EncodedKeySpec(encoded);
 
             RSAPublicKey rsa = (RSAPublicKey) keyFactory.generatePublic(keySpec);
-            String exponent = Base64.getUrlEncoder().encodeToString(rsa.getPublicExponent().toByteArray());
-            String modulus = Base64.getUrlEncoder().withoutPadding().encodeToString(rsa.getModulus().toByteArray());
+            String exponent = toUnsignedBase64(rsa.getPublicExponent());
+            String modulus = toUnsignedBase64(rsa.getModulus());
             log.info("RSA Exponent: {}", exponent);
             log.info("RSA Modulus: {}", modulus);
 


### PR DESCRIPTION
Keys will sometimes (50/50), have a leading byte 0x80-0xFF causing a padding byte to be added to the modulus to make the bigint positive, resulting in different encoding of the bytes from RFC 7518. Using the OIDC token Terrakube generated in a JWK decode, the signing check fails with a modulus with padding whereas the  JWKS generated by another tool passes.

This code removes the first byte if zero resulting in a modulus that matches other implementations.

See #2932 for details of the validation done.