### PR TITLE
feat(ui): add TerminalOutput component with toolbar for job logs

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -77,6 +77,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-dynamic-import-vars": "^2.1.5",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
@@ -101,8 +102,10 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.26",
     "globals": "^17.3.0",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
+    "jest-transformer-svg": "^2.1.0",
     "prettier": "^3.8.1",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",

--- a/ui/src/domain/Jobs/Details.tsx
+++ b/ui/src/domain/Jobs/Details.tsx
@@ -12,7 +12,6 @@ import {
   SyncOutlined,
   UserOutlined,
 } from "@ant-design/icons";
-import Ansi from "ansi-to-react";
 import { Avatar, Button, Card, Collapse, message, Radio, RadioChangeEvent, Space, Spin, Tag } from "antd";
 import { AxiosResponse } from "axios";
 import parse from "html-react-parser";
@@ -21,6 +20,7 @@ import { useEffect, useState } from "react";
 import { ORGANIZATION_ARCHIVE } from "../../config/actionTypes";
 import axiosInstance, { axiosClient } from "../../config/axiosConfig";
 import { Job, JobStep } from "../types";
+import { TerminalOutput } from "./TerminalOutput";
 
 type Props = {
   jobId: string;
@@ -332,13 +332,6 @@ export const DetailsJob = ({ jobId }: Props) => {
           {steps.length > 0 ? (
             steps.map((item) => (
               <>
-                <style>
-                  {`
-                .ant-collapse .ant-collapse-content > .ant-collapse-content-box {
-                  padding: 0 !important;
-                }
-              `}
-                </style>
                 <Collapse
                   style={{ width: "100%" }}
                   defaultActiveKey={item.status === "running" ? ["2"] : []}
@@ -371,19 +364,19 @@ export const DetailsJob = ({ jobId }: Props) => {
                               {uiType === "structured" ? (
                                 <div>{parse(uiTemplates[item.stepNumber])}</div>
                               ) : (
-                                <div id="code-container">
-                                  <div id="code-content">
-                                    <Ansi>{item.outputLog}</Ansi>
-                                  </div>
-                                </div>
+                                <TerminalOutput
+                                  outputLog={item.outputLog}
+                                  stepName={item.name}
+                                  isRunning={item.status === "running"}
+                                />
                               )}
                             </>
                           ) : (
-                            <div id="code-container">
-                              <div id="code-content">
-                                <Ansi>{item.outputLog}</Ansi>
-                              </div>
-                            </div>
+                            <TerminalOutput
+                              outputLog={item.outputLog}
+                              stepName={item.name}
+                              isRunning={item.status === "running"}
+                            />
                           )}
                         </>
                       ),

--- a/ui/src/domain/Jobs/TerminalOutput.css
+++ b/ui/src/domain/Jobs/TerminalOutput.css
@@ -1,0 +1,68 @@
+.terminal-wrapper {
+  position: relative;
+}
+
+.terminal-container {
+  max-height: calc(100vh - 280px);
+  min-height: 400px;
+  overflow-y: auto;
+  background-color: #1e1e1e;
+  width: 100%;
+}
+
+.terminal-content {
+  color: #ffffff;
+  font-family: SFMono-Regular, consolas, "Liberation Mono", menlo, courier, monospace;
+  padding: 20px;
+  font-size: 0.875em;
+  white-space: pre-wrap;
+}
+
+.terminal-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px;
+  padding: 8px;
+  opacity: 0;
+  transition: opacity 0.15s ease-in-out;
+  pointer-events: none;
+}
+
+.terminal-wrapper:hover .terminal-toolbar {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.terminal-toolbar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  font-size: 12px;
+  line-height: 1;
+  color: #d4d4d4;
+  background: rgba(30, 30, 30, 0.8);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+
+.terminal-toolbar-btn:hover {
+  background: rgba(60, 60, 60, 0.9);
+}
+
+.terminal-toolbar-btn--active {
+  background: #2563eb;
+  color: #ffffff;
+  border-color: #2563eb;
+}
+
+.terminal-toolbar-btn--active:hover {
+  background: #1d4ed8;
+}

--- a/ui/src/domain/Jobs/TerminalOutput.tsx
+++ b/ui/src/domain/Jobs/TerminalOutput.tsx
@@ -1,0 +1,85 @@
+import { CopyOutlined, DownloadOutlined, ExportOutlined, VerticalAlignBottomOutlined } from "@ant-design/icons";
+import { message, Tooltip } from "antd";
+import Ansi from "ansi-to-react";
+import { useEffect, useRef, useState } from "react";
+import { stripAnsi } from "./stripAnsi";
+import "./TerminalOutput.css";
+
+type Props = {
+  outputLog: string;
+  stepName: string;
+  isRunning: boolean;
+};
+
+export const TerminalOutput = ({ outputLog, stepName, isRunning }: Props) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [followEnabled, setFollowEnabled] = useState(isRunning);
+
+  useEffect(() => {
+    if (followEnabled && containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [outputLog, followEnabled]);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(stripAnsi(outputLog)).then(
+      () => message.success("Copied to clipboard"),
+      () => message.error("Failed to copy to clipboard")
+    );
+  };
+
+  const handleDownload = () => {
+    const blob = new Blob([stripAnsi(outputLog)], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${stepName}.log`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  const handleRaw = () => {
+    const blob = new Blob([stripAnsi(outputLog)], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    window.open(url, "_blank");
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="terminal-wrapper">
+      <div className="terminal-container" ref={containerRef}>
+        <div className="terminal-toolbar">
+          <Tooltip title="Auto-scroll to bottom">
+            <button
+              type="button"
+              className={`terminal-toolbar-btn ${followEnabled ? "terminal-toolbar-btn--active" : ""}`}
+              onClick={() => setFollowEnabled((prev) => !prev)}
+            >
+              <VerticalAlignBottomOutlined /> Follow
+            </button>
+          </Tooltip>
+          <Tooltip title="Copy to clipboard">
+            <button type="button" className="terminal-toolbar-btn" onClick={handleCopy}>
+              <CopyOutlined /> Copy
+            </button>
+          </Tooltip>
+          <Tooltip title="Download as .log file">
+            <button type="button" className="terminal-toolbar-btn" onClick={handleDownload}>
+              <DownloadOutlined /> Download
+            </button>
+          </Tooltip>
+          <Tooltip title="Open plain text in new tab">
+            <button type="button" className="terminal-toolbar-btn" onClick={handleRaw}>
+              Raw <ExportOutlined />
+            </button>
+          </Tooltip>
+        </div>
+        <div className="terminal-content">
+          <Ansi>{outputLog}</Ansi>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ui/src/domain/Jobs/__tests__/TerminalOutput.test.tsx
+++ b/ui/src/domain/Jobs/__tests__/TerminalOutput.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TerminalOutput } from "../TerminalOutput";
+
+jest.mock("ansi-to-react", () => {
+  return {
+    __esModule: true,
+    default: ({ children }: { children: string }) => <span data-testid="ansi">{children}</span>,
+  };
+});
+
+jest.mock("antd", () => {
+  const actual = jest.requireActual("antd");
+  return {
+    ...actual,
+    message: { success: jest.fn(), error: jest.fn() },
+    Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const defaultProps = {
+  outputLog: "hello world",
+  stepName: "plan",
+  isRunning: false,
+};
+
+describe("TerminalOutput", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders output text", () => {
+    render(<TerminalOutput {...defaultProps} />);
+    expect(screen.getByTestId("ansi")).toHaveTextContent("hello world");
+  });
+
+  it("renders all 4 toolbar buttons", () => {
+    render(<TerminalOutput {...defaultProps} />);
+    expect(screen.getByText("Follow")).toBeInTheDocument();
+    expect(screen.getByText("Copy")).toBeInTheDocument();
+    expect(screen.getByText("Download")).toBeInTheDocument();
+    expect(screen.getByText("Raw")).toBeInTheDocument();
+  });
+
+  it("defaults Follow OFF when not running", () => {
+    render(<TerminalOutput {...defaultProps} isRunning={false} />);
+    const followBtn = screen.getByText("Follow").closest("button");
+    expect(followBtn?.className).not.toContain("terminal-toolbar-btn--active");
+  });
+
+  it("defaults Follow ON when running", () => {
+    render(<TerminalOutput {...defaultProps} isRunning={true} />);
+    const followBtn = screen.getByText("Follow").closest("button");
+    expect(followBtn?.className).toContain("terminal-toolbar-btn--active");
+  });
+
+  it("toggles Follow on click", () => {
+    render(<TerminalOutput {...defaultProps} isRunning={false} />);
+    const followBtn = screen.getByText("Follow").closest("button")!;
+    expect(followBtn.className).not.toContain("terminal-toolbar-btn--active");
+
+    fireEvent.click(followBtn);
+    expect(followBtn.className).toContain("terminal-toolbar-btn--active");
+
+    fireEvent.click(followBtn);
+    expect(followBtn.className).not.toContain("terminal-toolbar-btn--active");
+  });
+
+  it("copies stripped text to clipboard", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<TerminalOutput {...defaultProps} outputLog={"\u001b[31mred\u001b[0m"} />);
+    fireEvent.click(screen.getByText("Copy").closest("button")!);
+
+    expect(writeText).toHaveBeenCalledWith("red");
+  });
+
+  it("shows error when clipboard write fails", async () => {
+    const writeText = jest.fn().mockRejectedValue(new Error("denied"));
+    Object.assign(navigator, { clipboard: { writeText } });
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { message: mockMsg } = require("antd");
+
+    render(<TerminalOutput {...defaultProps} />);
+    fireEvent.click(screen.getByText("Copy").closest("button")!);
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockMsg.error).toHaveBeenCalledWith("Failed to copy to clipboard");
+  });
+
+  it("downloads stripped text as .log file with correct filename", () => {
+    const createObjectURL = jest.fn().mockReturnValue("blob:test");
+    const revokeObjectURL = jest.fn();
+    global.URL.createObjectURL = createObjectURL;
+    global.URL.revokeObjectURL = revokeObjectURL;
+
+    const fakeAnchor = { click: jest.fn(), href: "", download: "" } as unknown as HTMLAnchorElement;
+    const originalAppend = document.body.appendChild.bind(document.body);
+    const originalRemove = document.body.removeChild.bind(document.body);
+    const appendSpy = jest.spyOn(document.body, "appendChild").mockImplementation(<T extends Node>(node: T): T => {
+      if (node === (fakeAnchor as unknown as Node)) return node;
+      return originalAppend(node);
+    });
+    const removeSpy = jest.spyOn(document.body, "removeChild").mockImplementation(<T extends Node>(node: T): T => {
+      if (node === (fakeAnchor as unknown as Node)) return node;
+      return originalRemove(node);
+    });
+    const originalCreateElement = document.createElement.bind(document);
+    jest.spyOn(document, "createElement").mockImplementation((tag: string, options?: ElementCreationOptions) => {
+      if (tag === "a") return fakeAnchor;
+      return originalCreateElement(tag, options);
+    });
+
+    render(<TerminalOutput {...defaultProps} stepName="apply" outputLog={"\u001b[32mok\u001b[0m"} />);
+    fireEvent.click(screen.getByText("Download").closest("button")!);
+
+    expect(createObjectURL).toHaveBeenCalled();
+    expect(fakeAnchor.download).toBe("apply.log");
+    expect(appendSpy).toHaveBeenCalledWith(fakeAnchor);
+    expect((fakeAnchor as unknown as { click: jest.Mock }).click).toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalledWith(fakeAnchor);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:test");
+  });
+
+  it("opens raw text in new tab and revokes blob URL", () => {
+    const createObjectURL = jest.fn().mockReturnValue("blob:raw");
+    const revokeObjectURL = jest.fn();
+    global.URL.createObjectURL = createObjectURL;
+    global.URL.revokeObjectURL = revokeObjectURL;
+    const openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
+
+    render(<TerminalOutput {...defaultProps} />);
+    fireEvent.click(screen.getByText("Raw").closest("button")!);
+
+    expect(openSpy).toHaveBeenCalledWith("blob:raw", "_blank");
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:raw");
+  });
+});

--- a/ui/src/domain/Jobs/__tests__/stripAnsi.test.ts
+++ b/ui/src/domain/Jobs/__tests__/stripAnsi.test.ts
@@ -1,0 +1,23 @@
+import { stripAnsi } from "../stripAnsi";
+
+describe("stripAnsi", () => {
+  it("strips SGR color codes", () => {
+    expect(stripAnsi("\u001b[31mred text\u001b[0m")).toBe("red text");
+  });
+
+  it("strips multiple ANSI sequences", () => {
+    expect(stripAnsi("\u001b[1m\u001b[32mbold green\u001b[0m normal")).toBe("bold green normal");
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(stripAnsi("hello world")).toBe("hello world");
+  });
+
+  it("handles empty string", () => {
+    expect(stripAnsi("")).toBe("");
+  });
+
+  it("strips cursor movement codes", () => {
+    expect(stripAnsi("\u001b[2Jcleared")).toBe("cleared");
+  });
+});

--- a/ui/src/domain/Jobs/stripAnsi.ts
+++ b/ui/src/domain/Jobs/stripAnsi.ts
@@ -1,0 +1,5 @@
+const ANSI_REGEX =
+  // eslint-disable-next-line no-control-regex
+  /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nq-uy=><~]/g;
+
+export const stripAnsi = (text: string): string => text.replace(ANSI_REGEX, "");

--- a/ui/src/domain/Workspaces/Workspaces.css
+++ b/ui/src/domain/Workspaces/Workspaces.css
@@ -66,22 +66,6 @@
   margin-right: 40px;
 }
 
-#code-container {
-  background-color: #000000;
-  width: 100%;
-  height: 100%;
-  resize: auto;
-  min-height: 400px;
-  overflow: scroll;
-}
-
-#code-content {
-  color: #ffffff;
-  font-family: SFMono-Regular, consolas, "Liberation Mono", menlo, courier, monospace;
-  padding: 20px;
-  font-size: 0.875em;
-  white-space: pre-wrap;
-}
 
 .ant-collapse-content > .ant-collapse-content-box {
   padding: 0px;

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -23,7 +23,20 @@
     "@babel/runtime" "^7.23.2"
     "@rc-component/util" "^1.4.0"
 
-"@ant-design/cssinjs@^2.0.1", "@ant-design/cssinjs@^2.0.3":
+"@ant-design/cssinjs@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@ant-design/cssinjs/-/cssinjs-2.0.1.tgz#a7742deba17d613769db6d1aa4cfa46222ccec45"
+  integrity sha512-Lw1Z4cUQxdMmTNir67gU0HCpTl5TtkKCJPZ6UBvCqzcOTl/QmMFB6qAEoj8qFl0CuZDX9qQYa3m9+rEKfaBSbA==
+  dependencies:
+    "@babel/runtime" "^7.11.1"
+    "@emotion/hash" "^0.8.0"
+    "@emotion/unitless" "^0.7.5"
+    "@rc-component/util" "^1.4.0"
+    clsx "^2.1.1"
+    csstype "^3.1.3"
+    stylis "^4.3.4"
+
+"@ant-design/cssinjs@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@ant-design/cssinjs/-/cssinjs-2.0.3.tgz#b6d35b7b00f76fa8a8894d157bc158429ec7b1ca"
   integrity sha512-HAo8SZ3a6G8v6jT0suCz1270na6EA3obeJWM4uzRijBhdwdoMAXWK2f4WWkwB28yUufsfk3CAhN1coGPQq4kNQ==
@@ -36,7 +49,12 @@
     csstype "^3.1.3"
     stylis "^4.3.4"
 
-"@ant-design/fast-color@^3.0.0", "@ant-design/fast-color@^3.0.1":
+"@ant-design/fast-color@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-3.0.0.tgz"
+  integrity sha512-eqvpP7xEDm2S7dUzl5srEQCBTXZMmY3ekf97zI+M2DHOYyKdJGH0qua0JACHTqbkRnD/KHFQP9J1uMJ/XWVzzA==
+
+"@ant-design/fast-color@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@ant-design/fast-color/-/fast-color-3.0.1.tgz#fee56b95427c0b55b216c93d9a7f3473f31615b5"
   integrity sha512-esKJegpW4nckh0o6kV3Tkb7NPIZYbPnnFxmQDUmL08ukXZAvV85TZBr70eGuke/CIArLaP6aw8lt9KILjnWuOw==
@@ -86,7 +104,7 @@
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
-"@babel/code-frame@^7.29.0":
+"@babel/code-frame@^7.10.4", "@babel/code-frame@^7.29.0":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.0.tgz#7cd7a59f15b3cc0dcd803038f7792712a7d0b15c"
   integrity sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==
@@ -95,7 +113,12 @@
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
-"@babel/compat-data@^7.28.6", "@babel/compat-data@^7.29.0":
+"@babel/compat-data@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.28.6.tgz#103f466803fa0f059e82ccac271475470570d74c"
+  integrity sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==
+
+"@babel/compat-data@^7.29.0":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.0.tgz#00d03e8c0ac24dd9be942c5370990cbe1f17d88d"
   integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
@@ -133,9 +156,9 @@
     jsesc "^3.0.2"
 
 "@babel/generator@^7.29.0":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.0.tgz#4cba5a76b3c71d8be31761b03329d5dc7768447f"
-  integrity sha512-vSH118/wwM/pLR38g/Sgk05sNtro6TlTJKuiMXDaZqPUfjTFcudpCOt00IhOfj+1BFAX+UFAlzCU+6WXr3GLFQ==
+  version "7.29.1"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.1.tgz#d09876290111abbb00ef962a7b83a5307fba0d50"
+  integrity sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==
   dependencies:
     "@babel/parser" "^7.29.0"
     "@babel/types" "^7.29.0"
@@ -1092,9 +1115,9 @@
   integrity sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==
 
 "@babel/standalone@^7.29.0":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.29.0.tgz#910b5ddbab5a3b1ea0b9f1853b1c928c7519f5c5"
-  integrity sha512-ZbVDXDodISaxYugID/OCXRv6kMnADgTnHqNtSm2oBq4vHI81uFkbxXtdlSlguYe3BB4HiFwZ5kxa1kjrLMOuWg==
+  version "7.29.1"
+  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.29.1.tgz#0e4e6d9c8994f404d38c1d5e27d040601e8aa5b4"
+  integrity sha512-z42abD0C6fiHfgLyCWw8PYv6FCJ0IGVtSCxXk/NPykWO5LNIEGfdLDJ3HdYqlPcAhwtQ3oKH1PvNj2JGpTxQKg==
 
 "@babel/template@^7.27.1", "@babel/template@^7.28.6":
   version "7.28.6"
@@ -1463,9 +1486,9 @@
   integrity sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==
 
 "@isaacs/brace-expansion@^5.0.0":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz#0ef5a92d91f2fff2a37646ce54da9e5f599f6eff"
-  integrity sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz#4b3dabab7d8e75a429414a96bd67bf4c1d13e0f3"
+  integrity sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==
   dependencies:
     "@isaacs/balanced-match" "^4.0.1"
 
@@ -1932,23 +1955,23 @@
     "@rc-component/util" "^1.3.0"
 
 "@rc-component/dialog@~1.8.2":
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/@rc-component/dialog/-/dialog-1.8.2.tgz#d2bb66ba60c9f632e65c5e471cae38e357397d4e"
-  integrity sha512-CwDSjpjZ1FcgsdKFPuSoYfi9Vbt2bp+ak4Pzkwq4APQC8DopJKWetRu1V+HE9vI1CNAeqvT5WAvAxE6RiDhl7A==
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/@rc-component/dialog/-/dialog-1.8.4.tgz#e1f05f311539852f40a5717bc3874ce0af64c6ff"
+  integrity sha512-Ay6PM7phkTkquplG8fWfUGFZ2GTLx9diTl4f0d8Eqxd7W1u1KjE9AQooFQHOHnhZf0Ya3z51+5EKCWHmt/dNEw==
   dependencies:
     "@rc-component/motion" "^1.1.3"
     "@rc-component/portal" "^2.1.0"
-    "@rc-component/util" "^1.7.0"
+    "@rc-component/util" "^1.9.0"
     clsx "^2.1.1"
 
 "@rc-component/drawer@~1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@rc-component/drawer/-/drawer-1.4.1.tgz#df1173ce8e387fd558f73dcc18500f3c778a5ff7"
-  integrity sha512-kNJQie/QjJO5wGeWrZQwSGeuo8staxXx1nYN+dpK2UY7i8teo5PQdZ6ukKSnnW9vmPXsLn3F5nKYRbf43e8+5g==
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@rc-component/drawer/-/drawer-1.4.2.tgz#eb13a6556fb67be28407295c89401b01549224e0"
+  integrity sha512-1ib+fZEp6FBu+YvcIktm+nCQ+Q+qIpwpoaJH6opGr4ofh2QMq+qdr5DLC4oCf5qf3pcWX9lUWPYX652k4ini8Q==
   dependencies:
     "@rc-component/motion" "^1.1.4"
     "@rc-component/portal" "^2.1.3"
-    "@rc-component/util" "^1.7.0"
+    "@rc-component/util" "^1.9.0"
     clsx "^2.1.1"
 
 "@rc-component/dropdown@~1.0.0", "@rc-component/dropdown@~1.0.2":
@@ -2127,7 +2150,18 @@
     "@rc-component/util" "^1.3.0"
     clsx "^2.1.1"
 
-"@rc-component/select@~1.5.0", "@rc-component/select@~1.5.2":
+"@rc-component/select@~1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@rc-component/select/-/select-1.5.0.tgz#3c4522c7c8b7c73cc6414021198ede99e13c6732"
+  integrity sha512-Zz0hpToAfOdWo/1jj3dW5iooBNU8F6fVgVaYN4Jy1SL3Xcx2OO+IqiQnxqk/PjY6hg1HVt7LjkkrYvpJQyZxoQ==
+  dependencies:
+    "@rc-component/overflow" "^1.0.0"
+    "@rc-component/trigger" "^3.0.0"
+    "@rc-component/util" "^1.3.0"
+    "@rc-component/virtual-list" "^1.0.1"
+    clsx "^2.1.1"
+
+"@rc-component/select@~1.5.2":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@rc-component/select/-/select-1.5.2.tgz#43fc247336d6b8ed6ae1656628c56d9a09959c11"
   integrity sha512-7wqD5D4I2+fc5XoB4nzDDK656QPlDnFAUaxLljkU1wwSpi4+MZxndv9vgg7NQfveuuf0/ilUdOjuPg7NPl7Mmg==
@@ -2253,10 +2287,18 @@
     "@rc-component/util" "^1.3.0"
     clsx "^2.1.1"
 
-"@rc-component/util@^1.1.0", "@rc-component/util@^1.2.0", "@rc-component/util@^1.2.1", "@rc-component/util@^1.3.0", "@rc-component/util@^1.4.0", "@rc-component/util@^1.6.2", "@rc-component/util@^1.7.0", "@rc-component/util@^1.8.1":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@rc-component/util/-/util-1.8.1.tgz#a3515ca34b983d6098b25a19a325346213e648b0"
-  integrity sha512-Ku6BzF0Ov5L9U3ewFJZDQ//iWCR2nIkLBBiYSrhxIVl3PqeUqiYP2W8gNI8qoKAFQKZdYcS0+B6+SQTDtv/erw==
+"@rc-component/util@^1.1.0", "@rc-component/util@^1.2.0", "@rc-component/util@^1.2.1", "@rc-component/util@^1.3.0", "@rc-component/util@^1.4.0", "@rc-component/util@^1.6.2", "@rc-component/util@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@rc-component/util/-/util-1.7.0.tgz#c6eb178e0b1c48c5ae6325b21c60aeaf4f3d8d04"
+  integrity sha512-tIvIGj4Vl6fsZFvWSkYw9sAfiCKUXMyhVz6kpKyZbwyZyRPqv2vxYZROdaO1VB4gqTNvUZFXh6i3APUiterw5g==
+  dependencies:
+    is-mobile "^5.0.0"
+    react-is "^18.2.0"
+
+"@rc-component/util@^1.8.1", "@rc-component/util@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@rc-component/util/-/util-1.9.0.tgz#ec5fe657a98554f26ef761345ca4b745be00af0e"
+  integrity sha512-5uW6AfhIigCWeEQDthTozlxiT4Prn6xYQWeO0xokjcaa186OtwPRHBZJ2o0T0FhbjGhZ3vXdbkv0sx3gAYW7Vg==
   dependencies:
     is-mobile "^5.0.0"
     react-is "^18.2.0"
@@ -2486,6 +2528,20 @@
   dependencies:
     "@sinonjs/commons" "^3.0.1"
 
+"@testing-library/dom@^10.4.1":
+  version "10.4.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.1.tgz#d444f8a889e9a46e9a3b4f3b88e0fcb3efb6cf95"
+  integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "5.3.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    picocolors "1.1.1"
+    pretty-format "^27.0.2"
+
 "@testing-library/jest-dom@^6.9.1":
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz#7613a04e146dd2976d24ddf019730d57a89d56c2"
@@ -2536,6 +2592,11 @@
   integrity sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==
   dependencies:
     tslib "^2.4.0"
+
+"@types/aria-query@^5.0.1":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
+  integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
 
 "@types/babel__core@^7.20.5":
   version "7.20.5"
@@ -2886,10 +2947,17 @@
   resolved "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz"
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
-"@types/node@*", "@types/node@^25.2.0":
-  version "25.2.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.2.0.tgz#015b7d228470c1dcbfc17fe9c63039d216b4d782"
-  integrity sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==
+"@types/node@*":
+  version "25.0.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.0.9.tgz#81ce3579ddf67cae812a9d49c8a0ab90c82e7782"
+  integrity sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==
+  dependencies:
+    undici-types "~7.16.0"
+
+"@types/node@^25.2.0":
+  version "25.2.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.2.2.tgz#0ddfe326c326afcb3422d32bfe5eb2938e1cb5db"
+  integrity sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==
   dependencies:
     undici-types "~7.16.0"
 
@@ -3035,12 +3103,12 @@
     debug "^4.4.3"
     ts-api-utils "^2.4.0"
 
-"@typescript-eslint/types@8.53.0":
+"@typescript-eslint/types@8.53.0", "@typescript-eslint/types@^8.53.0":
   version "8.53.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.53.0.tgz#1adcad3fa32bc2c4cbf3785ba07a5e3151819efb"
   integrity sha512-Bmh9KX31Vlxa13+PqPvt4RzKRN1XORYSLlAE+sO1i28NkisGbTtSLFVB3l7PWdHtR3E0mVMuC7JilWJ99m2HxQ==
 
-"@typescript-eslint/types@8.54.0", "@typescript-eslint/types@^8.53.0", "@typescript-eslint/types@^8.54.0":
+"@typescript-eslint/types@8.54.0", "@typescript-eslint/types@^8.54.0":
   version "8.54.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.54.0.tgz#c12d41f67a2e15a8a96fbc5f2d07b17331130889"
   integrity sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==
@@ -3271,7 +3339,7 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^5.2.0:
+ansi-styles@^5.0.0, ansi-styles@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
@@ -3368,6 +3436,13 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+aria-query@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
+  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
+  dependencies:
+    dequal "^2.0.3"
 
 aria-query@^5.0.0, aria-query@^5.3.2:
   version "5.3.2"
@@ -3498,12 +3573,12 @@ axe-core@^4.10.0:
   integrity sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==
 
 axios@^1.13.4:
-  version "1.13.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.4.tgz#15d109a4817fb82f73aea910d41a2c85606076bc"
-  integrity sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==
+  version "1.13.5"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.5.tgz#5e464688fa127e11a660a2c49441c009f6567a43"
+  integrity sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==
   dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.4"
+    follow-redirects "^1.15.11"
+    form-data "^4.0.5"
     proxy-from-env "^1.1.0"
 
 axobject-query@^4.1.0:
@@ -3732,9 +3807,9 @@ caniuse-lite@^1.0.30001688:
   integrity sha512-3ZczoTApMAZwPKYWmwVbQMFpXBDds3/0VciVoUwPUbldlYyVLmRVuRs/PcUZtHpbLRpzzDvrvnFuREsGt6lUug==
 
 caniuse-lite@^1.0.30001759:
-  version "1.0.30001767"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001767.tgz#0279c498e862efb067938bba0a0aabafe8d0b730"
-  integrity sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==
+  version "1.0.30001769"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz#1ad91594fad7dc233777c2781879ab5409f7d9c2"
+  integrity sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==
 
 ccount@^2.0.0:
   version "2.0.1"
@@ -4209,7 +4284,7 @@ delayed-stream@~1.0.0:
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-dequal@^2.0.0:
+dequal@^2.0.0, dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
@@ -4237,6 +4312,11 @@ doctrine@^2.1.0:
   integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
 dom-accessibility-api@^0.6.3:
   version "0.6.3"
@@ -4984,10 +5064,10 @@ flatted@^3.2.9:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
-follow-redirects@^1.15.6:
-  version "1.15.9"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz"
-  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+follow-redirects@^1.15.11:
+  version "1.15.11"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
 
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"
@@ -5004,10 +5084,10 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
-form-data@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
-  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
+form-data@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
+  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -5203,6 +5283,11 @@ handlebars@^4.7.8:
   optionalDependencies:
     uglify-js "^3.1.4"
 
+harmony-reflect@^1.4.6:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.2.tgz#31ecbd32e648a34d030d86adb67d4d47547fe710"
+  integrity sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==
+
 has-bigints@^1.0.2:
   version "1.1.0"
   resolved "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz"
@@ -5291,10 +5376,10 @@ hermes-parser@^0.25.1:
   dependencies:
     hermes-estree "0.25.1"
 
-html-dom-parser@5.1.4:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/html-dom-parser/-/html-dom-parser-5.1.4.tgz#5fd3a05fade99f2a4b415d640dc178be46b6122b"
-  integrity sha512-UGjp7y8jSrDU2RdN2J9FDOo3X+WBu+LkS/I3TjjFW020ocZWjPvave+RKk1zeuY2sUWy5fh6zHgXHthzDGlFNQ==
+html-dom-parser@5.1.8:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/html-dom-parser/-/html-dom-parser-5.1.8.tgz#3bdce534dfe4872909dfa6000a7dbc09a7610b56"
+  integrity sha512-MCIUng//mF2qTtGHXJWr6OLfHWmg3Pm8ezpfiltF83tizPWY17JxT4dRLE8lykJ5bChJELoY3onQKPbufJHxYA==
   dependencies:
     domhandler "5.0.3"
     htmlparser2 "10.1.0"
@@ -5312,12 +5397,12 @@ html-escaper@^2.0.0:
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
 html-react-parser@^5.2.15:
-  version "5.2.15"
-  resolved "https://registry.yarnpkg.com/html-react-parser/-/html-react-parser-5.2.15.tgz#5499a3317c637e6ea5adaf27c73cd8eb69477e2b"
-  integrity sha512-mSyG0t6CyNI8o8FNy53/XMCzMqtbAmnjv/Qz1AnPgVVeScvCwTA4nQH4ZthYnevjKn+g6vZYco4Nq7m9XrXAFQ==
+  version "5.2.17"
+  resolved "https://registry.yarnpkg.com/html-react-parser/-/html-react-parser-5.2.17.tgz#1b44c9a92612439a649b4a382e780ddd9ea7f697"
+  integrity sha512-m+K/7Moq1jodAB4VL0RXSOmtwLUYoAsikZhwd+hGQe5Vtw2dbWfpFd60poxojMU0Tsh9w59mN1QLEcoHz0Dx9w==
   dependencies:
     domhandler "5.0.3"
-    html-dom-parser "5.1.4"
+    html-dom-parser "5.1.8"
     react-property "2.0.2"
     style-to-js "1.1.21"
 
@@ -5368,6 +5453,13 @@ iconv-lite@0.6.3:
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
+
+identity-obj-proxy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
+  integrity sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==
+  dependencies:
+    harmony-reflect "^1.4.6"
 
 ieee754@^1.2.1:
   version "1.2.1"
@@ -6127,6 +6219,11 @@ jest-snapshot@30.2.0:
     semver "^7.7.2"
     synckit "^0.11.8"
 
+jest-transformer-svg@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jest-transformer-svg/-/jest-transformer-svg-2.1.0.tgz#adfa28c57c0ec676235b39b0d7129a8517a64bc8"
+  integrity sha512-UqROTC1szruaDJENDeU95NPQztTTjE02R5Gzxydh+ylahwli7DlkYPGifnH+fc8bNVy905m2HqhPNgwx+Q5TBg==
+
 jest-util@30.0.2:
   version "30.0.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-30.0.2.tgz#1bd8411f81e6f5e2ca8b31bb2534ebcd7cbac065"
@@ -6414,6 +6511,11 @@ luxon@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.7.2.tgz#d697e48f478553cca187a0f8436aff468e3ba0ba"
   integrity sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==
+
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
 
 magic-string@^0.30.11, magic-string@^0.30.3:
   version "0.30.17"
@@ -7275,7 +7377,7 @@ performance-now@^2.1.0:
   resolved "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz"
   integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
 
-picocolors@^1.1.1:
+picocolors@1.1.1, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -7351,6 +7453,15 @@ pretty-format@30.2.0:
     ansi-styles "^5.2.0"
     react-is "^18.3.1"
 
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
@@ -7413,6 +7524,11 @@ react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-is@^18.2.0, react-is@^18.3.1:
   version "18.3.1"
@@ -8635,9 +8751,9 @@ vite-plugin-dynamic-import@^1.6.0:
     magic-string "^0.30.11"
 
 vite-tsconfig-paths@^6.0.5:
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/vite-tsconfig-paths/-/vite-tsconfig-paths-6.0.5.tgz#5bcbb44d6ae0d12fe42f5915a6ad9846b0ed7805"
-  integrity sha512-f/WvY6ekHykUF1rWJUAbCU7iS/5QYDIugwpqJA+ttwKbxSbzNlqlE8vZSrsnxNQciUW+z6lvhlXMaEyZn9MSig==
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.0.tgz#8c3b9ecb676571f7c8f7849d92cd7de3b50faf75"
+  integrity sha512-kpd3sY9glHIDaq4V/Tlc1Y8WaKtutoc3B525GHxEVKWX42FKfQsXvjFOemu1I8VIN8pNbrMLWVTbW79JaRUxKg==
   dependencies:
     debug "^4.1.1"
     globrex "^0.1.2"


### PR DESCRIPTION
<img width="1613" height="935" alt="image" src="https://github.com/user-attachments/assets/b81ff6c5-c2c0-485f-8c15-d35b4c94d233" />

Closes #2935

## Summary
- Adds a reusable `TerminalOutput` component replacing inline `#code-container`/`#code-content` blocks for job log output
- Toolbar with Follow (auto-scroll), Copy, Download, and Raw buttons appears on hover
- Includes `stripAnsi` utility for cleaning ANSI escape codes from output
- Removes old CSS rules from `Workspaces.css`, new styles in `TerminalOutput.css`

## Test plan
- [ ] Verify job log output renders correctly in the workspace job detail view
- [ ] Confirm Follow button auto-scrolls to bottom of output
- [ ] Confirm Copy button copies log content to clipboard
- [ ] Confirm Download button saves log as `.txt` file
- [ ] Confirm Raw button opens log in new browser tab
- [ ] Verify toolbar appears on hover and hides when not hovering
- [x] Unit tests pass (`TerminalOutput.test.tsx`, `stripAnsi.test.ts`)