### PR TITLE
deps: update buildpack versions and Spring Boot parent version

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -40,9 +40,9 @@
         <commons-io.version>2.21.0</commons-io.version>
         <kubernetes-client.version>7.5.2</kubernetes-client.version>
         <!--BUILDPACK DATA-->
-        <buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.519</buildpack.builder>
-        <buildpack.java>paketobuildpacks/java:20.5.0</buildpack.java>
-        <buildpack.telemetry>paketobuildpacks/opentelemetry:2.20.0</buildpack.telemetry>
+        <buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.546</buildpack.builder>
+        <buildpack.java>paketobuildpacks/java:21.2.0</buildpack.java>
+        <buildpack.telemetry>paketobuildpacks/opentelemetry:2.23.0</buildpack.telemetry>
     </properties>
     <build>
         <plugins>

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -38,9 +38,9 @@
 		<sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}
 		</sonar.coverage.jacoco.xmlReportPaths>
 		<!--BUILDPACK DATA-->
-		<buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.519</buildpack.builder>
-		<buildpack.java>paketobuildpacks/java:20.5.0</buildpack.java>
-		<buildpack.telemetry>paketobuildpacks/opentelemetry:2.20.0</buildpack.telemetry>
+		<buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.546</buildpack.builder>
+		<buildpack.java>paketobuildpacks/java:21.2.0</buildpack.java>
+		<buildpack.telemetry>paketobuildpacks/opentelemetry:2.23.0</buildpack.telemetry>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.9</version>
+        <version>3.5.11</version>
     </parent>
 
     <groupId>io.terrakube</groupId>

--- a/registry/pom.xml
+++ b/registry/pom.xml
@@ -31,9 +31,9 @@
         <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}
         </sonar.coverage.jacoco.xmlReportPaths>
         <!--BUILDPACK DATA-->
-        <buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.519</buildpack.builder>
-        <buildpack.java>paketobuildpacks/java:20.5.0</buildpack.java>
-        <buildpack.telemetry>paketobuildpacks/opentelemetry:2.20.0</buildpack.telemetry>
+        <buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.546</buildpack.builder>
+        <buildpack.java>paketobuildpacks/java:21.2.0</buildpack.java>
+        <buildpack.telemetry>paketobuildpacks/opentelemetry:2.23.0</buildpack.telemetry>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
- Updated buildpacks for builder, Java, and telemetry across modules.
- Upgraded Spring Boot starter parent to version 3.5.11.