### PR TITLE
fix: executor stream logs

### DIFF
--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -46,12 +46,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>org.springframework.boot</groupId>
-					<artifactId>spring-boot-starter-logging</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -176,11 +170,6 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>${slf4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
 			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Removed exclusions for spring-boot-starter-logging and slf4j-simple dependency.

I noted the executor logs were always written to the stderr. 
This seems to be because slf4j-simple by default writes all logs to stderr.

Previously Executor implementation:
- Explicitly excludes spring-boot-starter-logging from spring-boot-starter
- Then manually adds slf4j-simple (which defaults to stderr)

What I did is correctly working on my environment since a couple of days. 
I was in doubt of opening this PR because I don't know if there were a reason for the explicit exclusion of spring-boot-starter-logging. 

Let me know your thoughts.