### PR TITLE
feat: Add sorting to workspace listing and add static assets cache

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -23,3 +23,7 @@ body,
 .mh-100 {
   min-height: 100%;
 }
+
+.workspaceFilterSegmentedWrapper .ant-segmented-group {
+  flex-wrap: wrap;
+}

--- a/ui/src/modules/layout/PageWrapper/PageWrapper.tsx
+++ b/ui/src/modules/layout/PageWrapper/PageWrapper.tsx
@@ -61,7 +61,7 @@ export default function PageWrapper({
             innerClassName
           )}
         >
-          <Flex justify="space-between" flex={1}>
+          <Flex justify="space-between" flex={1} wrap>
             <div>
               <Typography.Title className="page-wrapper-title">{title}</Typography.Title>
               {subTitle && <Typography.Text type="secondary">{subTitle}</Typography.Text>}

--- a/ui/src/modules/organizations/OrganizationDetailsPage.tsx
+++ b/ui/src/modules/organizations/OrganizationDetailsPage.tsx
@@ -2,7 +2,7 @@ import { Button, Flex, List, Space } from "antd";
 import "antd/dist/reset.css";
 import PageWrapper from "@/modules/layout/PageWrapper/PageWrapper";
 import { ImportOutlined, PlusOutlined } from "@ant-design/icons";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import WorkspaceFilter from "@/modules/workspaces/components/WorkspaceFilter";
 import { WorkspaceListItem } from "@/modules/workspaces/types";
 import { Link, useNavigate, useParams } from "react-router-dom";
@@ -11,6 +11,12 @@ import useApiRequest from "@/modules/api/useApiRequest";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "../../config/actionTypes";
 import { TagModel } from "./types";
 import WorkspaceCard from "@/modules/workspaces/components/WorkspaceCard";
+import {
+  getStoredWorkspaceSortOption,
+  setStoredWorkspaceSortOption,
+  sortWorkspaces,
+  WorkspaceSortOption,
+} from "@/modules/workspaces/utils/workspaceSort";
 
 type Props = {
   organizationName: string;
@@ -22,7 +28,18 @@ export default function OrganizationsDetailPage({ organizationName, setOrganizat
   const navigate = useNavigate();
   const [workspaces, setWorkspaces] = useState<WorkspaceListItem[]>([]);
   const [filteredWorkspaces, setFilteredWorkspaces] = useState<WorkspaceListItem[]>([]);
+  const [sortOption, setSortOption] = useState<WorkspaceSortOption>(() => getStoredWorkspaceSortOption());
   const [tags, setTags] = useState<TagModel[]>([]);
+
+  const sortedWorkspaces = useMemo(
+    () => sortWorkspaces(filteredWorkspaces, sortOption),
+    [filteredWorkspaces, sortOption]
+  );
+
+  const handleSortChange = (option: WorkspaceSortOption) => {
+    setSortOption(option);
+    setStoredWorkspaceSortOption(option);
+  };
 
   const { loading, execute, error } = useApiRequest({
     action: () => workspaceService.listWorkspaces(id!),
@@ -73,11 +90,13 @@ export default function OrganizationsDetailPage({ organizationName, setOrganizat
             onFiltered={(filtered) => setFilteredWorkspaces(filtered)}
             organizationId={id}
             onTagsLoaded={(t) => setTags(t)}
+            sortOption={sortOption}
+            onSortChange={handleSortChange}
           />
         )}
         <List
           split={false}
-          dataSource={filteredWorkspaces}
+          dataSource={sortedWorkspaces}
           pagination={{ showSizeChanger: true, defaultPageSize: 10 }}
           renderItem={(item) => (
             <List.Item

--- a/ui/src/modules/workspaces/components/WorkspaceCard.tsx
+++ b/ui/src/modules/workspaces/components/WorkspaceCard.tsx
@@ -18,7 +18,7 @@ type Props = {
 };
 export default function WorkspaceCard({ item, tags }: Props) {
   return (
-    <Card hoverable>
+    <Card hoverable style={{ width: "100%" }}>
       <Space style={{ width: "100%" }} orientation="vertical">
         <Row>
           <Col span={12}>
@@ -37,7 +37,7 @@ export default function WorkspaceCard({ item, tags }: Props) {
             </Row>
           </Col>
         </Row>
-        <Space size={40} style={{ marginTop: "25px" }}>
+        <Space size={40} style={{ marginTop: "25px" }} wrap>
           <Space>
             <WorkspaceStatusTag status={item.lastStatus} /> <br />
           </Space>

--- a/ui/src/modules/workspaces/components/WorkspaceFilter.tsx
+++ b/ui/src/modules/workspaces/components/WorkspaceFilter.tsx
@@ -4,6 +4,7 @@ import {
   StopOutlined,
   SyncOutlined,
   CheckCircleOutlined,
+  CloseCircleOutlined,
   InfoCircleOutlined,
 } from "@ant-design/icons";
 import { Card, Row, Col, Segmented, Flex, Select, Input, theme } from "antd";
@@ -14,12 +15,15 @@ import organizationService from "@/modules/organizations/organizationService";
 import useApiRequest from "@/modules/api/useApiRequest";
 import { mapTag } from "@/modules/organizations/organizationMapper";
 import { TagModel } from "@/modules/organizations/types";
+import { WorkspaceSortOption, WORKSPACE_SORT_OPTIONS } from "../utils/workspaceSort";
 
 type Props = {
   organizationId: string;
   workspaces: WorkspaceListItem[];
   onFiltered: (workspaces: WorkspaceListItem[]) => void;
   onTagsLoaded: (tags: TagModel[]) => void;
+  sortOption: WorkspaceSortOption;
+  onSortChange: (option: WorkspaceSortOption) => void;
 };
 
 enum Additional {
@@ -27,7 +31,14 @@ enum Additional {
   NeverExecuted = "NeverExecuted",
 }
 
-export default function WorkspaceFilter({ workspaces, onFiltered, organizationId, onTagsLoaded }: Props) {
+export default function WorkspaceFilter({
+  workspaces,
+  onFiltered,
+  organizationId,
+  onTagsLoaded,
+  sortOption,
+  onSortChange,
+}: Props) {
   const {
     token: { colorBgContainer },
   } = theme.useToken();
@@ -92,35 +103,54 @@ export default function WorkspaceFilter({ workspaces, onFiltered, organizationId
         },
       }}
     >
-      <Row justify="end">
-        <Col span={16}>
-          <Segmented
-            onChange={setStatusFilter}
-            value={statusFilter}
-            options={[
-              { label: "All", value: Additional.All, icon: <BarsOutlined /> },
-              {
-                label: "Awaiting approval",
-                value: JobStatus.WaitingApproval,
-                icon: <ExclamationCircleOutlined style={{ color: "#fa8f37" }} />,
-              },
-              { label: "Failed", value: JobStatus.Failed, icon: <StopOutlined style={{ color: "#FB0136" }} /> },
-              { label: "Running", value: JobStatus.Running, icon: <SyncOutlined style={{ color: "#108ee9" }} /> },
-              {
-                label: "Completed",
-                value: JobStatus.Completed,
-                icon: <CheckCircleOutlined style={{ color: "#2eb039" }} />,
-              },
-              {
-                label: "Never Executed",
-                value: Additional.NeverExecuted,
-                icon: <InfoCircleOutlined />,
-              },
-            ]}
-          />
+      <Row justify="end" gutter={[0, 5]}>
+        <Col span={24} xxl={16}>
+          <div className="workspaceFilterSegmentedWrapper">
+            <Segmented
+              onChange={setStatusFilter}
+              value={statusFilter}
+              options={[
+                {
+                  label: "All",
+                  value: Additional.All,
+                  icon: <BarsOutlined />,
+                },
+                {
+                  label: "Awaiting approval",
+                  value: JobStatus.WaitingApproval,
+                  icon: <ExclamationCircleOutlined style={{ color: "#fa8f37" }} />,
+                },
+                {
+                  label: "Failed",
+                  value: JobStatus.Failed,
+                  icon: <StopOutlined style={{ color: "#FB0136" }} />,
+                },
+                {
+                  label: "Rejected",
+                  value: JobStatus.Rejected,
+                  icon: <CloseCircleOutlined style={{ color: "#FB0136" }} />,
+                },
+                {
+                  label: "Running",
+                  value: JobStatus.Running,
+                  icon: <SyncOutlined style={{ color: "#108ee9" }} />,
+                },
+                {
+                  label: "Completed",
+                  value: JobStatus.Completed,
+                  icon: <CheckCircleOutlined style={{ color: "#2eb039" }} />,
+                },
+                {
+                  label: "Never Executed",
+                  value: Additional.NeverExecuted,
+                  icon: <InfoCircleOutlined />,
+                },
+              ]}
+            />
+          </div>
         </Col>
 
-        <Col span={8}>
+        <Col span={24} xxl={8}>
           <Flex gap="middle">
             <Select
               mode="multiple"
@@ -149,6 +179,18 @@ export default function WorkspaceFilter({ workspaces, onFiltered, organizationId
               allowClear
             />
           </Flex>
+        </Col>
+      </Row>
+      <Row style={{ marginTop: "5px" }}>
+        <Col span={24} xl={8}>
+          <Select
+            prefix={<span style={{ marginRight: "5px" }}>Sort by:</span>}
+            options={WORKSPACE_SORT_OPTIONS}
+            value={sortOption}
+            onChange={onSortChange}
+            style={{ minWidth: 220 }}
+            placeholder="Sort by"
+          />
         </Col>
       </Row>
     </Card>

--- a/ui/src/modules/workspaces/utils/workspaceSort.ts
+++ b/ui/src/modules/workspaces/utils/workspaceSort.ts
@@ -1,0 +1,113 @@
+import { JobStatus } from "../../../domain/types";
+import { WorkspaceListItem } from "../types";
+
+/** Combined sort option: field + direction in one value for the UI */
+export type WorkspaceSortOption =
+  | "name_asc"
+  | "name_desc"
+  | "lastRun_desc"
+  | "lastRun_asc"
+  | "status"
+  | "source_asc"
+  | "source_desc"
+  | "terraformVersion_asc"
+  | "terraformVersion_desc";
+
+const SORT_STORAGE_KEY = "workspaceSortValue";
+
+/** Order for "sort by status" (lower index = earlier in list when ascending) */
+const STATUS_ORDER: (JobStatus | "NeverExecuted")[] = [
+  JobStatus.Running,
+  JobStatus.Queue,
+  JobStatus.WaitingApproval,
+  JobStatus.Failed,
+  JobStatus.Rejected,
+  JobStatus.Cancelled,
+  JobStatus.Completed,
+  JobStatus.NoChanges,
+  JobStatus.NotExecuted,
+  JobStatus.Approved,
+  JobStatus.Pending,
+  JobStatus.Unknown,
+  "NeverExecuted",
+];
+
+function statusRank(s: JobStatus | undefined): number {
+  const idx = STATUS_ORDER.indexOf(s ?? ("NeverExecuted" as const));
+  return idx === -1 ? STATUS_ORDER.length : idx;
+}
+
+function parseDate(iso: string | undefined): number {
+  if (!iso) return 0;
+  const t = new Date(iso).getTime();
+  return Number.isNaN(t) ? 0 : t;
+}
+
+function str(a: string | undefined, b: string | undefined): number {
+  const A = (a ?? "").toLowerCase();
+  const B = (b ?? "").toLowerCase();
+  return A.localeCompare(B, undefined, { sensitivity: "base" });
+}
+
+export function sortWorkspaces(workspaces: WorkspaceListItem[], option: WorkspaceSortOption): WorkspaceListItem[] {
+  const list = [...workspaces];
+
+  switch (option) {
+    case "name_asc":
+      return list.sort((a, b) => str(a.name, b.name));
+    case "name_desc":
+      return list.sort((a, b) => str(b.name, a.name));
+    case "lastRun_desc":
+      return list.sort((a, b) => parseDate(b.lastRun) - parseDate(a.lastRun));
+    case "lastRun_asc":
+      return list.sort((a, b) => parseDate(a.lastRun) - parseDate(b.lastRun));
+    case "status":
+      return list.sort((a, b) => statusRank(a.lastStatus) - statusRank(b.lastStatus));
+    case "source_asc":
+      return list.sort((a, b) => str(a.source ?? a.normalizedSource, b.source ?? b.normalizedSource));
+    case "source_desc":
+      return list.sort((a, b) => str(b.source ?? b.normalizedSource, a.source ?? a.normalizedSource));
+    case "terraformVersion_asc":
+      return list.sort((a, b) => str(a.terraformVersion, b.terraformVersion));
+    case "terraformVersion_desc":
+      return list.sort((a, b) => str(b.terraformVersion, a.terraformVersion));
+    default:
+      return list;
+  }
+}
+
+export function getStoredWorkspaceSortOption(): WorkspaceSortOption {
+  const stored = sessionStorage.getItem(SORT_STORAGE_KEY);
+  const valid: WorkspaceSortOption[] = [
+    "name_asc",
+    "name_desc",
+    "lastRun_desc",
+    "lastRun_asc",
+    "status",
+    "source_asc",
+    "source_desc",
+    "terraformVersion_asc",
+    "terraformVersion_desc",
+  ];
+  if (stored && valid.includes(stored as WorkspaceSortOption)) {
+    return stored as WorkspaceSortOption;
+  }
+  return "name_asc";
+}
+
+export function setStoredWorkspaceSortOption(option: WorkspaceSortOption): void {
+  sessionStorage.setItem(SORT_STORAGE_KEY, option);
+}
+
+/** Options for the Sort by dropdown (combined field + direction) */
+export const WORKSPACE_SORT_OPTIONS: { label: string; value: WorkspaceSortOption }[] = [
+  { label: "Name (A → Z)", value: "name_asc" },
+  { label: "Name (Z → A)", value: "name_desc" },
+  { label: "Last run (newest first)", value: "lastRun_desc" },
+  { label: "Last run (oldest first)", value: "lastRun_asc" },
+  { label: "Job status", value: "status" },
+  { label: "Repository (A → Z)", value: "source_asc" },
+  { label: "Repository (Z → A)", value: "source_desc" },
+  { label: "Terraform version (A → Z)", value: "terraformVersion_asc" },
+  { label: "Terraform version (Z → A)", value: "terraformVersion_desc" },
+];


### PR DESCRIPTION
Closes  #2980 

* Introduces sorting of workspaces
* Made the workspace listing a bit more responsive to allow for smaller screens
* Adds a filter for the 'Rejected' status

Side note: I attempted to fix a regression(?) introduced in https://github.com/terrakube-io/terrakube/pull/2956 where the workspace cards no longer filled the width of the `<ul>`. Not sure if that change was intentional or not. It looks like most of that code was from an LLM so I'm assuming it was unintended.