### PR TITLE
fix: add conditional edit handling for workspace variable values

### DIFF
--- a/ui/src/domain/Workspaces/Variables.tsx
+++ b/ui/src/domain/Workspaces/Variables.tsx
@@ -57,7 +57,19 @@ const VARIABLES_COLUMS = (
           overlayClassName="tooltip"
           trigger={["hover"]}
         >
-          <div style={{ maxWidth: 2000, maxHeight: 100, overflow: "auto" }}>{record.value}</div>
+          <div
+            style={{
+              maxWidth: 2000,
+              maxHeight: 100,
+              overflow: "auto",
+              cursor: manageWorkspace ? "pointer" : "default",
+            }}
+            onClick={() => {
+              if (manageWorkspace) onEdit(record);
+            }}
+          >
+            {record.value}
+          </div>
         </Tooltip>
       );
     },


### PR DESCRIPTION
- Updated `Variables.tsx` to conditionally enable click-to-edit functionality based on `manageWorkspace` permission.
- Added `onClick` handler for editing workspace variables.

fix #2603