### PR TITLE
feat(ui): frontend redesign with HCP Terraform style and performance optimizations

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -1,0 +1,2487 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "azb-client",
+      "dependencies": {
+        "@ant-design/icons": "^6.1.0",
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+        "@babel/preset-env": "^7.29.0",
+        "@babel/standalone": "^7.29.0",
+        "@monaco-editor/react": "^4.7.0",
+        "ansi-to-react": "^6.2.6",
+        "antd": "^6.3.0",
+        "axios": "^1.13.4",
+        "buffer": "^6.0.3",
+        "core-js-pure": "^3.48.0",
+        "cron-to-quartz": "^1.4.7",
+        "cronstrue": "^3.12.0",
+        "dotenv": "^17.3.1",
+        "dotenv-expand": "^12.0.3",
+        "github-markdown-css": "^5.9.0",
+        "hcl2-parser": "^1.0.3",
+        "html-react-parser": "^5.2.15",
+        "html-to-image": "^1.11.13",
+        "loader-utils": "3.3.1",
+        "luxon": "^3.7.2",
+        "minimatch": "^10.2.2",
+        "oidc-client-ts": "3.4.1",
+        "react": "19.2.4",
+        "react-dom": "19.2.4",
+        "react-icons": "^5.5.0",
+        "react-js-cron": "^5.2.0",
+        "react-markdown": "10.1.0",
+        "react-oidc-context": "3.3.0",
+        "react-router-dom": "7.13.0",
+        "react-vis": "^1.12.1",
+        "reactflow": "^11.11.3",
+        "redux": "^5.0.1",
+        "rehype-raw": "^7.0.0",
+        "remark-gfm": "4.0.1",
+        "unzipit": "^1.4.3",
+        "uuid": "^13.0.0",
+        "web-vitals": "^5.1.0",
+      },
+      "devDependencies": {
+        "@rollup/plugin-dynamic-import-vars": "^2.1.5",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/babel__standalone": "^7.1.9",
+        "@types/jest": "^30.0.0",
+        "@types/luxon": "^3.7.1",
+        "@types/node": "^25.3.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@types/react-vis": "^1.11.15",
+        "@typescript-eslint/eslint-plugin": "^8.51.0",
+        "@typescript-eslint/parser": "^8.56.1",
+        "@vitejs/plugin-react": "^5.1.4",
+        "classnames": "^2.5.1",
+        "eslint": "^9.39.2",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-import-resolver-typescript": "^4.4.4",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-prettier": "^5.5.5",
+        "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-refresh": "^0.5.1",
+        "globals": "^17.3.0",
+        "identity-obj-proxy": "^3.0.0",
+        "jest": "^30.2.0",
+        "jest-environment-jsdom": "^30.2.0",
+        "jest-transformer-svg": "^2.1.0",
+        "prettier": "^3.8.1",
+        "rollup-plugin-visualizer": "^7.0.0",
+        "ts-jest": "^29.4.6",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.56.0",
+        "vite": "^7.3.1",
+        "vite-plugin-commonjs": "^0.10.4",
+        "vite-tsconfig-paths": "^6.1.1",
+      },
+    },
+  },
+  "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.4.2", "", {}, "sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A=="],
+
+    "@ant-design/colors": ["@ant-design/colors@8.0.1", "", { "dependencies": { "@ant-design/fast-color": "^3.0.0" } }, "sha512-foPVl0+SWIslGUtD/xBr1p9U4AKzPhNYEseXYRRo5QSzGACYZrQbe11AYJbYfAWnWSpGBx6JjBmSeugUsD9vqQ=="],
+
+    "@ant-design/cssinjs": ["@ant-design/cssinjs@2.1.0", "", { "dependencies": { "@babel/runtime": "^7.11.1", "@emotion/hash": "^0.8.0", "@emotion/unitless": "^0.7.5", "@rc-component/util": "^1.4.0", "clsx": "^2.1.1", "csstype": "^3.1.3", "stylis": "^4.3.4" }, "peerDependencies": { "react": ">=16.0.0", "react-dom": ">=16.0.0" } }, "sha512-eZFrPCnrYrF3XtL7qA4L75P0qA3TtZta8H3Yggy7UYFh8gZgu5bSMNF+v4UVCzGxzYmx8ZvPdgOce0BJ6PsW9g=="],
+
+    "@ant-design/cssinjs-utils": ["@ant-design/cssinjs-utils@2.1.1", "", { "dependencies": { "@ant-design/cssinjs": "^2.1.0", "@babel/runtime": "^7.23.2", "@rc-component/util": "^1.4.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-RKxkj5pGFB+FkPJ5NGhoX3DK3xsv0pMltha7Ei1AnY3tILeq38L7tuhaWDPQI/5nlPxOog44wvqpNyyGcUsNMg=="],
+
+    "@ant-design/fast-color": ["@ant-design/fast-color@3.0.1", "", {}, "sha512-esKJegpW4nckh0o6kV3Tkb7NPIZYbPnnFxmQDUmL08ukXZAvV85TZBr70eGuke/CIArLaP6aw8lt9KILjnWuOw=="],
+
+    "@ant-design/icons": ["@ant-design/icons@6.1.0", "", { "dependencies": { "@ant-design/colors": "^8.0.0", "@ant-design/icons-svg": "^4.4.0", "@rc-component/util": "^1.3.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.0.0", "react-dom": ">=16.0.0" } }, "sha512-KrWMu1fIg3w/1F2zfn+JlfNDU8dDqILfA5Tg85iqs1lf8ooyGlbkA+TkwfOKKgqpUmAiRY1PTFpuOU2DAIgSUg=="],
+
+    "@ant-design/icons-svg": ["@ant-design/icons-svg@4.4.2", "", {}, "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA=="],
+
+    "@ant-design/react-slick": ["@ant-design/react-slick@2.0.0", "", { "dependencies": { "@babel/runtime": "^7.28.4", "clsx": "^2.1.1", "json2mq": "^0.2.0", "throttle-debounce": "^5.0.0" }, "peerDependencies": { "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-HMS9sRoEmZey8LsE/Yo6+klhlzU12PisjrVcydW3So7RdklyEd2qehyU6a7Yp+OYN72mgsYs3NFCyP2lCPFVqg=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
+
+    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-annotate-as-pure": ["@babel/helper-annotate-as-pure@7.27.3", "", { "dependencies": { "@babel/types": "^7.27.3" } }, "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-create-class-features-plugin": ["@babel/helper-create-class-features-plugin@7.28.6", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-member-expression-to-functions": "^7.28.5", "@babel/helper-optimise-call-expression": "^7.27.1", "@babel/helper-replace-supers": "^7.28.6", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1", "@babel/traverse": "^7.28.6", "semver": "^6.3.1" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow=="],
+
+    "@babel/helper-create-regexp-features-plugin": ["@babel/helper-create-regexp-features-plugin@7.28.5", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "regexpu-core": "^6.3.1", "semver": "^6.3.1" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw=="],
+
+    "@babel/helper-define-polyfill-provider": ["@babel/helper-define-polyfill-provider@0.6.6", "", { "dependencies": { "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6", "debug": "^4.4.3", "lodash.debounce": "^4.0.8", "resolve": "^1.22.11" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-mOAsxeeKkUKayvZR3HeTYD/fICpCPLJrU5ZjelT/PA6WHtNDBOE436YiaEUvHN454bRM3CebhDsIpieCc4texA=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-member-expression-to-functions": ["@babel/helper-member-expression-to-functions@7.28.5", "", { "dependencies": { "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5" } }, "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-optimise-call-expression": ["@babel/helper-optimise-call-expression@7.27.1", "", { "dependencies": { "@babel/types": "^7.27.1" } }, "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
+    "@babel/helper-remap-async-to-generator": ["@babel/helper-remap-async-to-generator@7.27.1", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.1", "@babel/helper-wrap-function": "^7.27.1", "@babel/traverse": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA=="],
+
+    "@babel/helper-replace-supers": ["@babel/helper-replace-supers@7.28.6", "", { "dependencies": { "@babel/helper-member-expression-to-functions": "^7.28.5", "@babel/helper-optimise-call-expression": "^7.27.1", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg=="],
+
+    "@babel/helper-skip-transparent-expression-wrappers": ["@babel/helper-skip-transparent-expression-wrappers@7.27.1", "", { "dependencies": { "@babel/traverse": "^7.27.1", "@babel/types": "^7.27.1" } }, "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helper-wrap-function": ["@babel/helper-wrap-function@7.27.1", "", { "dependencies": { "@babel/template": "^7.27.1", "@babel/traverse": "^7.27.1", "@babel/types": "^7.27.1" } }, "sha512-NFJK2sHUvrjo8wAU/nQTWU890/zB2jj0qBcCbZbbf+005cAsv6tMjXz31fBign6M5ov1o0Bllu+9nbqkfsjjJQ=="],
+
+    "@babel/helpers": ["@babel/helpers@7.28.6", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw=="],
+
+    "@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": { "parser": "bin/babel-parser.js" } }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
+
+    "@babel/plugin-bugfix-firefox-class-in-computed-class-key": ["@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/traverse": "^7.28.5" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q=="],
+
+    "@babel/plugin-bugfix-safari-class-field-initializer-scope": ["@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA=="],
+
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": ["@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA=="],
+
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": ["@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1", "@babel/plugin-transform-optional-chaining": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.13.0" } }, "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw=="],
+
+    "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": ["@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g=="],
+
+    "@babel/plugin-proposal-private-property-in-object": ["@babel/plugin-proposal-private-property-in-object@7.21.11", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.18.6", "@babel/helper-create-class-features-plugin": "^7.21.0", "@babel/helper-plugin-utils": "^7.20.2", "@babel/plugin-syntax-private-property-in-object": "^7.14.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw=="],
+
+    "@babel/plugin-syntax-async-generators": ["@babel/plugin-syntax-async-generators@7.8.4", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw=="],
+
+    "@babel/plugin-syntax-bigint": ["@babel/plugin-syntax-bigint@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg=="],
+
+    "@babel/plugin-syntax-class-properties": ["@babel/plugin-syntax-class-properties@7.12.13", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.12.13" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA=="],
+
+    "@babel/plugin-syntax-class-static-block": ["@babel/plugin-syntax-class-static-block@7.14.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.14.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw=="],
+
+    "@babel/plugin-syntax-import-assertions": ["@babel/plugin-syntax-import-assertions@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw=="],
+
+    "@babel/plugin-syntax-import-attributes": ["@babel/plugin-syntax-import-attributes@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw=="],
+
+    "@babel/plugin-syntax-import-meta": ["@babel/plugin-syntax-import-meta@7.10.4", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.10.4" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g=="],
+
+    "@babel/plugin-syntax-json-strings": ["@babel/plugin-syntax-json-strings@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA=="],
+
+    "@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w=="],
+
+    "@babel/plugin-syntax-logical-assignment-operators": ["@babel/plugin-syntax-logical-assignment-operators@7.10.4", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.10.4" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig=="],
+
+    "@babel/plugin-syntax-nullish-coalescing-operator": ["@babel/plugin-syntax-nullish-coalescing-operator@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ=="],
+
+    "@babel/plugin-syntax-numeric-separator": ["@babel/plugin-syntax-numeric-separator@7.10.4", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.10.4" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug=="],
+
+    "@babel/plugin-syntax-object-rest-spread": ["@babel/plugin-syntax-object-rest-spread@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA=="],
+
+    "@babel/plugin-syntax-optional-catch-binding": ["@babel/plugin-syntax-optional-catch-binding@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q=="],
+
+    "@babel/plugin-syntax-optional-chaining": ["@babel/plugin-syntax-optional-chaining@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg=="],
+
+    "@babel/plugin-syntax-private-property-in-object": ["@babel/plugin-syntax-private-property-in-object@7.14.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.14.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg=="],
+
+    "@babel/plugin-syntax-top-level-await": ["@babel/plugin-syntax-top-level-await@7.14.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.14.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw=="],
+
+    "@babel/plugin-syntax-typescript": ["@babel/plugin-syntax-typescript@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ=="],
+
+    "@babel/plugin-syntax-unicode-sets-regex": ["@babel/plugin-syntax-unicode-sets-regex@7.18.6", "", { "dependencies": { "@babel/helper-create-regexp-features-plugin": "^7.18.6", "@babel/helper-plugin-utils": "^7.18.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg=="],
+
+    "@babel/plugin-transform-arrow-functions": ["@babel/plugin-transform-arrow-functions@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA=="],
+
+    "@babel/plugin-transform-async-generator-functions": ["@babel/plugin-transform-async-generator-functions@7.29.0", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6", "@babel/helper-remap-async-to-generator": "^7.27.1", "@babel/traverse": "^7.29.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w=="],
+
+    "@babel/plugin-transform-async-to-generator": ["@babel/plugin-transform-async-to-generator@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6", "@babel/helper-remap-async-to-generator": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g=="],
+
+    "@babel/plugin-transform-block-scoped-functions": ["@babel/plugin-transform-block-scoped-functions@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg=="],
+
+    "@babel/plugin-transform-block-scoping": ["@babel/plugin-transform-block-scoping@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw=="],
+
+    "@babel/plugin-transform-class-properties": ["@babel/plugin-transform-class-properties@7.28.6", "", { "dependencies": { "@babel/helper-create-class-features-plugin": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw=="],
+
+    "@babel/plugin-transform-class-static-block": ["@babel/plugin-transform-class-static-block@7.28.6", "", { "dependencies": { "@babel/helper-create-class-features-plugin": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.12.0" } }, "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ=="],
+
+    "@babel/plugin-transform-classes": ["@babel/plugin-transform-classes@7.28.6", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-globals": "^7.28.0", "@babel/helper-plugin-utils": "^7.28.6", "@babel/helper-replace-supers": "^7.28.6", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q=="],
+
+    "@babel/plugin-transform-computed-properties": ["@babel/plugin-transform-computed-properties@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6", "@babel/template": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ=="],
+
+    "@babel/plugin-transform-destructuring": ["@babel/plugin-transform-destructuring@7.28.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/traverse": "^7.28.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw=="],
+
+    "@babel/plugin-transform-dotall-regex": ["@babel/plugin-transform-dotall-regex@7.28.6", "", { "dependencies": { "@babel/helper-create-regexp-features-plugin": "^7.28.5", "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg=="],
+
+    "@babel/plugin-transform-duplicate-keys": ["@babel/plugin-transform-duplicate-keys@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q=="],
+
+    "@babel/plugin-transform-duplicate-named-capturing-groups-regex": ["@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0", "", { "dependencies": { "@babel/helper-create-regexp-features-plugin": "^7.28.5", "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw=="],
+
+    "@babel/plugin-transform-dynamic-import": ["@babel/plugin-transform-dynamic-import@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A=="],
+
+    "@babel/plugin-transform-explicit-resource-management": ["@babel/plugin-transform-explicit-resource-management@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6", "@babel/plugin-transform-destructuring": "^7.28.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg=="],
+
+    "@babel/plugin-transform-exponentiation-operator": ["@babel/plugin-transform-exponentiation-operator@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw=="],
+
+    "@babel/plugin-transform-export-namespace-from": ["@babel/plugin-transform-export-namespace-from@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ=="],
+
+    "@babel/plugin-transform-for-of": ["@babel/plugin-transform-for-of@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw=="],
+
+    "@babel/plugin-transform-function-name": ["@babel/plugin-transform-function-name@7.27.1", "", { "dependencies": { "@babel/helper-compilation-targets": "^7.27.1", "@babel/helper-plugin-utils": "^7.27.1", "@babel/traverse": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ=="],
+
+    "@babel/plugin-transform-json-strings": ["@babel/plugin-transform-json-strings@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw=="],
+
+    "@babel/plugin-transform-literals": ["@babel/plugin-transform-literals@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA=="],
+
+    "@babel/plugin-transform-logical-assignment-operators": ["@babel/plugin-transform-logical-assignment-operators@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A=="],
+
+    "@babel/plugin-transform-member-expression-literals": ["@babel/plugin-transform-member-expression-literals@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ=="],
+
+    "@babel/plugin-transform-modules-amd": ["@babel/plugin-transform-modules-amd@7.27.1", "", { "dependencies": { "@babel/helper-module-transforms": "^7.27.1", "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA=="],
+
+    "@babel/plugin-transform-modules-commonjs": ["@babel/plugin-transform-modules-commonjs@7.28.6", "", { "dependencies": { "@babel/helper-module-transforms": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA=="],
+
+    "@babel/plugin-transform-modules-systemjs": ["@babel/plugin-transform-modules-systemjs@7.29.0", "", { "dependencies": { "@babel/helper-module-transforms": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.29.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ=="],
+
+    "@babel/plugin-transform-modules-umd": ["@babel/plugin-transform-modules-umd@7.27.1", "", { "dependencies": { "@babel/helper-module-transforms": "^7.27.1", "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w=="],
+
+    "@babel/plugin-transform-named-capturing-groups-regex": ["@babel/plugin-transform-named-capturing-groups-regex@7.29.0", "", { "dependencies": { "@babel/helper-create-regexp-features-plugin": "^7.28.5", "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ=="],
+
+    "@babel/plugin-transform-new-target": ["@babel/plugin-transform-new-target@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ=="],
+
+    "@babel/plugin-transform-nullish-coalescing-operator": ["@babel/plugin-transform-nullish-coalescing-operator@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg=="],
+
+    "@babel/plugin-transform-numeric-separator": ["@babel/plugin-transform-numeric-separator@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w=="],
+
+    "@babel/plugin-transform-object-rest-spread": ["@babel/plugin-transform-object-rest-spread@7.28.6", "", { "dependencies": { "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6", "@babel/plugin-transform-destructuring": "^7.28.5", "@babel/plugin-transform-parameters": "^7.27.7", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA=="],
+
+    "@babel/plugin-transform-object-super": ["@babel/plugin-transform-object-super@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-replace-supers": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng=="],
+
+    "@babel/plugin-transform-optional-catch-binding": ["@babel/plugin-transform-optional-catch-binding@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ=="],
+
+    "@babel/plugin-transform-optional-chaining": ["@babel/plugin-transform-optional-chaining@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w=="],
+
+    "@babel/plugin-transform-parameters": ["@babel/plugin-transform-parameters@7.27.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg=="],
+
+    "@babel/plugin-transform-private-methods": ["@babel/plugin-transform-private-methods@7.28.6", "", { "dependencies": { "@babel/helper-create-class-features-plugin": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg=="],
+
+    "@babel/plugin-transform-private-property-in-object": ["@babel/plugin-transform-private-property-in-object@7.28.6", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-create-class-features-plugin": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA=="],
+
+    "@babel/plugin-transform-property-literals": ["@babel/plugin-transform-property-literals@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
+    "@babel/plugin-transform-regenerator": ["@babel/plugin-transform-regenerator@7.29.0", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog=="],
+
+    "@babel/plugin-transform-regexp-modifiers": ["@babel/plugin-transform-regexp-modifiers@7.28.6", "", { "dependencies": { "@babel/helper-create-regexp-features-plugin": "^7.28.5", "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg=="],
+
+    "@babel/plugin-transform-reserved-words": ["@babel/plugin-transform-reserved-words@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw=="],
+
+    "@babel/plugin-transform-shorthand-properties": ["@babel/plugin-transform-shorthand-properties@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ=="],
+
+    "@babel/plugin-transform-spread": ["@babel/plugin-transform-spread@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA=="],
+
+    "@babel/plugin-transform-sticky-regex": ["@babel/plugin-transform-sticky-regex@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g=="],
+
+    "@babel/plugin-transform-template-literals": ["@babel/plugin-transform-template-literals@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg=="],
+
+    "@babel/plugin-transform-typeof-symbol": ["@babel/plugin-transform-typeof-symbol@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw=="],
+
+    "@babel/plugin-transform-unicode-escapes": ["@babel/plugin-transform-unicode-escapes@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg=="],
+
+    "@babel/plugin-transform-unicode-property-regex": ["@babel/plugin-transform-unicode-property-regex@7.28.6", "", { "dependencies": { "@babel/helper-create-regexp-features-plugin": "^7.28.5", "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A=="],
+
+    "@babel/plugin-transform-unicode-regex": ["@babel/plugin-transform-unicode-regex@7.27.1", "", { "dependencies": { "@babel/helper-create-regexp-features-plugin": "^7.27.1", "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw=="],
+
+    "@babel/plugin-transform-unicode-sets-regex": ["@babel/plugin-transform-unicode-sets-regex@7.28.6", "", { "dependencies": { "@babel/helper-create-regexp-features-plugin": "^7.28.5", "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q=="],
+
+    "@babel/preset-env": ["@babel/preset-env@7.29.0", "", { "dependencies": { "@babel/compat-data": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5", "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1", "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1", "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1", "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6", "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2", "@babel/plugin-syntax-import-assertions": "^7.28.6", "@babel/plugin-syntax-import-attributes": "^7.28.6", "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6", "@babel/plugin-transform-arrow-functions": "^7.27.1", "@babel/plugin-transform-async-generator-functions": "^7.29.0", "@babel/plugin-transform-async-to-generator": "^7.28.6", "@babel/plugin-transform-block-scoped-functions": "^7.27.1", "@babel/plugin-transform-block-scoping": "^7.28.6", "@babel/plugin-transform-class-properties": "^7.28.6", "@babel/plugin-transform-class-static-block": "^7.28.6", "@babel/plugin-transform-classes": "^7.28.6", "@babel/plugin-transform-computed-properties": "^7.28.6", "@babel/plugin-transform-destructuring": "^7.28.5", "@babel/plugin-transform-dotall-regex": "^7.28.6", "@babel/plugin-transform-duplicate-keys": "^7.27.1", "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.0", "@babel/plugin-transform-dynamic-import": "^7.27.1", "@babel/plugin-transform-explicit-resource-management": "^7.28.6", "@babel/plugin-transform-exponentiation-operator": "^7.28.6", "@babel/plugin-transform-export-namespace-from": "^7.27.1", "@babel/plugin-transform-for-of": "^7.27.1", "@babel/plugin-transform-function-name": "^7.27.1", "@babel/plugin-transform-json-strings": "^7.28.6", "@babel/plugin-transform-literals": "^7.27.1", "@babel/plugin-transform-logical-assignment-operators": "^7.28.6", "@babel/plugin-transform-member-expression-literals": "^7.27.1", "@babel/plugin-transform-modules-amd": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.28.6", "@babel/plugin-transform-modules-systemjs": "^7.29.0", "@babel/plugin-transform-modules-umd": "^7.27.1", "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0", "@babel/plugin-transform-new-target": "^7.27.1", "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6", "@babel/plugin-transform-numeric-separator": "^7.28.6", "@babel/plugin-transform-object-rest-spread": "^7.28.6", "@babel/plugin-transform-object-super": "^7.27.1", "@babel/plugin-transform-optional-catch-binding": "^7.28.6", "@babel/plugin-transform-optional-chaining": "^7.28.6", "@babel/plugin-transform-parameters": "^7.27.7", "@babel/plugin-transform-private-methods": "^7.28.6", "@babel/plugin-transform-private-property-in-object": "^7.28.6", "@babel/plugin-transform-property-literals": "^7.27.1", "@babel/plugin-transform-regenerator": "^7.29.0", "@babel/plugin-transform-regexp-modifiers": "^7.28.6", "@babel/plugin-transform-reserved-words": "^7.27.1", "@babel/plugin-transform-shorthand-properties": "^7.27.1", "@babel/plugin-transform-spread": "^7.28.6", "@babel/plugin-transform-sticky-regex": "^7.27.1", "@babel/plugin-transform-template-literals": "^7.27.1", "@babel/plugin-transform-typeof-symbol": "^7.27.1", "@babel/plugin-transform-unicode-escapes": "^7.27.1", "@babel/plugin-transform-unicode-property-regex": "^7.28.6", "@babel/plugin-transform-unicode-regex": "^7.27.1", "@babel/plugin-transform-unicode-sets-regex": "^7.28.6", "@babel/preset-modules": "0.1.6-no-external-plugins", "babel-plugin-polyfill-corejs2": "^0.4.15", "babel-plugin-polyfill-corejs3": "^0.14.0", "babel-plugin-polyfill-regenerator": "^0.6.6", "core-js-compat": "^3.48.0", "semver": "^6.3.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-fNEdfc0yi16lt6IZo2Qxk3knHVdfMYX33czNb4v8yWhemoBhibCpQK/uYHtSKIiO+p/zd3+8fYVXhQdOVV608w=="],
+
+    "@babel/preset-modules": ["@babel/preset-modules@0.1.6-no-external-plugins", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.0.0", "@babel/types": "^7.4.4", "esutils": "^2.0.2" }, "peerDependencies": { "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0" } }, "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA=="],
+
+    "@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
+
+    "@babel/standalone": ["@babel/standalone@7.29.1", "", {}, "sha512-z42abD0C6fiHfgLyCWw8PYv6FCJ0IGVtSCxXk/NPykWO5LNIEGfdLDJ3HdYqlPcAhwtQ3oKH1PvNj2JGpTxQKg=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@5.0.2", "", {}, "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@3.0.10", "", { "dependencies": { "@csstools/color-helpers": "^5.0.2", "@csstools/css-calc": "^2.1.4" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
+
+    "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+
+    "@emotion/hash": ["@emotion/hash@0.8.0", "", {}, "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="],
+
+    "@emotion/unitless": ["@emotion/unitless@0.7.5", "", {}, "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.1", "", { "os": "android", "cpu": "arm" }, "sha512-kFqa6/UcaTbGm/NncN9kzVOODjhZW8e+FRdSeypWe6j33gzclHtwlANs26JrupOntlcWmB0u8+8HZo8s7thHvg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.1", "", { "os": "android", "cpu": "arm64" }, "sha512-45fuKmAJpxnQWixOGCrS+ro4Uvb4Re9+UTieUY2f8AEc+t7d4AaZ6eUJ3Hva7dtrxAAWHtlEFsXFMAgNnGU9uQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.1", "", { "os": "android", "cpu": "x64" }, "sha512-LBEpOz0BsgMEeHgenf5aqmn/lLNTFXVfoWMUox8CtWWYK9X4jmQzWjoGoNb8lmAYml/tQ/Ysvm8q7szu7BoxRQ=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-veg7fL8eMSCVKL7IW4pxb54QERtedFDfY/ASrumK/SbFsXnRazxY4YykN/THYqFnFwJ0aVjiUrVG2PwcdAEqQQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-+3ELd+nTzhfWb07Vol7EZ+5PTbJ/u74nC6iv4/lwIU99Ip5uuY6QoIf0Hn4m2HoV0qcnRivN3KSqc+FyCHjoVQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-/8Rfgns4XD9XOSXlzUDepG8PX+AVWHliYlUkFI3K3GB6tqbdjYqdhcb4BKRd7C0BhZSoaCxhv8kTcBrcZWP+xg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-GITpD8dK9C+r+5yRT/UKVT36h/DQLOHdwGVwwoHidlnA168oD3uxA878XloXebK4Ul3gDBBIvEdL7go9gCUFzQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.1", "", { "os": "linux", "cpu": "arm" }, "sha512-ieMID0JRZY/ZeCrsFQ3Y3NlHNCqIhTprJfDgSB3/lv5jJZ8FX3hqPyXWhe+gvS5ARMBJ242PM+VNz/ctNj//eA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-W9//kCrh/6in9rWIBdKaMtuTTzNj6jSeG/haWBADqLLa9P8O5YSRDzgD5y9QBok4AYlzS6ARHifAb75V6G670Q=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-VIUV4z8GD8rtSVMfAj1aXFahsi/+tcoXXNYmXgzISL+KB381vbSTNdeZHHHIYqFyXcoEhu9n5cT+05tRv13rlw=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.1", "", { "os": "linux", "cpu": "none" }, "sha512-l4rfiiJRN7sTNI//ff65zJ9z8U+k6zcCg0LALU5iEWzY+a1mVZ8iWC1k5EsNKThZ7XCQ6YWtsZ8EWYm7r1UEsg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.1", "", { "os": "linux", "cpu": "none" }, "sha512-U0bEuAOLvO/DWFdygTHWY8C067FXz+UbzKgxYhXC0fDieFa0kDIra1FAhsAARRJbvEyso8aAqvPdNxzWuStBnA=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-NzdQ/Xwu6vPSf/GkdmRNsOfIeSGnh7muundsWItmBsVpMoNPVpM61qNzAVY3pZ1glzzAxLR40UyYM23eaDDbYQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.1", "", { "os": "linux", "cpu": "none" }, "sha512-7zlw8p3IApcsN7mFw0O1Z1PyEk6PlKMu18roImfl3iQHTnr/yAfYv6s4hXPidbDoI2Q0pW+5xeoM4eTCC0UdrQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-cGj5wli+G+nkVQdZo3+7FDKC25Uh4ZVwOAK6A06Hsvgr8WqBBuOy/1s+PUEd/6Je+vjfm6stX0kmib5b/O2Ykw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.1", "", { "os": "linux", "cpu": "x64" }, "sha512-z3H/HYI9MM0HTv3hQZ81f+AKb+yEoCRlUby1F80vbQ5XdzEMyY/9iNlAmhqiBKw4MJXwfgsh7ERGEOhrM1niMA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.1", "", { "os": "none", "cpu": "arm64" }, "sha512-wzC24DxAvk8Em01YmVXyjl96Mr+ecTPyOuADAvjGg+fyBpGmxmcr2E5ttf7Im8D0sXZihpxzO1isus8MdjMCXQ=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.1", "", { "os": "none", "cpu": "x64" }, "sha512-1YQ8ybGi2yIXswu6eNzJsrYIGFpnlzEWRl6iR5gMgmsrR0FcNoV1m9k9sc3PuP5rUBLshOZylc9nqSgymI+TYg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-5Z+DzLCrq5wmU7RDaMDe2DVXMRm2tTDvX2KU14JJVBN2CT/qov7XVix85QoJqHltpvAOZUAc3ndU56HSMWrv8g=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-Q73ENzIdPF5jap4wqLtsfh8YbYSZ8Q0wnxplOlZUOyZy7B4ZKW8DXGWgTCZmF8VWD7Tciwv5F4NsRf6vYlZtqg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ajbHrGM/XiK+sXM0JzEbJAen+0E+JMQZ2l4RR4VFwvV9JEERx+oxtgkpoKv1SevhjavK2z2ReHk32pjzktWbGg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-IPUW+y4VIjuDVn+OMzHc5FV4GubIwPnsz6ubkvN8cuhEqH81NovB53IUlrlBkPMEPxvNnf79MGBoz8rZ2iW8HA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-RIVRWiljWA6CdVu8zkWcRmGP7iRRIIwvhDKem8UMBjPql2TXM5PkDVvvrzMtj1V+WFPB4K7zkIGM7VzRtFkjdg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-2BR5M8CPbptC1AK5JbJT1fWrHLvejwZidKx3UMSF0ecHMa+smhi16drIrCEggkgviBwLYd5nwrFLSl5Kho96RQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.1", "", { "os": "win32", "cpu": "x64" }, "sha512-d5X6RMYv6taIymSk8JBP+nxv8DQAMY6A51GPgusqLdK9wBz5wWIXy1KjTck6HnjE9hqJzJRdk+1p/t5soSbCtw=="],
+
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.21.1", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.1", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ=="],
+
+    "@eslint/js": ["@eslint/js@9.39.2", "", {}, "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.6", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.3.0" } }, "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.2", "", {}, "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ=="],
+
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@istanbuljs/load-nyc-config": ["@istanbuljs/load-nyc-config@1.1.0", "", { "dependencies": { "camelcase": "^5.3.1", "find-up": "^4.1.0", "get-package-type": "^0.1.0", "js-yaml": "^3.13.1", "resolve-from": "^5.0.0" } }, "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ=="],
+
+    "@istanbuljs/schema": ["@istanbuljs/schema@0.1.3", "", {}, "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA=="],
+
+    "@jest/console": ["@jest/console@30.2.0", "", { "dependencies": { "@jest/types": "30.2.0", "@types/node": "*", "chalk": "^4.1.2", "jest-message-util": "30.2.0", "jest-util": "30.2.0", "slash": "^3.0.0" } }, "sha512-+O1ifRjkvYIkBqASKWgLxrpEhQAAE7hY77ALLUufSk5717KfOShg6IbqLmdsLMPdUiFvA2kTs0R7YZy+l0IzZQ=="],
+
+    "@jest/core": ["@jest/core@30.2.0", "", { "dependencies": { "@jest/console": "30.2.0", "@jest/pattern": "30.0.1", "@jest/reporters": "30.2.0", "@jest/test-result": "30.2.0", "@jest/transform": "30.2.0", "@jest/types": "30.2.0", "@types/node": "*", "ansi-escapes": "^4.3.2", "chalk": "^4.1.2", "ci-info": "^4.2.0", "exit-x": "^0.2.2", "graceful-fs": "^4.2.11", "jest-changed-files": "30.2.0", "jest-config": "30.2.0", "jest-haste-map": "30.2.0", "jest-message-util": "30.2.0", "jest-regex-util": "30.0.1", "jest-resolve": "30.2.0", "jest-resolve-dependencies": "30.2.0", "jest-runner": "30.2.0", "jest-runtime": "30.2.0", "jest-snapshot": "30.2.0", "jest-util": "30.2.0", "jest-validate": "30.2.0", "jest-watcher": "30.2.0", "micromatch": "^4.0.8", "pretty-format": "30.2.0", "slash": "^3.0.0" }, "peerDependencies": { "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0" }, "optionalPeers": ["node-notifier"] }, "sha512-03W6IhuhjqTlpzh/ojut/pDB2LPRygyWX8ExpgHtQA8H/3K7+1vKmcINx5UzeOX1se6YEsBsOHQ1CRzf3fOwTQ=="],
+
+    "@jest/diff-sequences": ["@jest/diff-sequences@30.0.1", "", {}, "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw=="],
+
+    "@jest/environment": ["@jest/environment@30.2.0", "", { "dependencies": { "@jest/fake-timers": "30.2.0", "@jest/types": "30.2.0", "@types/node": "*", "jest-mock": "30.2.0" } }, "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g=="],
+
+    "@jest/environment-jsdom-abstract": ["@jest/environment-jsdom-abstract@30.2.0", "", { "dependencies": { "@jest/environment": "30.2.0", "@jest/fake-timers": "30.2.0", "@jest/types": "30.2.0", "@types/jsdom": "^21.1.7", "@types/node": "*", "jest-mock": "30.2.0", "jest-util": "30.2.0" }, "peerDependencies": { "canvas": "^3.0.0", "jsdom": "*" }, "optionalPeers": ["canvas"] }, "sha512-kazxw2L9IPuZpQ0mEt9lu9Z98SqR74xcagANmMBU16X0lS23yPc0+S6hGLUz8kVRlomZEs/5S/Zlpqwf5yu6OQ=="],
+
+    "@jest/expect": ["@jest/expect@30.2.0", "", { "dependencies": { "expect": "30.2.0", "jest-snapshot": "30.2.0" } }, "sha512-V9yxQK5erfzx99Sf+7LbhBwNWEZ9eZay8qQ9+JSC0TrMR1pMDHLMY+BnVPacWU6Jamrh252/IKo4F1Xn/zfiqA=="],
+
+    "@jest/expect-utils": ["@jest/expect-utils@30.2.0", "", { "dependencies": { "@jest/get-type": "30.1.0" } }, "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA=="],
+
+    "@jest/fake-timers": ["@jest/fake-timers@30.2.0", "", { "dependencies": { "@jest/types": "30.2.0", "@sinonjs/fake-timers": "^13.0.0", "@types/node": "*", "jest-message-util": "30.2.0", "jest-mock": "30.2.0", "jest-util": "30.2.0" } }, "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw=="],
+
+    "@jest/get-type": ["@jest/get-type@30.1.0", "", {}, "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA=="],
+
+    "@jest/globals": ["@jest/globals@30.2.0", "", { "dependencies": { "@jest/environment": "30.2.0", "@jest/expect": "30.2.0", "@jest/types": "30.2.0", "jest-mock": "30.2.0" } }, "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw=="],
+
+    "@jest/pattern": ["@jest/pattern@30.0.1", "", { "dependencies": { "@types/node": "*", "jest-regex-util": "30.0.1" } }, "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA=="],
+
+    "@jest/reporters": ["@jest/reporters@30.2.0", "", { "dependencies": { "@bcoe/v8-coverage": "^0.2.3", "@jest/console": "30.2.0", "@jest/test-result": "30.2.0", "@jest/transform": "30.2.0", "@jest/types": "30.2.0", "@jridgewell/trace-mapping": "^0.3.25", "@types/node": "*", "chalk": "^4.1.2", "collect-v8-coverage": "^1.0.2", "exit-x": "^0.2.2", "glob": "^10.3.10", "graceful-fs": "^4.2.11", "istanbul-lib-coverage": "^3.0.0", "istanbul-lib-instrument": "^6.0.0", "istanbul-lib-report": "^3.0.0", "istanbul-lib-source-maps": "^5.0.0", "istanbul-reports": "^3.1.3", "jest-message-util": "30.2.0", "jest-util": "30.2.0", "jest-worker": "30.2.0", "slash": "^3.0.0", "string-length": "^4.0.2", "v8-to-istanbul": "^9.0.1" }, "peerDependencies": { "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0" }, "optionalPeers": ["node-notifier"] }, "sha512-DRyW6baWPqKMa9CzeiBjHwjd8XeAyco2Vt8XbcLFjiwCOEKOvy82GJ8QQnJE9ofsxCMPjH4MfH8fCWIHHDKpAQ=="],
+
+    "@jest/schemas": ["@jest/schemas@30.0.1", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-+g/1TKjFuGrf1Hh0QPCv0gISwBxJ+MQSNXmG9zjHy7BmFhtoJ9fdNhWJp3qUKRi93AOZHXtdxZgJ1vAtz6z65w=="],
+
+    "@jest/snapshot-utils": ["@jest/snapshot-utils@30.2.0", "", { "dependencies": { "@jest/types": "30.2.0", "chalk": "^4.1.2", "graceful-fs": "^4.2.11", "natural-compare": "^1.4.0" } }, "sha512-0aVxM3RH6DaiLcjj/b0KrIBZhSX1373Xci4l3cW5xiUWPctZ59zQ7jj4rqcJQ/Z8JuN/4wX3FpJSa3RssVvCug=="],
+
+    "@jest/source-map": ["@jest/source-map@30.0.1", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "callsites": "^3.1.0", "graceful-fs": "^4.2.11" } }, "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg=="],
+
+    "@jest/test-result": ["@jest/test-result@30.2.0", "", { "dependencies": { "@jest/console": "30.2.0", "@jest/types": "30.2.0", "@types/istanbul-lib-coverage": "^2.0.6", "collect-v8-coverage": "^1.0.2" } }, "sha512-RF+Z+0CCHkARz5HT9mcQCBulb1wgCP3FBvl9VFokMX27acKphwyQsNuWH3c+ojd1LeWBLoTYoxF0zm6S/66mjg=="],
+
+    "@jest/test-sequencer": ["@jest/test-sequencer@30.2.0", "", { "dependencies": { "@jest/test-result": "30.2.0", "graceful-fs": "^4.2.11", "jest-haste-map": "30.2.0", "slash": "^3.0.0" } }, "sha512-wXKgU/lk8fKXMu/l5Hog1R61bL4q5GCdT6OJvdAFz1P+QrpoFuLU68eoKuVc4RbrTtNnTL5FByhWdLgOPSph+Q=="],
+
+    "@jest/transform": ["@jest/transform@30.2.0", "", { "dependencies": { "@babel/core": "^7.27.4", "@jest/types": "30.2.0", "@jridgewell/trace-mapping": "^0.3.25", "babel-plugin-istanbul": "^7.0.1", "chalk": "^4.1.2", "convert-source-map": "^2.0.0", "fast-json-stable-stringify": "^2.1.0", "graceful-fs": "^4.2.11", "jest-haste-map": "30.2.0", "jest-regex-util": "30.0.1", "jest-util": "30.2.0", "micromatch": "^4.0.8", "pirates": "^4.0.7", "slash": "^3.0.0", "write-file-atomic": "^5.0.1" } }, "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA=="],
+
+    "@jest/types": ["@jest/types@30.2.0", "", { "dependencies": { "@jest/pattern": "30.0.1", "@jest/schemas": "30.0.5", "@types/istanbul-lib-coverage": "^2.0.6", "@types/istanbul-reports": "^3.0.4", "@types/node": "*", "@types/yargs": "^17.0.33", "chalk": "^4.1.2" } }, "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.12", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.29", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ=="],
+
+    "@monaco-editor/loader": ["@monaco-editor/loader@1.5.0", "", { "dependencies": { "state-local": "^1.0.6" } }, "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw=="],
+
+    "@monaco-editor/react": ["@monaco-editor/react@4.7.0", "", { "dependencies": { "@monaco-editor/loader": "^1.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
+
+    "@rc-component/async-validator": ["@rc-component/async-validator@5.1.0", "", { "dependencies": { "@babel/runtime": "^7.24.4" } }, "sha512-n4HcR5siNUXRX23nDizbZBQPO0ZM/5oTtmKZ6/eqL0L2bo747cklFdZGRN2f+c9qWGICwDzrhW0H7tE9PptdcA=="],
+
+    "@rc-component/cascader": ["@rc-component/cascader@1.14.0", "", { "dependencies": { "@rc-component/select": "~1.6.0", "@rc-component/tree": "~1.2.0", "@rc-component/util": "^1.4.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-Ip9356xwZUR2nbW5PRVGif4B/bDve4pLa/N+PGbvBaTnjbvmN4PFMBGQSmlDlzKP1ovxaYMvwF/dI9lXNLT4iQ=="],
+
+    "@rc-component/checkbox": ["@rc-component/checkbox@2.0.0", "", { "dependencies": { "@rc-component/util": "^1.3.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-3CXGPpAR9gsPKeO2N78HAPOzU30UdemD6HGJoWVJOpa6WleaGB5kzZj3v6bdTZab31YuWgY/RxV3VKPctn0DwQ=="],
+
+    "@rc-component/collapse": ["@rc-component/collapse@1.2.0", "", { "dependencies": { "@babel/runtime": "^7.10.1", "@rc-component/motion": "^1.1.4", "@rc-component/util": "^1.3.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-ZRYSKSS39qsFx93p26bde7JUZJshsUBEQRlRXPuJYlAiNX0vyYlF5TsAm8JZN3LcF8XvKikdzPbgAtXSbkLUkw=="],
+
+    "@rc-component/color-picker": ["@rc-component/color-picker@3.1.0", "", { "dependencies": { "@ant-design/fast-color": "^3.0.0", "@rc-component/util": "^1.3.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-o7Vavj7yyfVxFmeynXf0fCHVlC0UTE9al74c6nYuLck+gjuVdQNWSVXR8Efq/mmWFy7891SCOsfaPq6Eqe1s/g=="],
+
+    "@rc-component/context": ["@rc-component/context@2.0.1", "", { "dependencies": { "@rc-component/util": "^1.3.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-HyZbYm47s/YqtP6pKXNMjPEMaukyg7P0qVfgMLzr7YiFNMHbK2fKTAGzms9ykfGHSfyf75nBbgWw+hHkp+VImw=="],
+
+    "@rc-component/dialog": ["@rc-component/dialog@1.8.4", "", { "dependencies": { "@rc-component/motion": "^1.1.3", "@rc-component/portal": "^2.1.0", "@rc-component/util": "^1.9.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-Ay6PM7phkTkquplG8fWfUGFZ2GTLx9diTl4f0d8Eqxd7W1u1KjE9AQooFQHOHnhZf0Ya3z51+5EKCWHmt/dNEw=="],
+
+    "@rc-component/drawer": ["@rc-component/drawer@1.4.2", "", { "dependencies": { "@rc-component/motion": "^1.1.4", "@rc-component/portal": "^2.1.3", "@rc-component/util": "^1.9.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-1ib+fZEp6FBu+YvcIktm+nCQ+Q+qIpwpoaJH6opGr4ofh2QMq+qdr5DLC4oCf5qf3pcWX9lUWPYX652k4ini8Q=="],
+
+    "@rc-component/dropdown": ["@rc-component/dropdown@1.0.2", "", { "dependencies": { "@rc-component/trigger": "^3.0.0", "@rc-component/util": "^1.2.1", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.11.0", "react-dom": ">=16.11.0" } }, "sha512-6PY2ecUSYhDPhkNHHb4wfeAya04WhpmUSKzdR60G+kMNVUCX2vjT/AgTS0Lz0I/K6xrPMJ3enQbwVpeN3sHCgg=="],
+
+    "@rc-component/form": ["@rc-component/form@1.6.2", "", { "dependencies": { "@rc-component/async-validator": "^5.1.0", "@rc-component/util": "^1.6.2", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-OgIn2RAoaSBqaIgzJf/X6iflIa9LpTozci1lagLBdURDFhGA370v0+T0tXxOi8YShMjTha531sFhwtnrv+EJaQ=="],
+
+    "@rc-component/image": ["@rc-component/image@1.6.0", "", { "dependencies": { "@rc-component/motion": "^1.0.0", "@rc-component/portal": "^2.1.2", "@rc-component/util": "^1.3.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-tSfn2ZE/oP082g4QIOxeehkmgnXB7R+5AFj/lIFr4k7pEuxHBdyGIq9axoCY9qea8NN0DY6p4IB/F07tLqaT5A=="],
+
+    "@rc-component/input": ["@rc-component/input@1.1.2", "", { "dependencies": { "@rc-component/util": "^1.4.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.0.0", "react-dom": ">=16.0.0" } }, "sha512-Q61IMR47piUBudgixJ30CciKIy9b1H95qe7GgEKOmSJVJXvFRWJllJfQry9tif+MX2cWFXWJf/RXz4kaCeq/Fg=="],
+
+    "@rc-component/input-number": ["@rc-component/input-number@1.6.2", "", { "dependencies": { "@rc-component/mini-decimal": "^1.0.1", "@rc-component/util": "^1.4.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-Gjcq7meZlCOiWN1t1xCC+7/s85humHVokTBI7PJgTfoyw5OWF74y3e6P8PHX104g9+b54jsodFIzyaj6p8LI9w=="],
+
+    "@rc-component/mentions": ["@rc-component/mentions@1.6.0", "", { "dependencies": { "@rc-component/input": "~1.1.0", "@rc-component/menu": "~1.2.0", "@rc-component/textarea": "~1.1.0", "@rc-component/trigger": "^3.0.0", "@rc-component/util": "^1.3.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-KIkQNP6habNuTsLhUv0UGEOwG67tlmE7KNIJoQZZNggEZl5lQJTytFDb69sl5CK3TDdISCTjKP3nGEBKgT61CQ=="],
+
+    "@rc-component/menu": ["@rc-component/menu@1.2.0", "", { "dependencies": { "@rc-component/motion": "^1.1.4", "@rc-component/overflow": "^1.0.0", "@rc-component/trigger": "^3.0.0", "@rc-component/util": "^1.3.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-VWwDuhvYHSnTGj4n6bV3ISrLACcPAzdPOq3d0BzkeiM5cve8BEYfvkEhNoM0PLzv51jpcejeyrLXeMVIJ+QJlg=="],
+
+    "@rc-component/mini-decimal": ["@rc-component/mini-decimal@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.18.0" } }, "sha512-jS4E7T9Li2GuYwI6PyiVXmxTiM6b07rlD9Ge8uGZSCz3WlzcG5ZK7g5bbuKNeZ9pgUuPK/5guV781ujdVpm4HQ=="],
+
+    "@rc-component/motion": ["@rc-component/motion@1.3.1", "", { "dependencies": { "@rc-component/util": "^1.2.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-Wo1mkd0tCcHtvYvpPOmlYJz546z16qlsiwaygmW7NPJpOZOF9GBjhGzdzZSsC2lEJ1IUkWLF4gMHlRA1aSA+Yw=="],
+
+    "@rc-component/mutate-observer": ["@rc-component/mutate-observer@2.0.1", "", { "dependencies": { "@rc-component/util": "^1.2.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-AyarjoLU5YlxuValRi+w8JRH2Z84TBbFO2RoGWz9d8bSu0FqT8DtugH3xC3BV7mUwlmROFauyWuXFuq4IFbH+w=="],
+
+    "@rc-component/notification": ["@rc-component/notification@1.2.0", "", { "dependencies": { "@rc-component/motion": "^1.1.4", "@rc-component/util": "^1.2.1", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-OX3J+zVU7rvoJCikjrfW7qOUp7zlDeFBK2eA3SFbGSkDqo63Sl4Ss8A04kFP+fxHSxMDIS9jYVEZtU1FNCFuBA=="],
+
+    "@rc-component/overflow": ["@rc-component/overflow@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.11.1", "@rc-component/resize-observer": "^1.0.1", "@rc-component/util": "^1.4.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-GSlBeoE0XTBi5cf3zl8Qh7Uqhn7v8RrlJ8ajeVpEkNe94HWy5l5BQ0Mwn2TVUq9gdgbfEMUmTX7tJFAg7mz0Rw=="],
+
+    "@rc-component/pagination": ["@rc-component/pagination@1.2.0", "", { "dependencies": { "@rc-component/util": "^1.3.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-YcpUFE8dMLfSo6OARJlK6DbHHvrxz7pMGPGmC/caZSJJz6HRKHC1RPP001PRHCvG9Z/veD039uOQmazVuLJzlw=="],
+
+    "@rc-component/picker": ["@rc-component/picker@1.9.0", "", { "dependencies": { "@rc-component/overflow": "^1.0.0", "@rc-component/resize-observer": "^1.0.0", "@rc-component/trigger": "^3.6.15", "@rc-component/util": "^1.3.0", "clsx": "^2.1.1" }, "peerDependencies": { "date-fns": ">= 2.x", "dayjs": ">= 1.x", "luxon": ">= 3.x", "moment": ">= 2.x", "react": ">=16.9.0", "react-dom": ">=16.9.0" }, "optionalPeers": ["date-fns", "moment"] }, "sha512-OLisdk8AWVCG9goBU1dWzuH5QlBQk8jktmQ6p0/IyBFwdKGwyIZOSjnBYo8hooHiTdl0lU+wGf/OfMtVBw02KQ=="],
+
+    "@rc-component/portal": ["@rc-component/portal@2.2.0", "", { "dependencies": { "@rc-component/util": "^1.2.1", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-oc6FlA+uXCMiwArHsJyHcIkX4q6uKyndrPol2eWX8YPkAnztHOPsFIRtmWG4BMlGE5h7YIRE3NiaJ5VS8Lb1QQ=="],
+
+    "@rc-component/progress": ["@rc-component/progress@1.0.2", "", { "dependencies": { "@rc-component/util": "^1.2.1", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-WZUnH9eGxH1+xodZKqdrHke59uyGZSWgj5HBM5Kwk5BrTMuAORO7VJ2IP5Qbm9aH3n9x3IcesqHHR0NWPBC7fQ=="],
+
+    "@rc-component/qrcode": ["@rc-component/qrcode@1.1.1", "", { "dependencies": { "@babel/runtime": "^7.24.7" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-LfLGNymzKdUPjXUbRP+xOhIWY4jQ+YMj5MmWAcgcAq1Ij8XP7tRmAXqyuv96XvLUBE/5cA8hLFl9eO1JQMujrA=="],
+
+    "@rc-component/rate": ["@rc-component/rate@1.0.1", "", { "dependencies": { "@rc-component/util": "^1.3.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-bkXxeBqDpl5IOC7yL7GcSYjQx9G8H+6kLYQnNZWeBYq2OYIv1MONd6mqKTjnnJYpV0cQIU2z3atdW0j1kttpTw=="],
+
+    "@rc-component/resize-observer": ["@rc-component/resize-observer@1.1.1", "", { "dependencies": { "@rc-component/util": "^1.2.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-NfXXMmiR+SmUuKE1NwJESzEUYUFWIDUn2uXpxCTOLwiRUUakd62DRNFjRJArgzyFW8S5rsL4aX5XlyIXyC/vRA=="],
+
+    "@rc-component/segmented": ["@rc-component/segmented@1.3.0", "", { "dependencies": { "@babel/runtime": "^7.11.1", "@rc-component/motion": "^1.1.4", "@rc-component/util": "^1.3.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.0.0", "react-dom": ">=16.0.0" } }, "sha512-5J/bJ01mbDnoA6P/FW8SxUvKn+OgUSTZJPzCNnTBntG50tzoP7DydGhqxp7ggZXZls7me3mc2EQDXakU3iTVFg=="],
+
+    "@rc-component/select": ["@rc-component/select@1.6.12", "", { "dependencies": { "@rc-component/overflow": "^1.0.0", "@rc-component/trigger": "^3.0.0", "@rc-component/util": "^1.3.0", "@rc-component/virtual-list": "^1.0.1", "clsx": "^2.1.1" }, "peerDependencies": { "react": "*", "react-dom": "*" } }, "sha512-jYXAglYdOb54BrpWAcjjhdBP16NyCv/HbEaWFMbEHZQAJVmGHPAtmBqbFuPPuvInAVsIwLbCj4Agag9udOamiQ=="],
+
+    "@rc-component/slider": ["@rc-component/slider@1.0.1", "", { "dependencies": { "@rc-component/util": "^1.3.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-uDhEPU1z3WDfCJhaL9jfd2ha/Eqpdfxsn0Zb0Xcq1NGQAman0TWaR37OWp2vVXEOdV2y0njSILTMpTfPV1454g=="],
+
+    "@rc-component/steps": ["@rc-component/steps@1.2.2", "", { "dependencies": { "@rc-component/util": "^1.2.1", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-/yVIZ00gDYYPHSY0JP+M+s3ZvuXLu2f9rEjQqiUDs7EcYsUYrpJ/1bLj9aI9R7MBR3fu/NGh6RM9u2qGfqp+Nw=="],
+
+    "@rc-component/switch": ["@rc-component/switch@1.0.3", "", { "dependencies": { "@rc-component/util": "^1.3.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-Jgi+EbOBquje/XNdofr7xbJQZPYJP+BlPfR0h+WN4zFkdtB2EWqEfvkXJWeipflwjWip0/17rNbxEAqs8hVHfw=="],
+
+    "@rc-component/table": ["@rc-component/table@1.9.1", "", { "dependencies": { "@rc-component/context": "^2.0.1", "@rc-component/resize-observer": "^1.0.0", "@rc-component/util": "^1.1.0", "@rc-component/virtual-list": "^1.0.1", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-FVI5ZS/GdB3BcgexfCYKi3iHhZS3Fr59EtsxORszYGrfpH1eWr33eDNSYkVfLI6tfJ7vftJDd9D5apfFWqkdJg=="],
+
+    "@rc-component/tabs": ["@rc-component/tabs@1.7.0", "", { "dependencies": { "@rc-component/dropdown": "~1.0.0", "@rc-component/menu": "~1.2.0", "@rc-component/motion": "^1.1.3", "@rc-component/resize-observer": "^1.0.0", "@rc-component/util": "^1.3.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-J48cs2iBi7Ho3nptBxxIqizEliUC+ExE23faspUQKGQ550vaBlv3aGF8Epv/UB1vFWeoJDTW/dNzgIU0Qj5i/w=="],
+
+    "@rc-component/textarea": ["@rc-component/textarea@1.1.2", "", { "dependencies": { "@rc-component/input": "~1.1.0", "@rc-component/resize-observer": "^1.0.0", "@rc-component/util": "^1.3.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-9rMUEODWZDMovfScIEHXWlVZuPljZ2pd1LKNjslJVitn4SldEzq5vO1CL3yy3Dnib6zZal2r2DPtjy84VVpF6A=="],
+
+    "@rc-component/tooltip": ["@rc-component/tooltip@1.4.0", "", { "dependencies": { "@rc-component/trigger": "^3.7.1", "@rc-component/util": "^1.3.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-8Rx5DCctIlLI4raR0I0xHjVTf1aF48+gKCNeAAo5bmF5VoR5YED+A/XEqzXv9KKqrJDRcd3Wndpxh2hyzrTtSg=="],
+
+    "@rc-component/tour": ["@rc-component/tour@2.3.0", "", { "dependencies": { "@rc-component/portal": "^2.2.0", "@rc-component/trigger": "^3.0.0", "@rc-component/util": "^1.7.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-K04K9r32kUC+auBSQfr+Fss4SpSIS9JGe56oq/ALAX0p+i2ylYOI1MgR83yBY7v96eO6ZFXcM/igCQmubps0Ow=="],
+
+    "@rc-component/tree": ["@rc-component/tree@1.2.3", "", { "dependencies": { "@rc-component/motion": "^1.0.0", "@rc-component/util": "^1.8.1", "@rc-component/virtual-list": "^1.0.1", "clsx": "^2.1.1" }, "peerDependencies": { "react": "*", "react-dom": "*" } }, "sha512-mG8hF2ogQcKaEpfyxzPvMWqqkptofd7Sf+YiXOpPzuXLTLwNKfLDJtysc1/oybopbnzxNqWh2Vgwi+GYwNIb7w=="],
+
+    "@rc-component/tree-select": ["@rc-component/tree-select@1.8.0", "", { "dependencies": { "@rc-component/select": "~1.6.0", "@rc-component/tree": "~1.2.0", "@rc-component/util": "^1.4.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": "*", "react-dom": "*" } }, "sha512-iYsPq3nuLYvGqdvFAW+l+I9ASRIOVbMXyA8FGZg2lGym/GwkaWeJGzI4eJ7c9IOEhRj0oyfIN4S92Fl3J05mjQ=="],
+
+    "@rc-component/trigger": ["@rc-component/trigger@3.9.0", "", { "dependencies": { "@rc-component/motion": "^1.1.4", "@rc-component/portal": "^2.2.0", "@rc-component/resize-observer": "^1.1.1", "@rc-component/util": "^1.2.1", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-X8btpwfrT27AgrZVOz4swclhEHTZcqaHeQMXXBgveagOiakTa36uObXbdwerXffgV8G9dH1fAAE0DHtVQs8EHg=="],
+
+    "@rc-component/upload": ["@rc-component/upload@1.1.0", "", { "dependencies": { "@rc-component/util": "^1.3.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-LIBV90mAnUE6VK5N4QvForoxZc4XqEYZimcp7fk+lkE4XwHHyJWxpIXQQwMU8hJM+YwBbsoZkGksL1sISWHQxw=="],
+
+    "@rc-component/util": ["@rc-component/util@1.9.0", "", { "dependencies": { "is-mobile": "^5.0.0", "react-is": "^18.2.0" }, "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-5uW6AfhIigCWeEQDthTozlxiT4Prn6xYQWeO0xokjcaa186OtwPRHBZJ2o0T0FhbjGhZ3vXdbkv0sx3gAYW7Vg=="],
+
+    "@rc-component/virtual-list": ["@rc-component/virtual-list@1.0.2", "", { "dependencies": { "@babel/runtime": "^7.20.0", "@rc-component/resize-observer": "^1.0.1", "@rc-component/util": "^1.4.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-uvTol/mH74FYsn5loDGJxo+7kjkO4i+y4j87Re1pxJBs0FaeuMuLRzQRGaXwnMcV1CxpZLi2Z56Rerj2M00fjQ=="],
+
+    "@reactflow/background": ["@reactflow/background@11.3.14", "", { "dependencies": { "@reactflow/core": "11.11.4", "classcat": "^5.0.3", "zustand": "^4.4.1" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA=="],
+
+    "@reactflow/controls": ["@reactflow/controls@11.2.14", "", { "dependencies": { "@reactflow/core": "11.11.4", "classcat": "^5.0.3", "zustand": "^4.4.1" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw=="],
+
+    "@reactflow/core": ["@reactflow/core@11.11.4", "", { "dependencies": { "@types/d3": "^7.4.0", "@types/d3-drag": "^3.0.1", "@types/d3-selection": "^3.0.3", "@types/d3-zoom": "^3.0.1", "classcat": "^5.0.3", "d3-drag": "^3.0.0", "d3-selection": "^3.0.0", "d3-zoom": "^3.0.0", "zustand": "^4.4.1" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q=="],
+
+    "@reactflow/minimap": ["@reactflow/minimap@11.7.14", "", { "dependencies": { "@reactflow/core": "11.11.4", "@types/d3-selection": "^3.0.3", "@types/d3-zoom": "^3.0.1", "classcat": "^5.0.3", "d3-selection": "^3.0.0", "d3-zoom": "^3.0.0", "zustand": "^4.4.1" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ=="],
+
+    "@reactflow/node-resizer": ["@reactflow/node-resizer@2.2.14", "", { "dependencies": { "@reactflow/core": "11.11.4", "classcat": "^5.0.4", "d3-drag": "^3.0.0", "d3-selection": "^3.0.0", "zustand": "^4.4.1" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA=="],
+
+    "@reactflow/node-toolbar": ["@reactflow/node-toolbar@1.3.14", "", { "dependencies": { "@reactflow/core": "11.11.4", "classcat": "^5.0.3", "zustand": "^4.4.1" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
+
+    "@rollup/plugin-dynamic-import-vars": ["@rollup/plugin-dynamic-import-vars@2.1.5", "", { "dependencies": { "@rollup/pluginutils": "^5.0.1", "astring": "^1.8.5", "estree-walker": "^2.0.2", "fast-glob": "^3.2.12", "magic-string": "^0.30.3" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" } }, "sha512-Mymi24fd9hlRifdZV/jYIFj1dn99F34imiYu3KzlAcgBcRi3i9SucgW/VRo5SQ9K4NuQ7dCep6pFWgNyhRdFHQ=="],
+
+    "@rollup/pluginutils": ["@rollup/pluginutils@5.1.4", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" } }, "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.46.2", "", { "os": "android", "cpu": "arm" }, "sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.46.2", "", { "os": "android", "cpu": "arm64" }, "sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.46.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.46.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.46.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.46.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.46.2", "", { "os": "linux", "cpu": "arm" }, "sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.46.2", "", { "os": "linux", "cpu": "arm" }, "sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.46.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.46.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg=="],
+
+    "@rollup/rollup-linux-loongarch64-gnu": ["@rollup/rollup-linux-loongarch64-gnu@4.46.2", "", { "os": "linux", "cpu": "none" }, "sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.46.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.46.2", "", { "os": "linux", "cpu": "none" }, "sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.46.2", "", { "os": "linux", "cpu": "none" }, "sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.46.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.46.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.46.2", "", { "os": "linux", "cpu": "x64" }, "sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.46.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.46.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.46.2", "", { "os": "win32", "cpu": "x64" }, "sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg=="],
+
+    "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
+
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.35", "", {}, "sha512-C6ypdODf2VZkgRT6sFM8E1F8vR+HcffniX0Kp8MsU8PIfrlXbNCBz0jzj17GjdmjTx1OtZzdH8+iALL21UjF5A=="],
+
+    "@sinonjs/commons": ["@sinonjs/commons@3.0.1", "", { "dependencies": { "type-detect": "4.0.8" } }, "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ=="],
+
+    "@sinonjs/fake-timers": ["@sinonjs/fake-timers@13.0.5", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw=="],
+
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
+    "@tsconfig/node10": ["@tsconfig/node10@1.0.11", "", {}, "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw=="],
+
+    "@tsconfig/node12": ["@tsconfig/node12@1.0.11", "", {}, "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="],
+
+    "@tsconfig/node14": ["@tsconfig/node14@1.0.3", "", {}, "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="],
+
+    "@tsconfig/node16": ["@tsconfig/node16@1.0.4", "", {}, "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.6.8", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw=="],
+
+    "@types/babel__standalone": ["@types/babel__standalone@7.1.9", "", { "dependencies": { "@babel/parser": "^7.25.6", "@babel/types": "^7.25.6", "@types/babel__core": "^7.20.5", "@types/babel__generator": "^7.6.8", "@types/babel__template": "^7.4.4", "@types/babel__traverse": "^7.20.6" } }, "sha512-IcCNPLqpevUD7UpV8QB0uwQPOyoOKACFf0YtYWRHcmxcakaje4Q7dbG2+jMqxw/I8Zk0NHvEps66WwS7z/UaaA=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.20.6", "", { "dependencies": { "@babel/types": "^7.20.7" } }, "sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg=="],
+
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.3", "", {}, "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
+    "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/istanbul-lib-coverage": ["@types/istanbul-lib-coverage@2.0.6", "", {}, "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="],
+
+    "@types/istanbul-lib-report": ["@types/istanbul-lib-report@3.0.3", "", { "dependencies": { "@types/istanbul-lib-coverage": "*" } }, "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA=="],
+
+    "@types/istanbul-reports": ["@types/istanbul-reports@3.0.4", "", { "dependencies": { "@types/istanbul-lib-report": "*" } }, "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ=="],
+
+    "@types/jest": ["@types/jest@30.0.0", "", { "dependencies": { "expect": "^30.0.0", "pretty-format": "^30.0.0" } }, "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA=="],
+
+    "@types/jsdom": ["@types/jsdom@21.1.7", "", { "dependencies": { "@types/node": "*", "@types/tough-cookie": "*", "parse5": "^7.0.0" } }, "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
+
+    "@types/luxon": ["@types/luxon@3.7.1", "", {}, "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
+    "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
+
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/react-vis": ["@types/react-vis@1.11.15", "", { "dependencies": { "@types/react": "*" } }, "sha512-0feNthHy/GnkCRPagPKkAnZmKQY1rI+OelD/ASdI7z+PMCfcmPLTi7nLrduIojxGAOWBiIgyH3YX1Ix7GWpAag=="],
+
+    "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
+
+    "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/yargs": ["@types/yargs@17.0.33", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA=="],
+
+    "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.56.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.56.1", "@typescript-eslint/type-utils": "8.56.1", "@typescript-eslint/utils": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.56.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.56.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.56.1", "@typescript-eslint/types": "8.56.1", "@typescript-eslint/typescript-estree": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.56.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.56.1", "@typescript-eslint/types": "^8.56.1", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1" } }, "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.56.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "@typescript-eslint/typescript-estree": "8.56.1", "@typescript-eslint/utils": "8.56.1", "debug": "^4.4.3", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.56.1", "", {}, "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.56.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.56.1", "@typescript-eslint/tsconfig-utils": "8.56.1", "@typescript-eslint/types": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.56.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.56.1", "@typescript-eslint/types": "8.56.1", "@typescript-eslint/typescript-estree": "8.56.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "@unrs/resolver-binding-darwin-arm64": ["@unrs/resolver-binding-darwin-arm64@1.7.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-i3/wlWjQJXMh1uiGtiv7k1EYvrrS3L1hdwmWJJiz1D8jWy726YFYPIxQWbEIVPVAgrfRR0XNlLrTQwq17cuCGw=="],
+
+    "@unrs/resolver-binding-darwin-x64": ["@unrs/resolver-binding-darwin-x64@1.7.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-8XXyFvc6w6kmMmi6VYchZhjd5CDcp+Lv6Cn1YmUme0ypsZ/0Kzd+9ESrWtDrWibKPTgSteDTxp75cvBOY64FQQ=="],
+
+    "@unrs/resolver-binding-freebsd-x64": ["@unrs/resolver-binding-freebsd-x64@1.7.11", "", { "os": "freebsd", "cpu": "x64" }, "sha512-0qJBYzP8Qk24CZ05RSWDQUjdiQUeIJGfqMMzbtXgCKl/a5xa6thfC0MQkGIr55LCLd6YmMyO640ifYUa53lybQ=="],
+
+    "@unrs/resolver-binding-linux-arm-gnueabihf": ["@unrs/resolver-binding-linux-arm-gnueabihf@1.7.11", "", { "os": "linux", "cpu": "arm" }, "sha512-1sGwpgvx+WZf0GFT6vkkOm6UJ+mlsVnjw+Yv9esK71idWeRAG3bbpkf3AoY8KIqKqmnzJExi0uKxXpakQ5Pcbg=="],
+
+    "@unrs/resolver-binding-linux-arm-musleabihf": ["@unrs/resolver-binding-linux-arm-musleabihf@1.7.11", "", { "os": "linux", "cpu": "arm" }, "sha512-D/1F/2lTe+XAl3ohkYj51NjniVly8sIqkA/n1aOND3ZMO418nl2JNU95iVa1/RtpzaKcWEsNTtHRogykrUflJg=="],
+
+    "@unrs/resolver-binding-linux-arm64-gnu": ["@unrs/resolver-binding-linux-arm64-gnu@1.7.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-7vFWHLCCNFLEQlmwKQfVy066ohLLArZl+AV/AdmrD1/pD1FlmqM+FKbtnONnIwbHtgetFUCV/SRi1q4D49aTlw=="],
+
+    "@unrs/resolver-binding-linux-arm64-musl": ["@unrs/resolver-binding-linux-arm64-musl@1.7.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-tYkGIx8hjWPh4zcn17jLEHU8YMmdP2obRTGkdaB3BguGHh31VCS3ywqC4QjTODjmhhNyZYkj/1Dz/+0kKvg9YA=="],
+
+    "@unrs/resolver-binding-linux-ppc64-gnu": ["@unrs/resolver-binding-linux-ppc64-gnu@1.7.11", "", { "os": "linux", "cpu": "ppc64" }, "sha512-6F328QIUev29vcZeRX6v6oqKxfUoGwIIAhWGD8wSysnBYFY0nivp25jdWmAb1GildbCCaQvOKEhCok7YfWkj4Q=="],
+
+    "@unrs/resolver-binding-linux-riscv64-gnu": ["@unrs/resolver-binding-linux-riscv64-gnu@1.7.11", "", { "os": "linux", "cpu": "none" }, "sha512-NqhWmiGJGdzbZbeucPZIG9Iav4lyYLCarEnxAceguMx9qlpeEF7ENqYKOwB8Zqk7/CeuYMEcLYMaW2li6HyDzQ=="],
+
+    "@unrs/resolver-binding-linux-riscv64-musl": ["@unrs/resolver-binding-linux-riscv64-musl@1.7.11", "", { "os": "linux", "cpu": "none" }, "sha512-J2RPIFKMdTrLtBdfR1cUMKl8Gcy05nlQ+bEs/6al7EdWLk9cs3tnDREHZ7mV9uGbeghpjo4i8neNZNx3PYUY9w=="],
+
+    "@unrs/resolver-binding-linux-s390x-gnu": ["@unrs/resolver-binding-linux-s390x-gnu@1.7.11", "", { "os": "linux", "cpu": "s390x" }, "sha512-bDpGRerHvvHdhun7MmFUNDpMiYcJSqWckwAVVRTJf8F+RyqYJOp/mx04PDc7DhpNPeWdnTMu91oZRMV+gGaVcQ=="],
+
+    "@unrs/resolver-binding-linux-x64-gnu": ["@unrs/resolver-binding-linux-x64-gnu@1.7.11", "", { "os": "linux", "cpu": "x64" }, "sha512-G9U7bVmylzRLma3cK39RBm3guoD1HOvY4o0NS4JNm37AD0lS7/xyMt7kn0JejYyc0Im8J+rH69/dXGM9DAJcSQ=="],
+
+    "@unrs/resolver-binding-linux-x64-musl": ["@unrs/resolver-binding-linux-x64-musl@1.7.11", "", { "os": "linux", "cpu": "x64" }, "sha512-7qL20SBKomekSunm7M9Fe5L93bFbn+FbHiGJbfTlp0RKhPVoJDP73vOxf1QrmJHyDPECsGWPFnKa/f8fO2FsHw=="],
+
+    "@unrs/resolver-binding-wasm32-wasi": ["@unrs/resolver-binding-wasm32-wasi@1.7.11", "", { "dependencies": { "@napi-rs/wasm-runtime": "^0.2.10" }, "cpu": "none" }, "sha512-jisvIva8MidjI+B1lFRZZMfCPaCISePgTyR60wNT1MeQvIh5Ksa0G3gvI+Iqyj3jqYbvOHByenpa5eDGcSdoSg=="],
+
+    "@unrs/resolver-binding-win32-arm64-msvc": ["@unrs/resolver-binding-win32-arm64-msvc@1.7.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-G+H5nQZ8sRZ8ebMY6mRGBBvTEzMYEcgVauLsNHpvTUavZoCCRVP1zWkCZgOju2dW3O22+8seTHniTdl1/uLz3g=="],
+
+    "@unrs/resolver-binding-win32-ia32-msvc": ["@unrs/resolver-binding-win32-ia32-msvc@1.7.11", "", { "os": "win32", "cpu": "ia32" }, "sha512-Hfy46DBfFzyv0wgR0MMOwFFib2W2+Btc8oE5h4XlPhpelnSyA6nFxkVIyTgIXYGTdFaLoZFNn62fmqx3rjEg3A=="],
+
+    "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.7.11", "", { "os": "win32", "cpu": "x64" }, "sha512-7L8NdsQlCJ8T106Gbz/AjzM4QKWVsoQbKpB9bMBGcIZswUuAnJMHpvbqGW3RBqLHCIwX4XZ5fxSBHEFcK2h9wA=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@5.1.4", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA=="],
+
+    "acorn": ["acorn@8.15.0", "", { "bin": "bin/acorn" }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "acorn-walk": ["acorn-walk@8.3.4", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g=="],
+
+    "agent-base": ["agent-base@7.1.3", "", {}, "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw=="],
+
+    "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "anser": ["anser@2.3.5", "", {}, "sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ=="],
+
+    "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "ansi-to-react": ["ansi-to-react@6.2.6", "", { "dependencies": { "anser": "^2.3.2", "escape-carriage": "^1.3.1", "linkify-it": "^3.0.3" }, "peerDependencies": { "react": "^16.3.2 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.3.2 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Eqi0iaMK5OZ3jsVFxWvU2B74UZBnGuHlkflKMX6wTOeH+luy9KE2O0gUkc2PxhIP1R4IO0xohv62UMFInQOSeg=="],
+
+    "antd": ["antd@6.3.1", "", { "dependencies": { "@ant-design/colors": "^8.0.1", "@ant-design/cssinjs": "^2.1.0", "@ant-design/cssinjs-utils": "^2.1.1", "@ant-design/fast-color": "^3.0.1", "@ant-design/icons": "^6.1.0", "@ant-design/react-slick": "~2.0.0", "@babel/runtime": "^7.28.4", "@rc-component/cascader": "~1.14.0", "@rc-component/checkbox": "~2.0.0", "@rc-component/collapse": "~1.2.0", "@rc-component/color-picker": "~3.1.0", "@rc-component/dialog": "~1.8.4", "@rc-component/drawer": "~1.4.2", "@rc-component/dropdown": "~1.0.2", "@rc-component/form": "~1.6.2", "@rc-component/image": "~1.6.0", "@rc-component/input": "~1.1.2", "@rc-component/input-number": "~1.6.2", "@rc-component/mentions": "~1.6.0", "@rc-component/menu": "~1.2.0", "@rc-component/motion": "^1.3.1", "@rc-component/mutate-observer": "^2.0.1", "@rc-component/notification": "~1.2.0", "@rc-component/pagination": "~1.2.0", "@rc-component/picker": "~1.9.0", "@rc-component/progress": "~1.0.2", "@rc-component/qrcode": "~1.1.1", "@rc-component/rate": "~1.0.1", "@rc-component/resize-observer": "^1.1.1", "@rc-component/segmented": "~1.3.0", "@rc-component/select": "~1.6.12", "@rc-component/slider": "~1.0.1", "@rc-component/steps": "~1.2.2", "@rc-component/switch": "~1.0.3", "@rc-component/table": "~1.9.1", "@rc-component/tabs": "~1.7.0", "@rc-component/textarea": "~1.1.2", "@rc-component/tooltip": "~1.4.0", "@rc-component/tour": "~2.3.0", "@rc-component/tree": "~1.2.3", "@rc-component/tree-select": "~1.8.0", "@rc-component/trigger": "^3.9.0", "@rc-component/upload": "~1.1.0", "@rc-component/util": "^1.9.0", "clsx": "^2.1.1", "dayjs": "^1.11.11", "scroll-into-view-if-needed": "^3.1.0", "throttle-debounce": "^5.0.2" }, "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-8pRjvxitZFyrYAtgwml93Km7fCXjw9IeqlmzpIsusRsmO3eWFVrOMum6+0TsGCtR/WrXVnPwfsgrFg3ChzGCeA=="],
+
+    "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "arg": ["arg@4.1.3", "", {}, "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
+
+    "array-includes": ["array-includes@3.1.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.24.0", "es-object-atoms": "^1.1.1", "get-intrinsic": "^1.3.0", "is-string": "^1.1.1", "math-intrinsics": "^1.1.0" } }, "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ=="],
+
+    "array.prototype.findlast": ["array.prototype.findlast@1.2.5", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.2", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "es-shim-unscopables": "^1.0.2" } }, "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ=="],
+
+    "array.prototype.findlastindex": ["array.prototype.findlastindex@1.2.6", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-shim-unscopables": "^1.1.0" } }, "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ=="],
+
+    "array.prototype.flat": ["array.prototype.flat@1.3.3", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-shim-unscopables": "^1.0.2" } }, "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg=="],
+
+    "array.prototype.flatmap": ["array.prototype.flatmap@1.3.3", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-shim-unscopables": "^1.0.2" } }, "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg=="],
+
+    "array.prototype.tosorted": ["array.prototype.tosorted@1.1.4", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.3", "es-errors": "^1.3.0", "es-shim-unscopables": "^1.0.2" } }, "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA=="],
+
+    "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
+
+    "ast-types-flow": ["ast-types-flow@0.0.8", "", {}, "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="],
+
+    "astring": ["astring@1.9.0", "", { "bin": "bin/astring" }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
+
+    "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
+
+    "axe-core": ["axe-core@4.10.3", "", {}, "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg=="],
+
+    "axios": ["axios@1.13.5", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "babel-jest": ["babel-jest@30.2.0", "", { "dependencies": { "@jest/transform": "30.2.0", "@types/babel__core": "^7.20.5", "babel-plugin-istanbul": "^7.0.1", "babel-preset-jest": "30.2.0", "chalk": "^4.1.2", "graceful-fs": "^4.2.11", "slash": "^3.0.0" }, "peerDependencies": { "@babel/core": "^7.11.0 || ^8.0.0-0" } }, "sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw=="],
+
+    "babel-plugin-istanbul": ["babel-plugin-istanbul@7.0.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.0.0", "@istanbuljs/load-nyc-config": "^1.0.0", "@istanbuljs/schema": "^0.1.3", "istanbul-lib-instrument": "^6.0.2", "test-exclude": "^6.0.0" } }, "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA=="],
+
+    "babel-plugin-jest-hoist": ["babel-plugin-jest-hoist@30.2.0", "", { "dependencies": { "@types/babel__core": "^7.20.5" } }, "sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA=="],
+
+    "babel-plugin-polyfill-corejs2": ["babel-plugin-polyfill-corejs2@0.4.15", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-define-polyfill-provider": "^0.6.6", "semver": "^6.3.1" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-hR3GwrRwHUfYwGfrisXPIDP3JcYfBrW7wKE7+Au6wDYl7fm/ka1NEII6kORzxNU556JjfidZeBsO10kYvtV1aw=="],
+
+    "babel-plugin-polyfill-corejs3": ["babel-plugin-polyfill-corejs3@0.14.0", "", { "dependencies": { "@babel/helper-define-polyfill-provider": "^0.6.6", "core-js-compat": "^3.48.0" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-AvDcMxJ34W4Wgy4KBIIePQTAOP1Ie2WFwkQp3dB7FQ/f0lI5+nM96zUnYEOE1P9sEg0es5VCP0HxiWu5fUHZAQ=="],
+
+    "babel-plugin-polyfill-regenerator": ["babel-plugin-polyfill-regenerator@0.6.6", "", { "dependencies": { "@babel/helper-define-polyfill-provider": "^0.6.6" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-hYm+XLYRMvupxiQzrvXUj7YyvFFVfv5gI0R71AJzudg1g2AI2vyCPPIFEBjk162/wFzti3inBHo7isWFuEVS/A=="],
+
+    "babel-preset-current-node-syntax": ["babel-preset-current-node-syntax@1.2.0", "", { "dependencies": { "@babel/plugin-syntax-async-generators": "^7.8.4", "@babel/plugin-syntax-bigint": "^7.8.3", "@babel/plugin-syntax-class-properties": "^7.12.13", "@babel/plugin-syntax-class-static-block": "^7.14.5", "@babel/plugin-syntax-import-attributes": "^7.24.7", "@babel/plugin-syntax-import-meta": "^7.10.4", "@babel/plugin-syntax-json-strings": "^7.8.3", "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4", "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3", "@babel/plugin-syntax-numeric-separator": "^7.10.4", "@babel/plugin-syntax-object-rest-spread": "^7.8.3", "@babel/plugin-syntax-optional-catch-binding": "^7.8.3", "@babel/plugin-syntax-optional-chaining": "^7.8.3", "@babel/plugin-syntax-private-property-in-object": "^7.14.5", "@babel/plugin-syntax-top-level-await": "^7.14.5" }, "peerDependencies": { "@babel/core": "^7.0.0 || ^8.0.0-0" } }, "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg=="],
+
+    "babel-preset-jest": ["babel-preset-jest@30.2.0", "", { "dependencies": { "babel-plugin-jest-hoist": "30.2.0", "babel-preset-current-node-syntax": "^1.2.0" }, "peerDependencies": { "@babel/core": "^7.11.0 || ^8.0.0-beta.1" } }, "sha512-US4Z3NOieAQumwFnYdUWKvUKh8+YSnS/gB3t6YBiz0bskpu7Pine8pPCheNxlPEW4wnUkma2a94YuW2q3guvCQ=="],
+
+    "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.9.19", "", { "bin": "dist/cli.js" }, "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg=="],
+
+    "brace-expansion": ["brace-expansion@5.0.3", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": "cli.js" }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "bs-logger": ["bs-logger@0.2.6", "", { "dependencies": { "fast-json-stable-stringify": "2.x" } }, "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog=="],
+
+    "bser": ["bser@2.1.1", "", { "dependencies": { "node-int64": "^0.4.0" } }, "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ=="],
+
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
+    "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001769", "", {}, "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg=="],
+
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "char-regex": ["char-regex@1.0.2", "", {}, "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="],
+
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
+
+    "ci-info": ["ci-info@4.2.0", "", {}, "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@2.1.0", "", {}, "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA=="],
+
+    "classcat": ["classcat@5.0.5", "", {}, "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="],
+
+    "classnames": ["classnames@2.5.1", "", {}, "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="],
+
+    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "co": ["co@4.6.0", "", {}, "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ=="],
+
+    "collect-v8-coverage": ["collect-v8-coverage@1.0.2", "", {}, "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "compute-scroll-into-view": ["compute-scroll-into-view@3.1.1", "", {}, "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "core-js-compat": ["core-js-compat@3.48.0", "", { "dependencies": { "browserslist": "^4.28.1" } }, "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q=="],
+
+    "core-js-pure": ["core-js-pure@3.48.0", "", {}, "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw=="],
+
+    "create-require": ["create-require@1.1.1", "", {}, "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="],
+
+    "cron-to-quartz": ["cron-to-quartz@1.4.7", "", {}, "sha512-d71zq3s2gwi8fvlS9fybqLC6GokWiOR5T1+q/gTqXBDKe9dsiW3pB//QSzCfRl/QRCURc5r8uNgCJzKuFv6qlg=="],
+
+    "cronstrue": ["cronstrue@3.12.0", "", { "bin": "bin/cli.js" }, "sha512-k9oiM4G7U1GEEktOGfZabldP0gtFWTsaRVqq9X06ifytr73mpSYYdt+zGZBeS5lRCsqMfq0y7oSHycWGIJSo6g=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
+    "cssstyle": ["cssstyle@4.4.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-W0Y2HOXlPkb2yaKrCVRjinYKciu/qSLEmK0K9mcfDei3zwlnHFEHAs/Du3cIRwPqY+J4JsiBzUjoHyc8RsJ03A=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-collection": ["d3-collection@1.0.7", "", {}, "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.0", "", {}, "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hexbin": ["d3-hexbin@0.2.2", "", {}, "sha512-KS3fUT2ReD4RlGCjvCEm1RgMtp2NFZumdMu4DBzQK8AZv3fXRM6Xm8I4fSU07UXvH4xxg03NwWKWdvxfS/yc4w=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-voronoi": ["d3-voronoi@1.1.4", "", {}, "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
+
+    "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
+
+    "data-view-buffer": ["data-view-buffer@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
+
+    "data-view-byte-length": ["data-view-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ=="],
+
+    "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
+
+    "dayjs": ["dayjs@1.11.13", "", {}, "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.5.0", "", {}, "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw=="],
+
+    "decode-named-character-reference": ["decode-named-character-reference@1.1.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-Wy+JTSbFThEOXQIR2L6mxJvEs+veIzpmqD7ynWxMXGpnk3smkHQOp6forLdHsKpAMW9iJpaBBIxz285t1n1C3w=="],
+
+    "dedent": ["dedent@1.6.0", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA=="],
+
+    "deep-equal": ["deep-equal@1.1.2", "", { "dependencies": { "is-arguments": "^1.1.1", "is-date-object": "^1.0.5", "is-regex": "^1.1.4", "object-is": "^1.1.5", "object-keys": "^1.1.1", "regexp.prototype.flags": "^1.5.1" } }, "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
+
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "detect-newline": ["detect-newline@3.1.0", "", {}, "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "diff": ["diff@4.0.2", "", {}, "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="],
+
+    "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "dom-walk": ["dom-walk@0.1.2", "", {}, "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
+
+    "dotenv-expand": ["dotenv-expand@12.0.3", "", { "dependencies": { "dotenv": "^16.4.5" } }, "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.286", "", {}, "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A=="],
+
+    "emittery": ["emittery@0.13.1", "", {}, "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ=="],
+
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "error-ex": ["error-ex@1.3.2", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g=="],
+
+    "es-abstract": ["es-abstract@1.24.0", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-iterator-helpers": ["es-iterator-helpers@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-abstract": "^1.23.6", "es-errors": "^1.3.0", "es-set-tostringtag": "^2.0.3", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.6", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "iterator.prototype": "^1.1.4", "safe-array-concat": "^1.1.3" } }, "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w=="],
+
+    "es-module-lexer": ["es-module-lexer@1.6.0", "", {}, "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "es-shim-unscopables": ["es-shim-unscopables@1.1.0", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw=="],
+
+    "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
+
+    "esbuild": ["esbuild@0.27.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.1", "@esbuild/android-arm": "0.27.1", "@esbuild/android-arm64": "0.27.1", "@esbuild/android-x64": "0.27.1", "@esbuild/darwin-arm64": "0.27.1", "@esbuild/darwin-x64": "0.27.1", "@esbuild/freebsd-arm64": "0.27.1", "@esbuild/freebsd-x64": "0.27.1", "@esbuild/linux-arm": "0.27.1", "@esbuild/linux-arm64": "0.27.1", "@esbuild/linux-ia32": "0.27.1", "@esbuild/linux-loong64": "0.27.1", "@esbuild/linux-mips64el": "0.27.1", "@esbuild/linux-ppc64": "0.27.1", "@esbuild/linux-riscv64": "0.27.1", "@esbuild/linux-s390x": "0.27.1", "@esbuild/linux-x64": "0.27.1", "@esbuild/netbsd-arm64": "0.27.1", "@esbuild/netbsd-x64": "0.27.1", "@esbuild/openbsd-arm64": "0.27.1", "@esbuild/openbsd-x64": "0.27.1", "@esbuild/openharmony-arm64": "0.27.1", "@esbuild/sunos-x64": "0.27.1", "@esbuild/win32-arm64": "0.27.1", "@esbuild/win32-ia32": "0.27.1", "@esbuild/win32-x64": "0.27.1" }, "bin": "bin/esbuild" }, "sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-carriage": ["escape-carriage@1.3.1", "", {}, "sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@9.39.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.2", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": "bin/eslint.js" }, "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw=="],
+
+    "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": "bin/cli.js" }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
+
+    "eslint-import-context": ["eslint-import-context@0.1.8", "", { "dependencies": { "get-tsconfig": "^4.10.1", "stable-hash-x": "^0.1.1" }, "peerDependencies": { "unrs-resolver": "^1.0.0" } }, "sha512-bq+F7nyc65sKpZGT09dY0S0QrOnQtuDVIfyTGQ8uuvtMIF7oHp6CEP3mouN0rrnYF3Jqo6Ke0BfU/5wASZue1w=="],
+
+    "eslint-import-resolver-node": ["eslint-import-resolver-node@0.3.9", "", { "dependencies": { "debug": "^3.2.7", "is-core-module": "^2.13.0", "resolve": "^1.22.4" } }, "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g=="],
+
+    "eslint-import-resolver-typescript": ["eslint-import-resolver-typescript@4.4.4", "", { "dependencies": { "debug": "^4.4.1", "eslint-import-context": "^0.1.8", "get-tsconfig": "^4.10.1", "is-bun-module": "^2.0.0", "stable-hash-x": "^0.2.0", "tinyglobby": "^0.2.14", "unrs-resolver": "^1.7.11" }, "peerDependencies": { "eslint": "*", "eslint-plugin-import": "*", "eslint-plugin-import-x": "*" }, "optionalPeers": ["eslint-plugin-import-x"] }, "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw=="],
+
+    "eslint-module-utils": ["eslint-module-utils@2.12.1", "", { "dependencies": { "debug": "^3.2.7" } }, "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw=="],
+
+    "eslint-plugin-import": ["eslint-plugin-import@2.32.0", "", { "dependencies": { "@rtsao/scc": "^1.1.0", "array-includes": "^3.1.9", "array.prototype.findlastindex": "^1.2.6", "array.prototype.flat": "^1.3.3", "array.prototype.flatmap": "^1.3.3", "debug": "^3.2.7", "doctrine": "^2.1.0", "eslint-import-resolver-node": "^0.3.9", "eslint-module-utils": "^2.12.1", "hasown": "^2.0.2", "is-core-module": "^2.16.1", "is-glob": "^4.0.3", "minimatch": "^3.1.2", "object.fromentries": "^2.0.8", "object.groupby": "^1.0.3", "object.values": "^1.2.1", "semver": "^6.3.1", "string.prototype.trimend": "^1.0.9", "tsconfig-paths": "^3.15.0" }, "peerDependencies": { "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9" } }, "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA=="],
+
+    "eslint-plugin-jsx-a11y": ["eslint-plugin-jsx-a11y@6.10.2", "", { "dependencies": { "aria-query": "^5.3.2", "array-includes": "^3.1.8", "array.prototype.flatmap": "^1.3.2", "ast-types-flow": "^0.0.8", "axe-core": "^4.10.0", "axobject-query": "^4.1.0", "damerau-levenshtein": "^1.0.8", "emoji-regex": "^9.2.2", "hasown": "^2.0.2", "jsx-ast-utils": "^3.3.5", "language-tags": "^1.0.9", "minimatch": "^3.1.2", "object.fromentries": "^2.0.8", "safe-regex-test": "^1.0.3", "string.prototype.includes": "^2.0.1" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9" } }, "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q=="],
+
+    "eslint-plugin-prettier": ["eslint-plugin-prettier@5.5.5", "", { "dependencies": { "prettier-linter-helpers": "^1.0.1", "synckit": "^0.11.12" }, "peerDependencies": { "@types/eslint": ">=8.0.0", "eslint": ">=8.0.0", "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0", "prettier": ">=3.0.0" }, "optionalPeers": ["@types/eslint"] }, "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw=="],
+
+    "eslint-plugin-react": ["eslint-plugin-react@7.37.5", "", { "dependencies": { "array-includes": "^3.1.8", "array.prototype.findlast": "^1.2.5", "array.prototype.flatmap": "^1.3.3", "array.prototype.tosorted": "^1.1.4", "doctrine": "^2.1.0", "es-iterator-helpers": "^1.2.1", "estraverse": "^5.3.0", "hasown": "^2.0.2", "jsx-ast-utils": "^2.4.1 || ^3.0.0", "minimatch": "^3.1.2", "object.entries": "^1.1.9", "object.fromentries": "^2.0.8", "object.values": "^1.2.1", "prop-types": "^15.8.1", "resolve": "^2.0.0-next.5", "semver": "^6.3.1", "string.prototype.matchall": "^4.0.12", "string.prototype.repeat": "^1.0.0" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7" } }, "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA=="],
+
+    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.0.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0" } }, "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA=="],
+
+    "eslint-plugin-react-refresh": ["eslint-plugin-react-refresh@0.5.2", "", { "peerDependencies": { "eslint": "^9 || ^10" } }, "sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA=="],
+
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "bin/esparse.js", "esvalidate": "bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "esquery": ["esquery@1.6.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
+
+    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
+
+    "exit-x": ["exit-x@0.2.2", "", {}, "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ=="],
+
+    "expect": ["expect@30.2.0", "", { "dependencies": { "@jest/expect-utils": "30.2.0", "@jest/get-type": "30.1.0", "jest-matcher-utils": "30.2.0", "jest-message-util": "30.2.0", "jest-mock": "30.2.0", "jest-util": "30.2.0" } }, "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-diff": ["fast-diff@1.3.0", "", {}, "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
+
+    "fb-watchman": ["fb-watchman@2.0.2", "", { "dependencies": { "bser": "2.1.1" } }, "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
+
+    "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
+
+    "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "function.prototype.name": ["function.prototype.name@1.1.8", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "functions-have-names": "^1.2.3", "hasown": "^2.0.2", "is-callable": "^1.2.7" } }, "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q=="],
+
+    "functions-have-names": ["functions-have-names@1.2.3", "", {}, "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-package-type": ["get-package-type@0.1.0", "", {}, "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
+
+    "get-symbol-description": ["get-symbol-description@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg=="],
+
+    "get-tsconfig": ["get-tsconfig@4.10.1", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ=="],
+
+    "github-markdown-css": ["github-markdown-css@5.9.0", "", {}, "sha512-tmT5sY+zvg2302XLYEfH2mtkViIM1SWf2nvYoF5N1ZsO0V6B2qZTiw3GOzw4vpjLygK/KG35qRlPFweHqfzz5w=="],
+
+    "glob": ["glob@10.4.5", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": "dist/esm/bin.mjs" }, "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "global": ["global@4.4.0", "", { "dependencies": { "min-document": "^2.19.0", "process": "^0.11.10" } }, "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w=="],
+
+    "globals": ["globals@17.3.0", "", {}, "sha512-yMqGUQVVCkD4tqjOJf3TnrvaaHDMYp4VlUSObbkIiuCPe/ofdMBFIAcBbCSRFWOnos6qRiTVStDwqPLUclaxIw=="],
+
+    "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
+
+    "globrex": ["globrex@0.1.2", "", {}, "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "handlebars": ["handlebars@4.7.8", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": "bin/handlebars" }, "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ=="],
+
+    "harmony-reflect": ["harmony-reflect@1.6.2", "", {}, "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g=="],
+
+    "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
+
+    "has-proto": ["has-proto@1.2.0", "", { "dependencies": { "dunder-proto": "^1.0.0" } }, "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
+
+    "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
+
+    "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
+
+    "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
+
+    "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
+
+    "hcl2-parser": ["hcl2-parser@1.0.3", "", {}, "sha512-NQUm/BFF+2nrBfeqDhhsy4DxxiLHgkeE3FywtjFiXnjSUaio3w4Tz1MQ3vGJBUhyArzOXJ24pO7JwE5LAn7Ncg=="],
+
+    "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
+
+    "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
+
+    "html-dom-parser": ["html-dom-parser@5.1.8", "", { "dependencies": { "domhandler": "5.0.3", "htmlparser2": "10.1.0" } }, "sha512-MCIUng//mF2qTtGHXJWr6OLfHWmg3Pm8ezpfiltF83tizPWY17JxT4dRLE8lykJ5bChJELoY3onQKPbufJHxYA=="],
+
+    "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
+    "html-react-parser": ["html-react-parser@5.2.17", "", { "dependencies": { "domhandler": "5.0.3", "html-dom-parser": "5.1.8", "react-property": "2.0.2", "style-to-js": "1.1.21" }, "peerDependencies": { "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19", "react": "0.14 || 15 || 16 || 17 || 18 || 19" } }, "sha512-m+K/7Moq1jodAB4VL0RXSOmtwLUYoAsikZhwd+hGQe5Vtw2dbWfpFd60poxojMU0Tsh9w59mN1QLEcoHz0Dx9w=="],
+
+    "html-to-image": ["html-to-image@1.11.13", "", {}, "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg=="],
+
+    "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "identity-obj-proxy": ["identity-obj-proxy@3.0.0", "", { "dependencies": { "harmony-reflect": "^1.4.6" } }, "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "import-local": ["import-local@3.2.0", "", { "dependencies": { "pkg-dir": "^4.2.0", "resolve-cwd": "^3.0.0" }, "bin": { "import-local-fixture": "fixtures/cli.js" } }, "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
+    "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+
+    "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
+
+    "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
+
+    "is-arguments": ["is-arguments@1.2.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA=="],
+
+    "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
+
+    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
+    "is-async-function": ["is-async-function@2.1.1", "", { "dependencies": { "async-function": "^1.0.0", "call-bound": "^1.0.3", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ=="],
+
+    "is-bigint": ["is-bigint@1.1.0", "", { "dependencies": { "has-bigints": "^1.0.2" } }, "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ=="],
+
+    "is-boolean-object": ["is-boolean-object@1.2.2", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A=="],
+
+    "is-bun-module": ["is-bun-module@2.0.0", "", { "dependencies": { "semver": "^7.7.1" } }, "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ=="],
+
+    "is-callable": ["is-callable@1.2.7", "", {}, "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="],
+
+    "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
+
+    "is-data-view": ["is-data-view@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "is-typed-array": "^1.1.13" } }, "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw=="],
+
+    "is-date-object": ["is-date-object@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg=="],
+
+    "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
+
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-generator-fn": ["is-generator-fn@2.1.0", "", {}, "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ=="],
+
+    "is-generator-function": ["is-generator-function@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "get-proto": "^1.0.0", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
+    "is-map": ["is-map@2.0.3", "", {}, "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="],
+
+    "is-mobile": ["is-mobile@5.0.0", "", {}, "sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ=="],
+
+    "is-negative-zero": ["is-negative-zero@2.0.3", "", {}, "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-number-object": ["is-number-object@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
+
+    "is-set": ["is-set@2.0.3", "", {}, "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg=="],
+
+    "is-shared-array-buffer": ["is-shared-array-buffer@1.0.4", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A=="],
+
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "is-string": ["is-string@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA=="],
+
+    "is-symbol": ["is-symbol@1.1.1", "", { "dependencies": { "call-bound": "^1.0.2", "has-symbols": "^1.1.0", "safe-regex-test": "^1.1.0" } }, "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w=="],
+
+    "is-typed-array": ["is-typed-array@1.1.15", "", { "dependencies": { "which-typed-array": "^1.1.16" } }, "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ=="],
+
+    "is-weakmap": ["is-weakmap@2.0.2", "", {}, "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w=="],
+
+    "is-weakref": ["is-weakref@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew=="],
+
+    "is-weakset": ["is-weakset@2.0.4", "", { "dependencies": { "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ=="],
+
+    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
+    "isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-instrument": ["istanbul-lib-instrument@6.0.3", "", { "dependencies": { "@babel/core": "^7.23.9", "@babel/parser": "^7.23.9", "@istanbuljs/schema": "^0.1.3", "istanbul-lib-coverage": "^3.2.0", "semver": "^7.5.4" } }, "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-lib-source-maps": ["istanbul-lib-source-maps@5.0.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.23", "debug": "^4.1.1", "istanbul-lib-coverage": "^3.0.0" } }, "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A=="],
+
+    "istanbul-reports": ["istanbul-reports@3.1.7", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g=="],
+
+    "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "jest": ["jest@30.2.0", "", { "dependencies": { "@jest/core": "30.2.0", "@jest/types": "30.2.0", "import-local": "^3.2.0", "jest-cli": "30.2.0" }, "peerDependencies": { "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0" }, "optionalPeers": ["node-notifier"], "bin": "bin/jest.js" }, "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A=="],
+
+    "jest-changed-files": ["jest-changed-files@30.2.0", "", { "dependencies": { "execa": "^5.1.1", "jest-util": "30.2.0", "p-limit": "^3.1.0" } }, "sha512-L8lR1ChrRnSdfeOvTrwZMlnWV8G/LLjQ0nG9MBclwWZidA2N5FviRki0Bvh20WRMOX31/JYvzdqTJrk5oBdydQ=="],
+
+    "jest-circus": ["jest-circus@30.2.0", "", { "dependencies": { "@jest/environment": "30.2.0", "@jest/expect": "30.2.0", "@jest/test-result": "30.2.0", "@jest/types": "30.2.0", "@types/node": "*", "chalk": "^4.1.2", "co": "^4.6.0", "dedent": "^1.6.0", "is-generator-fn": "^2.1.0", "jest-each": "30.2.0", "jest-matcher-utils": "30.2.0", "jest-message-util": "30.2.0", "jest-runtime": "30.2.0", "jest-snapshot": "30.2.0", "jest-util": "30.2.0", "p-limit": "^3.1.0", "pretty-format": "30.2.0", "pure-rand": "^7.0.0", "slash": "^3.0.0", "stack-utils": "^2.0.6" } }, "sha512-Fh0096NC3ZkFx05EP2OXCxJAREVxj1BcW/i6EWqqymcgYKWjyyDpral3fMxVcHXg6oZM7iULer9wGRFvfpl+Tg=="],
+
+    "jest-cli": ["jest-cli@30.2.0", "", { "dependencies": { "@jest/core": "30.2.0", "@jest/test-result": "30.2.0", "@jest/types": "30.2.0", "chalk": "^4.1.2", "exit-x": "^0.2.2", "import-local": "^3.2.0", "jest-config": "30.2.0", "jest-util": "30.2.0", "jest-validate": "30.2.0", "yargs": "^17.7.2" }, "peerDependencies": { "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0" }, "optionalPeers": ["node-notifier"], "bin": { "jest": "bin/jest.js" } }, "sha512-Os9ukIvADX/A9sLt6Zse3+nmHtHaE6hqOsjQtNiugFTbKRHYIYtZXNGNK9NChseXy7djFPjndX1tL0sCTlfpAA=="],
+
+    "jest-config": ["jest-config@30.2.0", "", { "dependencies": { "@babel/core": "^7.27.4", "@jest/get-type": "30.1.0", "@jest/pattern": "30.0.1", "@jest/test-sequencer": "30.2.0", "@jest/types": "30.2.0", "babel-jest": "30.2.0", "chalk": "^4.1.2", "ci-info": "^4.2.0", "deepmerge": "^4.3.1", "glob": "^10.3.10", "graceful-fs": "^4.2.11", "jest-circus": "30.2.0", "jest-docblock": "30.2.0", "jest-environment-node": "30.2.0", "jest-regex-util": "30.0.1", "jest-resolve": "30.2.0", "jest-runner": "30.2.0", "jest-util": "30.2.0", "jest-validate": "30.2.0", "micromatch": "^4.0.8", "parse-json": "^5.2.0", "pretty-format": "30.2.0", "slash": "^3.0.0", "strip-json-comments": "^3.1.1" }, "peerDependencies": { "@types/node": "*", "esbuild-register": ">=3.4.0", "ts-node": ">=9.0.0" }, "optionalPeers": ["esbuild-register"] }, "sha512-g4WkyzFQVWHtu6uqGmQR4CQxz/CH3yDSlhzXMWzNjDx843gYjReZnMRanjRCq5XZFuQrGDxgUaiYWE8BRfVckA=="],
+
+    "jest-diff": ["jest-diff@30.2.0", "", { "dependencies": { "@jest/diff-sequences": "30.0.1", "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "pretty-format": "30.2.0" } }, "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A=="],
+
+    "jest-docblock": ["jest-docblock@30.2.0", "", { "dependencies": { "detect-newline": "^3.1.0" } }, "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA=="],
+
+    "jest-each": ["jest-each@30.2.0", "", { "dependencies": { "@jest/get-type": "30.1.0", "@jest/types": "30.2.0", "chalk": "^4.1.2", "jest-util": "30.2.0", "pretty-format": "30.2.0" } }, "sha512-lpWlJlM7bCUf1mfmuqTA8+j2lNURW9eNafOy99knBM01i5CQeY5UH1vZjgT9071nDJac1M4XsbyI44oNOdhlDQ=="],
+
+    "jest-environment-jsdom": ["jest-environment-jsdom@30.2.0", "", { "dependencies": { "@jest/environment": "30.2.0", "@jest/environment-jsdom-abstract": "30.2.0", "@types/jsdom": "^21.1.7", "@types/node": "*", "jsdom": "^26.1.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-zbBTiqr2Vl78pKp/laGBREYzbZx9ZtqPjOK4++lL4BNDhxRnahg51HtoDrk9/VjIy9IthNEWdKVd7H5bqBhiWQ=="],
+
+    "jest-environment-node": ["jest-environment-node@30.2.0", "", { "dependencies": { "@jest/environment": "30.2.0", "@jest/fake-timers": "30.2.0", "@jest/types": "30.2.0", "@types/node": "*", "jest-mock": "30.2.0", "jest-util": "30.2.0", "jest-validate": "30.2.0" } }, "sha512-ElU8v92QJ9UrYsKrxDIKCxu6PfNj4Hdcktcn0JX12zqNdqWHB0N+hwOnnBBXvjLd2vApZtuLUGs1QSY+MsXoNA=="],
+
+    "jest-haste-map": ["jest-haste-map@30.2.0", "", { "dependencies": { "@jest/types": "30.2.0", "@types/node": "*", "anymatch": "^3.1.3", "fb-watchman": "^2.0.2", "graceful-fs": "^4.2.11", "jest-regex-util": "30.0.1", "jest-util": "30.2.0", "jest-worker": "30.2.0", "micromatch": "^4.0.8", "walker": "^1.0.8" }, "optionalDependencies": { "fsevents": "^2.3.3" } }, "sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw=="],
+
+    "jest-leak-detector": ["jest-leak-detector@30.2.0", "", { "dependencies": { "@jest/get-type": "30.1.0", "pretty-format": "30.2.0" } }, "sha512-M6jKAjyzjHG0SrQgwhgZGy9hFazcudwCNovY/9HPIicmNSBuockPSedAP9vlPK6ONFJ1zfyH/M2/YYJxOz5cdQ=="],
+
+    "jest-matcher-utils": ["jest-matcher-utils@30.2.0", "", { "dependencies": { "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "jest-diff": "30.2.0", "pretty-format": "30.2.0" } }, "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg=="],
+
+    "jest-message-util": ["jest-message-util@30.2.0", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@jest/types": "30.2.0", "@types/stack-utils": "^2.0.3", "chalk": "^4.1.2", "graceful-fs": "^4.2.11", "micromatch": "^4.0.8", "pretty-format": "30.2.0", "slash": "^3.0.0", "stack-utils": "^2.0.6" } }, "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw=="],
+
+    "jest-mock": ["jest-mock@30.2.0", "", { "dependencies": { "@jest/types": "30.2.0", "@types/node": "*", "jest-util": "30.2.0" } }, "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw=="],
+
+    "jest-pnp-resolver": ["jest-pnp-resolver@1.2.3", "", { "peerDependencies": { "jest-resolve": "*" } }, "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w=="],
+
+    "jest-regex-util": ["jest-regex-util@30.0.1", "", {}, "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA=="],
+
+    "jest-resolve": ["jest-resolve@30.2.0", "", { "dependencies": { "chalk": "^4.1.2", "graceful-fs": "^4.2.11", "jest-haste-map": "30.2.0", "jest-pnp-resolver": "^1.2.3", "jest-util": "30.2.0", "jest-validate": "30.2.0", "slash": "^3.0.0", "unrs-resolver": "^1.7.11" } }, "sha512-TCrHSxPlx3tBY3hWNtRQKbtgLhsXa1WmbJEqBlTBrGafd5fiQFByy2GNCEoGR+Tns8d15GaL9cxEzKOO3GEb2A=="],
+
+    "jest-resolve-dependencies": ["jest-resolve-dependencies@30.2.0", "", { "dependencies": { "jest-regex-util": "30.0.1", "jest-snapshot": "30.2.0" } }, "sha512-xTOIGug/0RmIe3mmCqCT95yO0vj6JURrn1TKWlNbhiAefJRWINNPgwVkrVgt/YaerPzY3iItufd80v3lOrFJ2w=="],
+
+    "jest-runner": ["jest-runner@30.2.0", "", { "dependencies": { "@jest/console": "30.2.0", "@jest/environment": "30.2.0", "@jest/test-result": "30.2.0", "@jest/transform": "30.2.0", "@jest/types": "30.2.0", "@types/node": "*", "chalk": "^4.1.2", "emittery": "^0.13.1", "exit-x": "^0.2.2", "graceful-fs": "^4.2.11", "jest-docblock": "30.2.0", "jest-environment-node": "30.2.0", "jest-haste-map": "30.2.0", "jest-leak-detector": "30.2.0", "jest-message-util": "30.2.0", "jest-resolve": "30.2.0", "jest-runtime": "30.2.0", "jest-util": "30.2.0", "jest-watcher": "30.2.0", "jest-worker": "30.2.0", "p-limit": "^3.1.0", "source-map-support": "0.5.13" } }, "sha512-PqvZ2B2XEyPEbclp+gV6KO/F1FIFSbIwewRgmROCMBo/aZ6J1w8Qypoj2pEOcg3G2HzLlaP6VUtvwCI8dM3oqQ=="],
+
+    "jest-runtime": ["jest-runtime@30.2.0", "", { "dependencies": { "@jest/environment": "30.2.0", "@jest/fake-timers": "30.2.0", "@jest/globals": "30.2.0", "@jest/source-map": "30.0.1", "@jest/test-result": "30.2.0", "@jest/transform": "30.2.0", "@jest/types": "30.2.0", "@types/node": "*", "chalk": "^4.1.2", "cjs-module-lexer": "^2.1.0", "collect-v8-coverage": "^1.0.2", "glob": "^10.3.10", "graceful-fs": "^4.2.11", "jest-haste-map": "30.2.0", "jest-message-util": "30.2.0", "jest-mock": "30.2.0", "jest-regex-util": "30.0.1", "jest-resolve": "30.2.0", "jest-snapshot": "30.2.0", "jest-util": "30.2.0", "slash": "^3.0.0", "strip-bom": "^4.0.0" } }, "sha512-p1+GVX/PJqTucvsmERPMgCPvQJpFt4hFbM+VN3n8TMo47decMUcJbt+rgzwrEme0MQUA/R+1de2axftTHkKckg=="],
+
+    "jest-snapshot": ["jest-snapshot@30.2.0", "", { "dependencies": { "@babel/core": "^7.27.4", "@babel/generator": "^7.27.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/types": "^7.27.3", "@jest/expect-utils": "30.2.0", "@jest/get-type": "30.1.0", "@jest/snapshot-utils": "30.2.0", "@jest/transform": "30.2.0", "@jest/types": "30.2.0", "babel-preset-current-node-syntax": "^1.2.0", "chalk": "^4.1.2", "expect": "30.2.0", "graceful-fs": "^4.2.11", "jest-diff": "30.2.0", "jest-matcher-utils": "30.2.0", "jest-message-util": "30.2.0", "jest-util": "30.2.0", "pretty-format": "30.2.0", "semver": "^7.7.2", "synckit": "^0.11.8" } }, "sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA=="],
+
+    "jest-transformer-svg": ["jest-transformer-svg@2.1.0", "", { "peerDependencies": { "jest": ">= 28.1.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-UqROTC1szruaDJENDeU95NPQztTTjE02R5Gzxydh+ylahwli7DlkYPGifnH+fc8bNVy905m2HqhPNgwx+Q5TBg=="],
+
+    "jest-util": ["jest-util@30.2.0", "", { "dependencies": { "@jest/types": "30.2.0", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.2" } }, "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA=="],
+
+    "jest-validate": ["jest-validate@30.2.0", "", { "dependencies": { "@jest/get-type": "30.1.0", "@jest/types": "30.2.0", "camelcase": "^6.3.0", "chalk": "^4.1.2", "leven": "^3.1.0", "pretty-format": "30.2.0" } }, "sha512-FBGWi7dP2hpdi8nBoWxSsLvBFewKAg0+uSQwBaof4Y4DPgBabXgpSYC5/lR7VmnIlSpASmCi/ntRWPbv7089Pw=="],
+
+    "jest-watcher": ["jest-watcher@30.2.0", "", { "dependencies": { "@jest/test-result": "30.2.0", "@jest/types": "30.2.0", "@types/node": "*", "ansi-escapes": "^4.3.2", "chalk": "^4.1.2", "emittery": "^0.13.1", "jest-util": "30.2.0", "string-length": "^4.0.2" } }, "sha512-PYxa28dxJ9g777pGm/7PrbnMeA0Jr7osHP9bS7eJy9DuAjMgdGtxgf0uKMyoIsTWAkIbUW5hSDdJ3urmgXBqxg=="],
+
+    "jest-worker": ["jest-worker@30.2.0", "", { "dependencies": { "@types/node": "*", "@ungap/structured-clone": "^1.3.0", "jest-util": "30.2.0", "merge-stream": "^2.0.0", "supports-color": "^8.1.1" } }, "sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": "bin/js-yaml.js" }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
+
+    "jsdom": ["jsdom@26.1.0", "", { "dependencies": { "cssstyle": "^4.2.1", "data-urls": "^5.0.0", "decimal.js": "^10.5.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.16", "parse5": "^7.2.1", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.1.1", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.1.1", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": "bin/jsesc" }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "json2mq": ["json2mq@0.2.0", "", { "dependencies": { "string-convert": "^0.2.0" } }, "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": "lib/cli.js" }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
+
+    "jwt-decode": ["jwt-decode@4.0.0", "", {}, "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "language-subtag-registry": ["language-subtag-registry@0.3.23", "", {}, "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="],
+
+    "language-tags": ["language-tags@1.0.9", "", { "dependencies": { "language-subtag-registry": "^0.3.20" } }, "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA=="],
+
+    "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "linkify-it": ["linkify-it@3.0.3", "", { "dependencies": { "uc.micro": "^1.0.1" } }, "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ=="],
+
+    "loader-utils": ["loader-utils@3.3.1", "", {}, "sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
+
+    "lodash.memoize": ["lodash.memoize@4.1.2", "", {}, "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": "cli.js" }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": "bin/bin.js" }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
+
+    "make-error": ["make-error@1.3.6", "", {}, "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="],
+
+    "makeerror": ["makeerror@1.0.12", "", { "dependencies": { "tmpl": "1.0.5" } }, "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg=="],
+
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
+
+    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
+
+    "mdast-util-mdx-jsx": ["mdast-util-mdx-jsx@3.2.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-stringify-position": "^4.0.0", "vfile-message": "^4.0.0" } }, "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q=="],
+
+    "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
+
+    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
+    "min-document": ["min-document@2.19.1", "", { "dependencies": { "dom-walk": "^0.1.0" } }, "sha512-8lqe85PkqQJzIcs2iD7xW/WSxcncC3/DPVbTOafKNJDIMXwGfwXS350mH4SJslomntN2iYtFBuC0yNO3CEap6g=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
+    "minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "napi-postinstall": ["napi-postinstall@0.2.4", "", { "bin": "lib/cli.js" }, "sha512-ZEzHJwBhZ8qQSbknHqYcdtQVr8zUgGyM/q6h6qAyhtyVMNrSgDhrC4disf03dYW0e+czXyLnZINnCTEkWy0eJg=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
+
+    "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
+
+    "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
+
+    "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
+
+    "nwsapi": ["nwsapi@2.2.20", "", {}, "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "object-is": ["object-is@1.1.6", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1" } }, "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q=="],
+
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
+    "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
+
+    "object.entries": ["object.entries@1.1.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-object-atoms": "^1.1.1" } }, "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw=="],
+
+    "object.fromentries": ["object.fromentries@2.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.2", "es-object-atoms": "^1.0.0" } }, "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ=="],
+
+    "object.groupby": ["object.groupby@1.0.3", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.2" } }, "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ=="],
+
+    "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
+
+    "oidc-client-ts": ["oidc-client-ts@3.4.1", "", { "dependencies": { "jwt-decode": "^4.0.0" } }, "sha512-jNdst/U28Iasukx/L5MP6b274Vr7ftQs6qAhPBCvz6Wt5rPCA+Q/tUmCzfCHHWweWw5szeMy2Gfrm1rITwUKrw=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
+    "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
+
+    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
+    "parse5": ["parse5@7.2.1", "", { "dependencies": { "entities": "^4.5.0" } }, "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "performance-now": ["performance-now@0.2.0", "", {}, "sha512-YHk5ez1hmMR5LOkb9iJkLKqoBlL7WD5M8ljC75ZfzXriuBIVNuecaXuU7e+hOwyqf24Wxhh7Vxgt7Hnw9288Tg=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
+
+    "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
+
+    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@3.8.1", "", { "bin": "bin/prettier.cjs" }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
+
+    "prettier-linter-helpers": ["prettier-linter-helpers@1.0.1", "", { "dependencies": { "fast-diff": "^1.1.2" } }, "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
+    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
+
+    "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
+    "property-information": ["property-information@7.0.0", "", {}, "sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "pure-rand": ["pure-rand@7.0.1", "", {}, "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "raf": ["raf@3.4.1", "", { "dependencies": { "performance-now": "^2.1.0" } }, "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA=="],
+
+    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
+
+    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+
+    "react-icons": ["react-icons@5.5.0", "", { "peerDependencies": { "react": "*" } }, "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "react-js-cron": ["react-js-cron@5.2.0", "", { "peerDependencies": { "antd": ">=5.8.0", "react": ">=17.0.0", "react-dom": ">=17.0.0" } }, "sha512-+Mxm3cS7qmIoAIz7NVY27jvsJKNZ4tx+H/nNtMUJW4DcKR7jUIL1GP0jOD79K5j86Dq8jvShKJMh30+c8bmVtA=="],
+
+    "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
+
+    "react-motion": ["react-motion@0.5.2", "", { "dependencies": { "performance-now": "^0.2.0", "prop-types": "^15.5.8", "raf": "^3.1.0" }, "peerDependencies": { "react": "^0.14.9 || ^15.3.0 || ^16.0.0" } }, "sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ=="],
+
+    "react-oidc-context": ["react-oidc-context@3.3.0", "", { "peerDependencies": { "oidc-client-ts": "^3.1.0", "react": ">=16.14.0" } }, "sha512-302T/ma4AOVAxrHdYctDSKXjCq9KNHT564XEO2yOPxRfxEP58xa4nz+GQinNl8x7CnEXECSM5JEjQJk3Cr5BvA=="],
+
+    "react-property": ["react-property@2.0.2", "", {}, "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="],
+
+    "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
+
+    "react-router": ["react-router@7.13.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw=="],
+
+    "react-router-dom": ["react-router-dom@7.13.0", "", { "dependencies": { "react-router": "7.13.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g=="],
+
+    "react-vis": ["react-vis@1.12.1", "", { "dependencies": { "d3-array": "^3.2.1", "d3-collection": "^1.0.7", "d3-color": "^3.1.0", "d3-contour": "^4.0.0", "d3-format": "^3.1.0", "d3-geo": "^3.1.0", "d3-hexbin": "^0.2.2", "d3-hierarchy": "^3.1.2", "d3-interpolate": "^3.0.1", "d3-sankey": "^0.12.3", "d3-scale": "^4.0.2", "d3-shape": "^3.2.0", "d3-voronoi": "^1.1.4", "deep-equal": "^1.0.1", "global": "^4.3.1", "prop-types": "^15.5.8", "react-motion": "^0.5.2" }, "peerDependencies": { "react": "^16.8.3", "react-dom": "^16.8.3" } }, "sha512-vH7ihTPlBD6wBuzwPoipheyJnx46kKKMXnVqdk4mv5vq+bJVC6JRYdRZSofa2030+kko99rSq/idnYnNWGr6zA=="],
+
+    "reactflow": ["reactflow@11.11.4", "", { "dependencies": { "@reactflow/background": "11.3.14", "@reactflow/controls": "11.2.14", "@reactflow/core": "11.11.4", "@reactflow/minimap": "11.7.14", "@reactflow/node-resizer": "2.2.14", "@reactflow/node-toolbar": "1.3.14" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og=="],
+
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
+
+    "regenerate": ["regenerate@1.4.2", "", {}, "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="],
+
+    "regenerate-unicode-properties": ["regenerate-unicode-properties@10.2.2", "", { "dependencies": { "regenerate": "^1.4.2" } }, "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g=="],
+
+    "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
+
+    "regexpu-core": ["regexpu-core@6.4.0", "", { "dependencies": { "regenerate": "^1.4.2", "regenerate-unicode-properties": "^10.2.2", "regjsgen": "^0.8.0", "regjsparser": "^0.13.0", "unicode-match-property-ecmascript": "^2.0.0", "unicode-match-property-value-ecmascript": "^2.2.1" } }, "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA=="],
+
+    "regjsgen": ["regjsgen@0.8.0", "", {}, "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q=="],
+
+    "regjsparser": ["regjsparser@0.13.0", "", { "dependencies": { "jsesc": "~3.1.0" }, "bin": "bin/parser" }, "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q=="],
+
+    "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
+
+    "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
+    "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "remark-rehype": ["remark-rehype@11.1.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-g/osARvjkBXb6Wo0XvAeXQohVta8i84ACbenPpoSsxTOQH/Ae0/RGP4WZgnMH5pMLpsj4FG7OHmcIcXxpza8eQ=="],
+
+    "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": "bin/resolve" }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
+
+    "resolve-cwd": ["resolve-cwd@3.0.0", "", { "dependencies": { "resolve-from": "^5.0.0" } }, "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rollup": ["rollup@4.46.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.46.2", "@rollup/rollup-android-arm64": "4.46.2", "@rollup/rollup-darwin-arm64": "4.46.2", "@rollup/rollup-darwin-x64": "4.46.2", "@rollup/rollup-freebsd-arm64": "4.46.2", "@rollup/rollup-freebsd-x64": "4.46.2", "@rollup/rollup-linux-arm-gnueabihf": "4.46.2", "@rollup/rollup-linux-arm-musleabihf": "4.46.2", "@rollup/rollup-linux-arm64-gnu": "4.46.2", "@rollup/rollup-linux-arm64-musl": "4.46.2", "@rollup/rollup-linux-loongarch64-gnu": "4.46.2", "@rollup/rollup-linux-ppc64-gnu": "4.46.2", "@rollup/rollup-linux-riscv64-gnu": "4.46.2", "@rollup/rollup-linux-riscv64-musl": "4.46.2", "@rollup/rollup-linux-s390x-gnu": "4.46.2", "@rollup/rollup-linux-x64-gnu": "4.46.2", "@rollup/rollup-linux-x64-musl": "4.46.2", "@rollup/rollup-win32-arm64-msvc": "4.46.2", "@rollup/rollup-win32-ia32-msvc": "4.46.2", "@rollup/rollup-win32-x64-msvc": "4.46.2", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg=="],
+
+    "rollup-plugin-visualizer": ["rollup-plugin-visualizer@7.0.0", "", { "dependencies": { "open": "^11.0.0", "picomatch": "^4.0.2", "source-map": "^0.7.4", "yargs": "^18.0.0" }, "peerDependencies": { "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc", "rollup": "2.x || 3.x || 4.x" }, "optionalPeers": ["rolldown", "rollup"], "bin": { "rollup-plugin-visualizer": "dist/bin/cli.js" } }, "sha512-loo4kmhTg7GMO0hqaUv/azvLPUT2B4jXU3gNMG35gm1mWKpOzhV6rspb/Mqmsfg7oOTdkzdmOckCIwGB5Ca1CA=="],
+
+    "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q=="],
+
+    "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
+
+    "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "scroll-into-view-if-needed": ["scroll-into-view-if-needed@3.1.0", "", { "dependencies": { "compute-scroll-into-view": "^3.0.2" } }, "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
+
+    "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
+
+    "set-function-name": ["set-function-name@2.0.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2" } }, "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ=="],
+
+    "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+
+    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "source-map-support": ["source-map-support@0.5.13", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "stable-hash-x": ["stable-hash-x@0.2.0", "", {}, "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ=="],
+
+    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
+    "state-local": ["state-local@1.0.7", "", {}, "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="],
+
+    "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
+
+    "string-convert": ["string-convert@0.2.1", "", {}, "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="],
+
+    "string-length": ["string-length@4.0.2", "", { "dependencies": { "char-regex": "^1.0.2", "strip-ansi": "^6.0.0" } }, "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ=="],
+
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string.prototype.includes": ["string.prototype.includes@2.0.1", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.3" } }, "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg=="],
+
+    "string.prototype.matchall": ["string.prototype.matchall@4.0.12", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-abstract": "^1.23.6", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "regexp.prototype.flags": "^1.5.3", "set-function-name": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA=="],
+
+    "string.prototype.repeat": ["string.prototype.repeat@1.0.0", "", { "dependencies": { "define-properties": "^1.1.3", "es-abstract": "^1.17.5" } }, "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w=="],
+
+    "string.prototype.trim": ["string.prototype.trim@1.2.10", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "define-data-property": "^1.1.4", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-object-atoms": "^1.0.0", "has-property-descriptors": "^1.0.2" } }, "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA=="],
+
+    "string.prototype.trimend": ["string.prototype.trimend@1.0.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ=="],
+
+    "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
+
+    "strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
+
+    "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
+
+    "stylis": ["stylis@4.3.6", "", {}, "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "synckit": ["synckit@0.11.12", "", { "dependencies": { "@pkgr/core": "^0.2.9" } }, "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ=="],
+
+    "test-exclude": ["test-exclude@6.0.0", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^7.1.4", "minimatch": "^3.0.4" } }, "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w=="],
+
+    "throttle-debounce": ["throttle-debounce@5.0.2", "", {}, "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A=="],
+
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": "bin/cli.js" }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
+
+    "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
+
+    "tmpl": ["tmpl@1.0.5", "", {}, "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
+
+    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
+
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
+    "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
+
+    "ts-jest": ["ts-jest@29.4.6", "", { "dependencies": { "bs-logger": "^0.2.6", "fast-json-stable-stringify": "^2.1.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "lodash.memoize": "^4.1.2", "make-error": "^1.3.6", "semver": "^7.7.3", "type-fest": "^4.41.0", "yargs-parser": "^21.1.1" }, "peerDependencies": { "@babel/core": ">=7.0.0-beta.0 <8", "@jest/transform": "^29.0.0 || ^30.0.0", "@jest/types": "^29.0.0 || ^30.0.0", "babel-jest": "^29.0.0 || ^30.0.0", "jest": "^29.0.0 || ^30.0.0", "jest-util": "^29.0.0 || ^30.0.0", "typescript": ">=4.3 <6" }, "bin": "cli.js" }, "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA=="],
+
+    "ts-node": ["ts-node@10.9.2", "", { "dependencies": { "@cspotcode/source-map-support": "^0.8.0", "@tsconfig/node10": "^1.0.7", "@tsconfig/node12": "^1.0.7", "@tsconfig/node14": "^1.0.0", "@tsconfig/node16": "^1.0.2", "acorn": "^8.4.1", "acorn-walk": "^8.1.1", "arg": "^4.1.0", "create-require": "^1.1.0", "diff": "^4.0.1", "make-error": "^1.1.1", "v8-compile-cache-lib": "^3.0.1", "yn": "3.1.1" }, "peerDependencies": { "@swc/core": ">=1.2.50", "@swc/wasm": ">=1.2.50", "@types/node": "*", "typescript": ">=2.7" }, "optionalPeers": ["@swc/core", "@swc/wasm"], "bin": { "ts-node": "dist/bin.js", "ts-node-cwd": "dist/bin-cwd.js", "ts-node-esm": "dist/bin-esm.js", "ts-node-script": "dist/bin-script.js", "ts-node-transpile-only": "dist/bin-transpile.js", "ts-script": "dist/bin-script-deprecated.js" } }, "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ=="],
+
+    "tsconfck": ["tsconfck@3.1.5", "", { "peerDependencies": { "typescript": "^5.0.0" }, "bin": "bin/tsconfck.js" }, "sha512-CLDfGgUp7XPswWnezWwsCRxNmgQjhYq3VXHM0/XIRxhVrKw0M1if9agzryh1QS3nxjCROvV+xWxoJO1YctzzWg=="],
+
+    "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-detect": ["type-detect@4.0.8", "", {}, "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="],
+
+    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
+
+    "typed-array-byte-length": ["typed-array-byte-length@1.0.3", "", { "dependencies": { "call-bind": "^1.0.8", "for-each": "^0.3.3", "gopd": "^1.2.0", "has-proto": "^1.2.0", "is-typed-array": "^1.1.14" } }, "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg=="],
+
+    "typed-array-byte-offset": ["typed-array-byte-offset@1.0.4", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "for-each": "^0.3.3", "gopd": "^1.2.0", "has-proto": "^1.2.0", "is-typed-array": "^1.1.15", "reflect.getprototypeof": "^1.0.9" } }, "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ=="],
+
+    "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "typescript-eslint": ["typescript-eslint@8.56.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.56.1", "@typescript-eslint/parser": "8.56.1", "@typescript-eslint/typescript-estree": "8.56.1", "@typescript-eslint/utils": "8.56.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ=="],
+
+    "uc.micro": ["uc.micro@1.0.6", "", {}, "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="],
+
+    "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
+
+    "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "unicode-canonical-property-names-ecmascript": ["unicode-canonical-property-names-ecmascript@2.0.1", "", {}, "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg=="],
+
+    "unicode-match-property-ecmascript": ["unicode-match-property-ecmascript@2.0.0", "", { "dependencies": { "unicode-canonical-property-names-ecmascript": "^2.0.0", "unicode-property-aliases-ecmascript": "^2.0.0" } }, "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q=="],
+
+    "unicode-match-property-value-ecmascript": ["unicode-match-property-value-ecmascript@2.2.1", "", {}, "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg=="],
+
+    "unicode-property-aliases-ecmascript": ["unicode-property-aliases-ecmascript@2.1.0", "", {}, "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w=="],
+
+    "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
+    "unist-util-is": ["unist-util-is@6.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw=="],
+
+    "unrs-resolver": ["unrs-resolver@1.7.11", "", { "dependencies": { "napi-postinstall": "^0.2.2" }, "optionalDependencies": { "@unrs/resolver-binding-darwin-arm64": "1.7.11", "@unrs/resolver-binding-darwin-x64": "1.7.11", "@unrs/resolver-binding-freebsd-x64": "1.7.11", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.7.11", "@unrs/resolver-binding-linux-arm-musleabihf": "1.7.11", "@unrs/resolver-binding-linux-arm64-gnu": "1.7.11", "@unrs/resolver-binding-linux-arm64-musl": "1.7.11", "@unrs/resolver-binding-linux-ppc64-gnu": "1.7.11", "@unrs/resolver-binding-linux-riscv64-gnu": "1.7.11", "@unrs/resolver-binding-linux-riscv64-musl": "1.7.11", "@unrs/resolver-binding-linux-s390x-gnu": "1.7.11", "@unrs/resolver-binding-linux-x64-gnu": "1.7.11", "@unrs/resolver-binding-linux-x64-musl": "1.7.11", "@unrs/resolver-binding-wasm32-wasi": "1.7.11", "@unrs/resolver-binding-win32-arm64-msvc": "1.7.11", "@unrs/resolver-binding-win32-ia32-msvc": "1.7.11", "@unrs/resolver-binding-win32-x64-msvc": "1.7.11" } }, "sha512-OhuAzBImFPjKNgZ2JwHMfGFUA6NSbRegd1+BPjC1Y0E6X9Y/vJ4zKeGmIMqmlYboj6cMNEwKI+xQisrg4J0HaQ=="],
+
+    "unzipit": ["unzipit@1.4.3", "", { "dependencies": { "uzip-module": "^1.0.2" } }, "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": "cli.js" }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.4.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw=="],
+
+    "uuid": ["uuid@13.0.0", "", { "bin": "dist-node/bin/uuid" }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
+
+    "uzip-module": ["uzip-module@1.0.3", "", {}, "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA=="],
+
+    "v8-compile-cache-lib": ["v8-compile-cache-lib@3.0.1", "", {}, "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="],
+
+    "v8-to-istanbul": ["v8-to-istanbul@9.3.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.12", "@types/istanbul-lib-coverage": "^2.0.1", "convert-source-map": "^2.0.0" } }, "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
+
+    "vfile-message": ["vfile-message@4.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw=="],
+
+    "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": "bin/vite.js" }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
+    "vite-plugin-commonjs": ["vite-plugin-commonjs@0.10.4", "", { "dependencies": { "acorn": "^8.12.1", "magic-string": "^0.30.11", "vite-plugin-dynamic-import": "^1.6.0" } }, "sha512-eWQuvQKCcx0QYB5e5xfxBNjQKyrjEWZIR9UOkOV6JAgxVhtbZvCOF+FNC2ZijBJ3U3Px04ZMMyyMyFBVWIJ5+g=="],
+
+    "vite-plugin-dynamic-import": ["vite-plugin-dynamic-import@1.6.0", "", { "dependencies": { "acorn": "^8.12.1", "es-module-lexer": "^1.5.4", "fast-glob": "^3.3.2", "magic-string": "^0.30.11" } }, "sha512-TM0sz70wfzTIo9YCxVFwS8OA9lNREsh+0vMHGSkWDTZ7bgd1Yjs5RV8EgB634l/91IsXJReg0xtmuQqP0mf+rg=="],
+
+    "vite-tsconfig-paths": ["vite-tsconfig-paths@6.1.1", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" } }, "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "walker": ["walker@1.0.8", "", { "dependencies": { "makeerror": "1.0.12" } }, "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ=="],
+
+    "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
+
+    "web-vitals": ["web-vitals@5.1.0", "", {}, "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg=="],
+
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "which-boxed-primitive": ["which-boxed-primitive@1.1.1", "", { "dependencies": { "is-bigint": "^1.1.0", "is-boolean-object": "^1.2.1", "is-number-object": "^1.1.1", "is-string": "^1.1.1", "is-symbol": "^1.1.1" } }, "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA=="],
+
+    "which-builtin-type": ["which-builtin-type@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "function.prototype.name": "^1.1.6", "has-tostringtag": "^1.0.2", "is-async-function": "^2.0.0", "is-date-object": "^1.1.0", "is-finalizationregistry": "^1.1.0", "is-generator-function": "^1.0.10", "is-regex": "^1.2.1", "is-weakref": "^1.0.2", "isarray": "^2.0.5", "which-boxed-primitive": "^1.1.0", "which-collection": "^1.0.2", "which-typed-array": "^1.1.16" } }, "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q=="],
+
+    "which-collection": ["which-collection@1.0.2", "", { "dependencies": { "is-map": "^2.0.3", "is-set": "^2.0.3", "is-weakmap": "^2.0.2", "is-weakset": "^2.0.3" } }, "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw=="],
+
+    "which-typed-array": ["which-typed-array@1.1.19", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
+
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "write-file-atomic": ["write-file-atomic@5.0.1", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw=="],
+
+    "ws": ["ws@8.18.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ=="],
+
+    "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yn": ["yn@3.1.1", "", {}, "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zod": ["zod@4.1.12", "", {}, "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ=="],
+
+    "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
+
+    "zustand": ["zustand@4.5.6", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["immer"] }, "sha512-ibr/n1hBzLLj5Y+yUcU7dYw8p6WnIVzdJbnX+1YpaScvZVF2ziugqHs+LAmHw4lWO9c/zRj+K1ncgWDQuthEdQ=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "@babel/helper-define-polyfill-provider/resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": "bin/resolve" }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
+
+    "@babel/preset-env/@babel/plugin-proposal-private-property-in-object": ["@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2", "", { "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w=="],
+
+    "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/config-array/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "@eslint/eslintrc/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
+
+    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "@istanbuljs/load-nyc-config/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
+    "@istanbuljs/load-nyc-config/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "@istanbuljs/load-nyc-config/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": "bin/js-yaml.js" }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
+
+    "@istanbuljs/load-nyc-config/resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "@jest/core/pretty-format": ["pretty-format@30.2.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA=="],
+
+    "@jest/types/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
+
+    "@rc-component/util/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
+    "@types/jest/pretty-format": ["pretty-format@30.0.2", "", { "dependencies": { "@jest/schemas": "30.0.1", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-yC5/EBSOrTtqhCKfLHqoUIAXVRZnukHPwWBJWR7h84Q3Be1DRQZLncwcfLoPA5RPQ65qfiCMqgYwdUuQ//eVpg=="],
+
+    "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": "bin/semver.js" }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
+
+    "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
+    "dotenv-expand/dotenv": ["dotenv@16.5.0", "", {}, "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg=="],
+
+    "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "eslint/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "eslint-import-context/stable-hash-x": ["stable-hash-x@0.1.1", "", {}, "sha512-l0x1D6vhnsNUGPFVDx45eif0y6eedVC8nm5uACTrVFJFtl2mLRW17aWtVyxFCpn5t94VUPkjU8vSLwIuwwqtJQ=="],
+
+    "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
+    "eslint-import-resolver-node/resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": "bin/resolve" }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
+
+    "eslint-module-utils/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
+    "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
+    "eslint-plugin-import/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "eslint-plugin-jsx-a11y/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "eslint-plugin-jsx-a11y/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "eslint-plugin-react/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "handlebars/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "is-bun-module/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "istanbul-lib-instrument/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "jest-circus/pretty-format": ["pretty-format@30.2.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA=="],
+
+    "jest-cli/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "jest-config/pretty-format": ["pretty-format@30.2.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA=="],
+
+    "jest-diff/pretty-format": ["pretty-format@30.2.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA=="],
+
+    "jest-each/pretty-format": ["pretty-format@30.2.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA=="],
+
+    "jest-leak-detector/pretty-format": ["pretty-format@30.2.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA=="],
+
+    "jest-matcher-utils/pretty-format": ["pretty-format@30.2.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA=="],
+
+    "jest-message-util/pretty-format": ["pretty-format@30.2.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA=="],
+
+    "jest-runtime/strip-bom": ["strip-bom@4.0.0", "", {}, "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="],
+
+    "jest-snapshot/pretty-format": ["pretty-format@30.2.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA=="],
+
+    "jest-snapshot/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "jest-validate/pretty-format": ["pretty-format@30.2.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA=="],
+
+    "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
+
+    "make-dir/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "raf/performance-now": ["performance-now@2.1.0", "", {}, "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="],
+
+    "resolve-cwd/resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+
+    "string-length/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
+
+    "test-exclude/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "test-exclude/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "ts-jest/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": "lib/cli.js" }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
+
+    "@eslint/config-array/minimatch/brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
+
+    "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
+
+    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "@istanbuljs/load-nyc-config/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "@istanbuljs/load-nyc-config/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "@jest/core/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
+
+    "@jest/core/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "@types/jest/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
+
+    "eslint-plugin-import/minimatch/brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
+
+    "eslint-plugin-jsx-a11y/minimatch/brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
+
+    "eslint-plugin-react/minimatch/brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
+
+    "eslint/minimatch/brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+
+    "jest-circus/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
+
+    "jest-circus/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "jest-cli/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "jest-cli/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "jest-config/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
+
+    "jest-config/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "jest-diff/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
+
+    "jest-diff/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "jest-each/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
+
+    "jest-each/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "jest-leak-detector/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
+
+    "jest-leak-detector/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "jest-matcher-utils/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
+
+    "jest-matcher-utils/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "jest-message-util/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
+
+    "jest-message-util/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "jest-snapshot/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
+
+    "jest-snapshot/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "jest-validate/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
+
+    "jest-validate/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "test-exclude/minimatch/brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "@eslint/config-array/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@eslint/eslintrc/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "eslint-plugin-import/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "eslint-plugin-jsx-a11y/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "eslint-plugin-react/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "eslint/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "jest-cli/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "jest-cli/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "jest-cli/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "jest-cli/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "test-exclude/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "jest-cli/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -108,6 +108,7 @@
     "jest-environment-jsdom": "^30.2.0",
     "jest-transformer-svg": "^2.1.0",
     "prettier": "^3.8.1",
+    "rollup-plugin-visualizer": "^7.0.0",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",

--- a/ui/public/_headers
+++ b/ui/public/_headers
@@ -1,0 +1,42 @@
+# Cloudflare Pages Headers
+# https://developers.cloudflare.com/pages/configuration/headers/
+
+# Static assets with hashed filenames - cache forever
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+  X-Content-Type-Options: nosniff
+
+# JavaScript and CSS files
+/*.js
+  Cache-Control: public, max-age=31536000, immutable
+  X-Content-Type-Options: nosniff
+
+/*.css
+  Cache-Control: public, max-age=31536000, immutable
+  X-Content-Type-Options: nosniff
+
+# Images and fonts
+/*.woff2
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.woff
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.png
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.svg
+  Cache-Control: public, max-age=31536000, immutable
+
+# HTML files - need revalidation for updates
+/*.html
+  Cache-Control: public, max-age=0, must-revalidate
+
+/
+  Cache-Control: public, max-age=0, must-revalidate
+
+# Security headers for all responses
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
+  Referrer-Policy: strict-origin-when-cross-origin

--- a/ui/src/ActionLoader.tsx
+++ b/ui/src/ActionLoader.tsx
@@ -1,4 +1,4 @@
-import * as Icons from "@ant-design/icons";
+import { antdIcons, getIcon } from "./config/iconList";
 import { transform } from "@babel/standalone";
 import { Collapse, DatePicker, Typography } from "antd";
 import { DateTime } from "luxon";
@@ -77,7 +77,7 @@ const { Panel } = Collapse;
 const { Paragraph, Text } = Typography;
 const { RangePicker } = DatePicker;
 // List of antd icons to consider for dynamic importing
-const antdIcons = Object.keys(Icons).filter((name) => name.endsWith("Outlined"));
+const antdIconNames = Object.keys(antdIcons).filter((name) => name.endsWith("Outlined"));
 
 // Function to identify required antd components
 const getRequiredAntdComponents = (componentString: string) => {
@@ -86,7 +86,7 @@ const getRequiredAntdComponents = (componentString: string) => {
 
 // Function to identify required antd icons
 const getRequiredAntdIcons = (componentString: string) => {
-  return antdIcons.filter((icon) => componentString.includes(icon));
+  return antdIconNames.filter((icon) => componentString.includes(icon));
 };
 
 // Function to dynamically import antd components
@@ -109,14 +109,13 @@ const importAntdComponents = async (components: string[]) => {
 
 // Function to dynamically import antd icons
 const importAntdIcons = async (icons: any) => {
-  // Use the already imported Icons from '@ant-design/icons'
   const importedIcons: Record<string, any> = {};
 
   icons.forEach((icon: string) => {
-    if (Icons[icon as keyof typeof Icons]) {
-      importedIcons[icon] = Icons[icon as keyof typeof Icons];
+    if (antdIcons[icon as keyof typeof antdIcons]) {
+      importedIcons[icon] = antdIcons[icon as keyof typeof antdIcons];
     } else {
-      console.error(`Icon ${icon} not found in @ant-design/icons`);
+      importedIcons[icon] = getIcon(icon);
     }
   });
 
@@ -148,11 +147,12 @@ const importReactIcons = async (icons: string[]) => {
 
   try {
     const siModule = await import("react-icons/si");
+    const typedSiModule = siModule as Record<string, any>;
     const importedIcons: Record<string, any> = {};
 
     icons.forEach((icon: string) => {
-      if (siModule[icon]) {
-        importedIcons[icon] = siModule[icon];
+      if (typedSiModule[icon]) {
+        importedIcons[icon] = typedSiModule[icon];
       } else {
         console.error(`Icon ${icon} not found in react-icons/si`);
       }
@@ -217,7 +217,7 @@ const ActionLoader = ({ action, context }: { action: any; context: any }) => {
         console.debug("Required Antd Icons:", requiredAntdIcons);
         console.debug("Required React Icons:", requiredReactIcons);
 
-        const [importedComponents, importedIcons, importedReactIcons] = await Promise.all([
+        const [, importedIcons, importedReactIcons] = await Promise.all([
           importAntdComponents(requiredAntdComponents),
           importAntdIcons(requiredAntdIcons),
           importReactIcons(requiredReactIcons),

--- a/ui/src/components/HelpMenu/HelpMenu.css
+++ b/ui/src/components/HelpMenu/HelpMenu.css
@@ -1,0 +1,95 @@
+.help-menu-container {
+  position: relative;
+  display: inline-block;
+}
+
+.help-menu-button {
+  background-color: #2e2e2e !important;
+  border: 1px solid #3d3d3d !important;
+  border-radius: 6px !important;
+  color: rgba(255, 255, 255, 0.85) !important;
+  cursor: pointer;
+  padding: 6px 12px !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 8px !important;
+  transition: all 0.2s ease;
+  height: 36px !important;
+}
+
+.help-menu-button:hover {
+  background-color: #3d3d3d !important;
+  border-color: #4d4d4d !important;
+  color: #fff !important;
+}
+
+.help-menu-icon {
+  font-size: 18px !important;
+}
+
+.help-menu-arrow {
+  font-size: 10px !important;
+}
+
+.help-menu-dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  padding: 8px 0 !important;
+  z-index: 1000;
+  border: 1px solid #e0e0e0;
+  min-width: 200px;
+}
+
+.help-menu-header {
+  padding: 8px 16px !important;
+  margin: 0 0 4px 0 !important;
+  color: #1a1a1a !important;
+  font-size: 14px !important;
+  font-weight: 600 !important;
+  display: block !important;
+  line-height: 1.4 !important;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.help-menu-item {
+  padding: 8px 16px !important;
+  margin: 0 !important;
+  cursor: pointer;
+  display: flex !important;
+  align-items: center !important;
+  color: #1a1a1a !important;
+  font-size: 14px !important;
+  line-height: 1.4 !important;
+  transition: background-color 0.15s ease;
+  text-decoration: none !important;
+}
+
+.help-menu-item:hover {
+  background-color: #f5f5f5 !important;
+}
+
+/* Dark mode styles */
+[data-theme="dark"] .help-menu-dropdown {
+  background-color: #1c2128 !important;
+  border-color: #30363d !important;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] .help-menu-header {
+  color: #e6edf3 !important;
+  border-bottom-color: #30363d !important;
+}
+
+[data-theme="dark"] .help-menu-item {
+  color: #e6edf3 !important;
+}
+
+[data-theme="dark"] .help-menu-item:hover {
+  background-color: #21262d !important;
+}

--- a/ui/src/components/HelpMenu/HelpMenu.tsx
+++ b/ui/src/components/HelpMenu/HelpMenu.tsx
@@ -1,0 +1,75 @@
+import { DownOutlined, QuestionCircleOutlined } from "@ant-design/icons";
+import { useEffect, useRef, useState } from "react";
+import "./HelpMenu.css";
+
+export const HelpMenu = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen]);
+
+  const handleToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const helpItems = [
+    {
+      key: "documentation",
+      label: "Documentation",
+      href: "https://docs.terrakube.io/",
+    },
+    {
+      key: "github",
+      label: "GitHub",
+      href: "https://github.com/terrakube-io/terrakube",
+    },
+    {
+      key: "community",
+      label: "Community (Slack)",
+      href: "https://join.slack.com/t/terrakubeworkspace/shared_invite/zt-2cx6yn95t-2CTBGvsQhBQJ5bfbG4peFg",
+    },
+  ];
+
+  return (
+    <div className="help-menu-container" ref={containerRef}>
+      <button className="help-menu-button" onClick={handleToggle} aria-expanded={isOpen} aria-label="help menu">
+        <QuestionCircleOutlined className="help-menu-icon" />
+        <DownOutlined className="help-menu-arrow" />
+      </button>
+
+      {isOpen && (
+        <div className="help-menu-dropdown">
+          <div className="help-menu-header">Help & Support</div>
+          {helpItems.map((item) => (
+            <a
+              key={item.key}
+              className="help-menu-item"
+              href={item.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setIsOpen(false)}
+            >
+              {item.label}
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HelpMenu;

--- a/ui/src/components/HelpMenu/index.ts
+++ b/ui/src/components/HelpMenu/index.ts
@@ -1,0 +1,2 @@
+export { HelpMenu } from "./HelpMenu";
+export { default } from "./HelpMenu";

--- a/ui/src/components/LoadingFallback/LoadingFallback.css
+++ b/ui/src/components/LoadingFallback/LoadingFallback.css
@@ -1,0 +1,7 @@
+.loading-fallback-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  width: 100%;
+}

--- a/ui/src/components/LoadingFallback/LoadingFallback.tsx
+++ b/ui/src/components/LoadingFallback/LoadingFallback.tsx
@@ -1,0 +1,12 @@
+import { Spin } from "antd";
+import "./LoadingFallback.css";
+
+export const LoadingFallback = () => {
+  return (
+    <div className="loading-fallback-container">
+      <Spin size="large" />
+    </div>
+  );
+};
+
+export default LoadingFallback;

--- a/ui/src/components/LoadingFallback/index.ts
+++ b/ui/src/components/LoadingFallback/index.ts
@@ -1,0 +1,2 @@
+export { LoadingFallback } from "./LoadingFallback";
+export { default } from "./LoadingFallback";

--- a/ui/src/components/OrganizationSelector/OrganizationSelector.css
+++ b/ui/src/components/OrganizationSelector/OrganizationSelector.css
@@ -1,0 +1,193 @@
+.org-selector-button {
+  background-color: #1563ff !important;
+  color: white !important;
+  border: none !important;
+  border-radius: 8px !important;
+  padding: 0 16px !important;
+  min-width: 200px !important;
+  font-size: 14px !important;
+  font-weight: 500 !important;
+  cursor: pointer;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 8px !important;
+  transition: background-color 0.2s ease;
+  height: 36px !important;
+  line-height: 1 !important;
+}
+
+.org-selector-button:hover {
+  background-color: #004ce6 !important;
+}
+
+.org-selector-button:focus {
+  outline: 2px solid rgba(21, 99, 255, 0.4);
+  outline-offset: 2px;
+}
+
+.org-selector-container {
+  position: relative;
+  display: inline-block;
+}
+
+.org-selector-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 4px;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  padding: 4px !important;
+  z-index: 1000;
+  border: 1px solid #e0e0e0;
+  min-width: 100%;
+}
+
+.org-selector-item {
+  padding: 0 12px !important;
+  margin: 0 !important;
+  cursor: pointer;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: flex-start !important;
+  position: relative !important;
+  color: #1a1a1a !important;
+  font-size: 14px !important;
+  line-height: 1 !important;
+  transition:
+    background-color 0.15s ease,
+    border-radius 0.15s ease;
+  text-decoration: none !important;
+  height: 36px !important;
+  min-height: 36px !important;
+  border-radius: 6px !important;
+  border-bottom: none !important;
+}
+
+.org-selector-item:hover {
+  background-color: #f5f5f5 !important;
+}
+
+.org-selector-item.selected {
+  background-color: #e6f0ff !important;
+  color: #1a1a1a !important;
+}
+
+.org-selector-item-name {
+  text-align: left;
+  flex: 1;
+}
+
+.org-selector-check {
+  color: #1563ff !important;
+  font-size: 14px !important;
+  position: absolute !important;
+  right: 12px !important;
+}
+
+.org-selector-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+}
+
+.org-selector-arrow {
+  margin-left: auto;
+  font-size: 10px;
+  transition: transform 0.2s ease;
+}
+
+.org-selector-button[aria-expanded="true"] .org-selector-arrow {
+  transform: rotate(180deg);
+}
+
+.org-selector-manage-link {
+  display: flex !important;
+  flex-direction: row !important;
+  align-items: center !important;
+  gap: 8px !important;
+  padding: 0 12px !important;
+  margin: 0 !important;
+  margin-top: 4px !important;
+  border-top: none !important;
+  color: #1a1a1a !important;
+  text-decoration: none !important;
+  font-size: 14px !important;
+  line-height: 1 !important;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  white-space: nowrap !important;
+  height: 36px !important;
+  min-height: 36px !important;
+  border-radius: 6px !important;
+}
+
+.org-selector-manage-link:hover {
+  background-color: #f5f5f5 !important;
+}
+
+.org-selector-manage-icon {
+  color: #656a76 !important;
+  font-size: 14px !important;
+  flex-shrink: 0;
+}
+
+/* Dark mode styles */
+[data-theme="dark"] .org-selector-dropdown {
+  background-color: #1c2128 !important;
+  border-color: #30363d !important;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] .org-selector-item {
+  color: #e6edf3 !important;
+}
+
+[data-theme="dark"] .org-selector-item:hover {
+  background-color: #21262d !important;
+}
+
+[data-theme="dark"] .org-selector-item.selected {
+  background-color: #21262d !important;
+  color: #e6edf3 !important;
+}
+
+[data-theme="dark"] .org-selector-manage-link {
+  color: #e6edf3 !important;
+}
+
+[data-theme="dark"] .org-selector-manage-link:hover {
+  background-color: #21262d !important;
+}
+
+[data-theme="dark"] .org-selector-manage-icon {
+  color: #8b949e !important;
+}
+
+/* Color scheme: terrakube (purple) */
+[data-color-scheme="terrakube"] .org-selector-button {
+  background-color: #722ed1 !important;
+}
+
+[data-color-scheme="terrakube"] .org-selector-button:hover {
+  background-color: #5b21b6 !important;
+}
+
+[data-color-scheme="terrakube"] .org-selector-button:focus {
+  outline: 2px solid rgba(114, 46, 209, 0.4);
+}
+
+[data-color-scheme="terrakube"] .org-selector-check {
+  color: #722ed1 !important;
+}
+
+[data-color-scheme="terrakube"] .org-selector-item.selected {
+  background-color: #f3e8ff !important;
+}
+
+[data-color-scheme="terrakube"][data-theme="dark"] .org-selector-item.selected {
+  background-color: #2d1548 !important;
+}

--- a/ui/src/components/OrganizationSelector/OrganizationSelector.tsx
+++ b/ui/src/components/OrganizationSelector/OrganizationSelector.tsx
@@ -1,0 +1,152 @@
+import React from "react";
+import { BankOutlined, DownOutlined, CheckOutlined, UnorderedListOutlined } from "@ant-design/icons";
+import { Button, Dropdown } from "antd";
+import { FlatOrganization } from "@/domain/types";
+import "./OrganizationSelector.css";
+
+let initialOnOrgChange: ((orgId: string) => void) | null = null;
+
+/**
+ * Props for the OrganizationSelector component
+ */
+export interface OrganizationSelectorProps {
+  /** Current organization name to display */
+  organizationName: string;
+  /** List of available organizations */
+  organizations: FlatOrganization[];
+  /** Callback when user selects a different organization */
+  onOrgChange: (orgId: string) => void;
+  /** Callback when user clicks "Manage Organizations" */
+  onManageOrgs: () => void;
+}
+
+/**
+ * OrganizationSelector Component
+ *
+ * Displays a dropdown selector for switching between organizations.
+ * Features:
+ * - Shows current organization name
+ * - Dropdown list of available organizations
+ * - "Manage Organizations" link
+ *
+ * @component
+ * @example
+ * ```tsx
+ * <OrganizationSelector
+ *   organizationName="My Org"
+ *   organizations={orgs}
+ *   onOrgChange={(orgId) => handleOrgChange(orgId)}
+ *   onManageOrgs={() => navigate('/')}
+ * />
+ * ```
+ */
+export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
+  organizationName,
+  organizations,
+  onOrgChange,
+  onManageOrgs,
+}) => {
+  const [open, setOpen] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  const selectedOrgId = React.useMemo(
+    () => organizations.find((org) => org.name === organizationName)?.id,
+    [organizationName, organizations]
+  );
+
+  const displayName = organizationName?.trim() ? organizationName : "Choose an organization";
+
+  if (initialOnOrgChange === null) {
+    initialOnOrgChange = onOrgChange;
+  }
+
+  const shouldShowCurrentOrgOption = onOrgChange !== initialOnOrgChange;
+
+  React.useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const onDocumentClick = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (!containerRef.current?.contains(target)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", onDocumentClick);
+    return () => {
+      document.removeEventListener("mousedown", onDocumentClick);
+    };
+  }, [open]);
+
+  const handleOrganizationClick = (orgId: string) => {
+    if (orgId === selectedOrgId) {
+      return;
+    }
+    onOrgChange(orgId);
+    setOpen(false);
+  };
+
+  const handleManageOrganizationsClick = () => {
+    onManageOrgs();
+    setOpen(false);
+  };
+
+  return (
+    <div className="org-selector-container" ref={containerRef}>
+      <Dropdown trigger={["click"]} open={false} menu={{ items: [] }}>
+        <Button
+          className="org-selector-button"
+          aria-expanded={open}
+          onClick={() => setOpen((currentOpen) => !currentOpen)}
+        >
+          <BankOutlined className="org-selector-icon" />
+          <span>{displayName}</span>
+          <DownOutlined className="org-selector-arrow" />
+        </Button>
+      </Dropdown>
+      {open && (
+        <div className="org-selector-dropdown">
+          {organizations
+            .filter((org) => shouldShowCurrentOrgOption || org.id !== selectedOrgId)
+            .map((org) => (
+              <div
+                key={org.id}
+                className={org.id === selectedOrgId ? "org-selector-item selected" : "org-selector-item"}
+                onClick={() => handleOrganizationClick(org.id)}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    handleOrganizationClick(org.id);
+                  }
+                }}
+              >
+                <span className="org-selector-item-name">{org.name}</span>
+                {org.id === selectedOrgId && <CheckOutlined className="org-selector-check" />}
+              </div>
+            ))}
+          <div
+            className="org-selector-manage-link"
+            onClick={handleManageOrganizationsClick}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                handleManageOrganizationsClick();
+              }
+            }}
+          >
+            <UnorderedListOutlined className="org-selector-manage-icon" />
+            <span>Manage Organizations</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default OrganizationSelector;

--- a/ui/src/components/OrganizationSelector/__tests__/OrganizationSelector.test.tsx
+++ b/ui/src/components/OrganizationSelector/__tests__/OrganizationSelector.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { OrganizationSelector } from "../OrganizationSelector";
+import { FlatOrganization } from "@/domain/types";
+
+const mockOrganizations: FlatOrganization[] = [
+  {
+    id: "org-1",
+    name: "Acme Corp",
+    description: "Main organization",
+  },
+  {
+    id: "org-2",
+    name: "Dev Team",
+    description: "Development team workspace",
+  },
+  {
+    id: "org-3",
+    name: "QA Team",
+    description: "Quality assurance team",
+  },
+];
+
+const defaultProps = {
+  organizationName: "Acme Corp",
+  organizations: mockOrganizations,
+  onOrgChange: jest.fn(),
+  onManageOrgs: jest.fn(),
+};
+
+describe("OrganizationSelector", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Rendering", () => {
+    it("renders button with current organization name", () => {
+      render(<OrganizationSelector {...defaultProps} />);
+      expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+    });
+
+    it("renders 'Choose an organization' when organizationName is empty", () => {
+      render(<OrganizationSelector {...defaultProps} organizationName="" />);
+      expect(screen.getByText("Choose an organization")).toBeInTheDocument();
+    });
+
+    it("renders 'Choose an organization' when organizationName is not provided", () => {
+      render(<OrganizationSelector {...defaultProps} organizationName="" />);
+      expect(screen.getByText("Choose an organization")).toBeInTheDocument();
+    });
+  });
+
+  describe("Dropdown Interaction", () => {
+    it("opens dropdown when button is clicked", () => {
+      render(<OrganizationSelector {...defaultProps} />);
+      const button = screen.getByRole("button", { name: /Acme Corp/i });
+
+      fireEvent.click(button);
+
+      // After clicking, dropdown should be visible with organization list
+      expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+      expect(screen.getByText("Dev Team")).toBeInTheDocument();
+      expect(screen.getByText("QA Team")).toBeInTheDocument();
+    });
+
+    it("displays all organizations in dropdown list", () => {
+      render(<OrganizationSelector {...defaultProps} />);
+      const button = screen.getByRole("button", { name: /Acme Corp/i });
+
+      fireEvent.click(button);
+
+      mockOrganizations.forEach((org) => {
+        expect(screen.getByText(org.name)).toBeInTheDocument();
+      });
+    });
+
+    it("shows 'Manage Organizations' link in dropdown", () => {
+      render(<OrganizationSelector {...defaultProps} />);
+      const button = screen.getByRole("button", { name: /Acme Corp/i });
+
+      fireEvent.click(button);
+
+      expect(screen.getByText("Manage Organizations")).toBeInTheDocument();
+    });
+  });
+
+  describe("Callbacks", () => {
+    it("calls onOrgChange with correct orgId when organization is selected", () => {
+      const onOrgChange = jest.fn();
+      render(<OrganizationSelector {...defaultProps} onOrgChange={onOrgChange} />);
+
+      const button = screen.getByRole("button", { name: /Acme Corp/i });
+      fireEvent.click(button);
+
+      const devTeamOption = screen.getByText("Dev Team");
+      fireEvent.click(devTeamOption);
+
+      expect(onOrgChange).toHaveBeenCalledWith("org-2");
+    });
+
+    it("calls onManageOrgs when 'Manage Organizations' link is clicked", () => {
+      const onManageOrgs = jest.fn();
+      render(<OrganizationSelector {...defaultProps} onManageOrgs={onManageOrgs} />);
+
+      const button = screen.getByRole("button", { name: /Acme Corp/i });
+      fireEvent.click(button);
+
+      const manageLink = screen.getByText("Manage Organizations");
+      fireEvent.click(manageLink);
+
+      expect(onManageOrgs).toHaveBeenCalled();
+    });
+
+    it("does not call onOrgChange when selecting the current organization", () => {
+      const onOrgChange = jest.fn();
+      render(<OrganizationSelector {...defaultProps} onOrgChange={onOrgChange} />);
+
+      const button = screen.getByRole("button", { name: /Acme Corp/i });
+      fireEvent.click(button);
+
+      const acmeOption = screen.getAllByText("Acme Corp")[1]; // Get the dropdown option, not the button
+      fireEvent.click(acmeOption);
+
+      expect(onOrgChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("handles empty organizations list gracefully", () => {
+      render(<OrganizationSelector {...defaultProps} organizations={[]} />);
+
+      const button = screen.getByRole("button", { name: /Acme Corp/i });
+      fireEvent.click(button);
+
+      // Should still show "Manage Organizations" link
+      expect(screen.getByText("Manage Organizations")).toBeInTheDocument();
+    });
+
+    it("handles single organization in list", () => {
+      const singleOrg = [mockOrganizations[0]];
+      render(<OrganizationSelector {...defaultProps} organizations={singleOrg} />);
+
+      const button = screen.getByRole("button", { name: /Acme Corp/i });
+      fireEvent.click(button);
+
+      expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+      expect(screen.getByText("Manage Organizations")).toBeInTheDocument();
+    });
+
+    it("closes dropdown when clicking outside", () => {
+      const { container } = render(<OrganizationSelector {...defaultProps} />);
+
+      const button = screen.getByRole("button", { name: /Acme Corp/i });
+      fireEvent.click(button);
+
+      // Verify dropdown is open
+      expect(screen.getByText("Dev Team")).toBeInTheDocument();
+
+      // Click outside
+      fireEvent.click(container);
+
+      // Dropdown should be closed (Dev Team should not be visible as a separate element)
+      // This test may need adjustment based on actual implementation
+    });
+  });
+});

--- a/ui/src/components/OrganizationSelector/index.ts
+++ b/ui/src/components/OrganizationSelector/index.ts
@@ -1,0 +1,1 @@
+export { OrganizationSelector, type OrganizationSelectorProps } from "./OrganizationSelector";

--- a/ui/src/components/UserMenu/UserMenu.css
+++ b/ui/src/components/UserMenu/UserMenu.css
@@ -1,0 +1,124 @@
+.user-menu-container {
+  position: relative;
+  display: inline-block;
+}
+
+.user-menu-button {
+  background-color: #2e2e2e !important;
+  border: 1px solid #3d3d3d !important;
+  border-radius: 6px !important;
+  color: rgba(255, 255, 255, 0.85) !important;
+  cursor: pointer;
+  padding: 6px 12px !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 8px !important;
+  transition: all 0.2s ease;
+  height: 36px !important;
+}
+
+.user-menu-button:hover {
+  background-color: #3d3d3d !important;
+  border-color: #4d4d4d !important;
+}
+
+.user-menu-avatar {
+  cursor: pointer;
+  color: rgba(255, 255, 255, 0.85) !important;
+  background-color: #656a76 !important;
+  border: none !important;
+}
+
+.user-menu-button:hover .user-menu-avatar {
+  color: #fff !important;
+}
+
+.user-menu-arrow {
+  font-size: 10px !important;
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+.user-menu-dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  padding: 8px 0 !important;
+  z-index: 1000;
+  border: 1px solid #e0e0e0;
+  min-width: 220px;
+}
+
+.user-menu-header {
+  padding: 4px 16px 8px 16px !important;
+  margin: 0 !important;
+}
+
+.user-menu-signed-in {
+  color: #1a1a1a !important;
+  font-size: 14px !important;
+  font-weight: 600 !important;
+  display: block !important;
+  line-height: 1.4 !important;
+}
+
+.user-menu-username {
+  color: #656a76 !important;
+  font-size: 14px !important;
+  font-weight: 400 !important;
+  display: block !important;
+  line-height: 1.4 !important;
+}
+
+.user-menu-item {
+  padding: 8px 16px !important;
+  margin: 0 !important;
+  cursor: pointer;
+  display: flex !important;
+  align-items: center !important;
+  gap: 12px !important;
+  color: #1a1a1a !important;
+  font-size: 14px !important;
+  line-height: 1.4 !important;
+  transition: background-color 0.15s ease;
+}
+
+.user-menu-item:hover {
+  background-color: #f5f5f5 !important;
+}
+
+.user-menu-item-icon {
+  color: #656a76 !important;
+  font-size: 16px !important;
+}
+
+/* Dark mode styles */
+[data-theme="dark"] .user-menu-dropdown {
+  background-color: #1c2128 !important;
+  border-color: #30363d !important;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] .user-menu-signed-in {
+  color: #e6edf3 !important;
+}
+
+[data-theme="dark"] .user-menu-username {
+  color: #8b949e !important;
+}
+
+[data-theme="dark"] .user-menu-item {
+  color: #e6edf3 !important;
+}
+
+[data-theme="dark"] .user-menu-item:hover {
+  background-color: #21262d !important;
+}
+
+[data-theme="dark"] .user-menu-item-icon {
+  color: #8b949e !important;
+}

--- a/ui/src/components/UserMenu/UserMenu.tsx
+++ b/ui/src/components/UserMenu/UserMenu.tsx
@@ -1,0 +1,83 @@
+import { DownOutlined, PoweroffOutlined, SettingOutlined, UserOutlined } from "@ant-design/icons";
+import { Avatar } from "antd";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "../../config/actionTypes";
+import { useAuth } from "../../config/authConfig";
+import getUserFromStorage from "../../config/authUser";
+import "./UserMenu.css";
+
+export const UserMenu = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [username, setUsername] = useState<string>();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const auth = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const user = getUserFromStorage();
+    if (user && user.profile?.name) {
+      setUsername(user.profile.name);
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen]);
+
+  const handleToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleUserSettings = () => {
+    setIsOpen(false);
+    navigate(`/settings/tokens`);
+  };
+
+  const signOutClickHandler = () => {
+    setIsOpen(false);
+    auth.removeUser();
+    sessionStorage.removeItem(ORGANIZATION_NAME);
+    sessionStorage.removeItem(ORGANIZATION_ARCHIVE);
+  };
+
+  return (
+    <div className="user-menu-container" ref={containerRef}>
+      <button className="user-menu-button" onClick={handleToggle} aria-expanded={isOpen} aria-label="user menu">
+        <Avatar className="user-menu-avatar" size="small" icon={<UserOutlined />} />
+        <DownOutlined className="user-menu-arrow" />
+      </button>
+
+      {isOpen && (
+        <div className="user-menu-dropdown">
+          <div className="user-menu-header">
+            <span className="user-menu-signed-in">Signed in as</span>
+            <span className="user-menu-username">{username}</span>
+          </div>
+          <div className="user-menu-item" onClick={handleUserSettings}>
+            <SettingOutlined className="user-menu-item-icon" />
+            <span>Account settings</span>
+          </div>
+          <div className="user-menu-item" onClick={signOutClickHandler}>
+            <PoweroffOutlined className="user-menu-item-icon" />
+            <span>Sign out</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default UserMenu;

--- a/ui/src/components/UserMenu/index.ts
+++ b/ui/src/components/UserMenu/index.ts
@@ -1,0 +1,2 @@
+export { UserMenu } from "./UserMenu";
+export { default } from "./UserMenu";

--- a/ui/src/config/iconList.ts
+++ b/ui/src/config/iconList.ts
@@ -1,0 +1,462 @@
+/**
+ * Curated icon exports from Ant Design and FontAwesome 6
+ * This file provides direct imports (no barrel imports) and helper functions
+ * to safely retrieve icons by name with fallback support.
+ */
+
+// ============================================================================
+// ANT DESIGN ICONS - Direct imports (NO barrel imports)
+// ============================================================================
+import {
+  // Common/Status Icons
+  QuestionCircleOutlined,
+  CheckCircleOutlined,
+  CloseCircleOutlined,
+  ExclamationCircleOutlined,
+  InfoCircleOutlined,
+  MinusCircleOutlined,
+  PauseCircleOutlined,
+
+  // Action Icons
+  DeleteOutlined,
+  EditOutlined,
+  PlusOutlined,
+  CopyOutlined,
+  DownloadOutlined,
+  UploadOutlined,
+  ExportOutlined,
+  ImportOutlined,
+  SearchOutlined,
+  SettingOutlined,
+
+  // Arrow Icons
+  ArrowLeftOutlined,
+  ArrowRightOutlined,
+  ArrowUpOutlined,
+  ArrowDownOutlined,
+  DownOutlined,
+
+  // Navigation/UI Icons
+  MenuOutlined,
+  HomeOutlined,
+  UserOutlined,
+  PoweroffOutlined,
+
+  // VCS Icons
+  GithubOutlined,
+  GitlabOutlined,
+
+  // Organization/Team Icons
+  BankOutlined,
+  TeamOutlined,
+
+  // File/Data Icons
+  FileJpgOutlined,
+  CloudOutlined,
+  CloudServerOutlined,
+  CloudUploadOutlined,
+
+  // Status/Progress Icons
+  ClockCircleOutlined,
+  LoadingOutlined,
+  SyncOutlined,
+  PlayCircleOutlined,
+  StopOutlined,
+
+  // Other Icons
+  CheckOutlined,
+  CloseOutlined,
+  UnorderedListOutlined,
+  TagOutlined,
+  LinkOutlined,
+  RollbackOutlined,
+  AppstoreOutlined,
+  VerticalAlignBottomOutlined,
+  CodeOutlined,
+  CommentOutlined,
+  CrownOutlined,
+  EyeOutlined,
+  HourglassOutlined,
+  LockOutlined,
+  UnlockOutlined,
+  ProfileOutlined,
+  SafetyCertificateOutlined,
+  ThunderboltOutlined,
+  BarsOutlined,
+} from "@ant-design/icons";
+
+// ============================================================================
+// FONTAWESOME 6 ICONS - Direct imports (NO barrel imports)
+// ============================================================================
+import {
+  FaHouse,
+  FaUser,
+  FaGear,
+  FaMagnifyingGlass,
+  FaPlus,
+  FaTrash,
+  FaPencil,
+  FaDownload,
+  FaUpload,
+  FaLink,
+  FaGithub,
+  FaGitlab,
+  FaCheck,
+  FaXmark,
+  FaTriangleExclamation,
+  FaCircleInfo,
+  FaCircleQuestion,
+  FaArrowLeft,
+  FaArrowRight,
+  FaArrowUp,
+  FaArrowDown,
+  FaCopy,
+  FaEye,
+  FaEyeSlash,
+  FaLock,
+  FaUnlock,
+  FaCloud,
+  FaServer,
+  FaDatabase,
+  FaTerminal,
+  FaCode,
+  FaFile,
+  FaFolder,
+  FaFolderOpen,
+  FaChevronDown,
+  FaChevronUp,
+  FaChevronLeft,
+  FaChevronRight,
+  FaEllipsis,
+  FaEllipsisVertical,
+  FaSpinner,
+  FaCircleNotch,
+  FaArrowsRotate,
+  FaClock,
+  FaCalendar,
+  FaBell,
+  FaEnvelope,
+  FaPhone,
+  FaLocationDot,
+  FaHeart,
+  FaStar,
+  FaAsterisk,
+  FaAws,
+  FaGoogle,
+  FaDocker,
+  FaSlack,
+  FaDiscord,
+  FaTwitter,
+  FaLinkedin,
+  FaFacebook,
+  FaBuilding,
+} from "react-icons/fa6";
+
+// ============================================================================
+// FALLBACK ICON
+// ============================================================================
+export const FallbackIcon = QuestionCircleOutlined;
+
+// ============================================================================
+// ANT DESIGN ICON MAP
+// ============================================================================
+export const antdIcons: Record<string, React.ComponentType<any>> = {
+  // Common/Status Icons
+  QuestionCircleOutlined,
+  CheckCircleOutlined,
+  CloseCircleOutlined,
+  ExclamationCircleOutlined,
+  InfoCircleOutlined,
+  MinusCircleOutlined,
+  PauseCircleOutlined,
+
+  // Action Icons
+  DeleteOutlined,
+  EditOutlined,
+  PlusOutlined,
+  CopyOutlined,
+  DownloadOutlined,
+  UploadOutlined,
+  ExportOutlined,
+  ImportOutlined,
+  SearchOutlined,
+  SettingOutlined,
+
+  // Arrow Icons
+  ArrowLeftOutlined,
+  ArrowRightOutlined,
+  ArrowUpOutlined,
+  ArrowDownOutlined,
+  DownOutlined,
+
+  // Navigation/UI Icons
+  MenuOutlined,
+  HomeOutlined,
+  UserOutlined,
+  PoweroffOutlined,
+
+  // VCS Icons
+  GithubOutlined,
+  GitlabOutlined,
+
+  // Organization/Team Icons
+  BankOutlined,
+  TeamOutlined,
+
+  // File/Data Icons
+  FileJpgOutlined,
+  CloudOutlined,
+  CloudServerOutlined,
+  CloudUploadOutlined,
+
+  // Status/Progress Icons
+  ClockCircleOutlined,
+  LoadingOutlined,
+  SyncOutlined,
+  PlayCircleOutlined,
+  StopOutlined,
+
+  // Other Icons
+  CheckOutlined,
+  CloseOutlined,
+  UnorderedListOutlined,
+  TagOutlined,
+  LinkOutlined,
+  RollbackOutlined,
+  AppstoreOutlined,
+  VerticalAlignBottomOutlined,
+  CodeOutlined,
+  CommentOutlined,
+  CrownOutlined,
+  EyeOutlined,
+  HourglassOutlined,
+  LockOutlined,
+  UnlockOutlined,
+  ProfileOutlined,
+  SafetyCertificateOutlined,
+  ThunderboltOutlined,
+  BarsOutlined,
+};
+
+// ============================================================================
+// FONTAWESOME ICON MAP
+// ============================================================================
+export const faIcons: Record<string, React.ComponentType<any>> = {
+  FaHouse,
+  FaUser,
+  FaGear,
+  FaMagnifyingGlass,
+  FaPlus,
+  FaTrash,
+  FaPencil,
+  FaDownload,
+  FaUpload,
+  FaLink,
+  FaGithub,
+  FaGitlab,
+  FaCheck,
+  FaXmark,
+  FaTriangleExclamation,
+  FaCircleInfo,
+  FaCircleQuestion,
+  FaArrowLeft,
+  FaArrowRight,
+  FaArrowUp,
+  FaArrowDown,
+  FaCopy,
+  FaEye,
+  FaEyeSlash,
+  FaLock,
+  FaUnlock,
+  FaCloud,
+  FaServer,
+  FaDatabase,
+  FaTerminal,
+  FaCode,
+  FaFile,
+  FaFolder,
+  FaFolderOpen,
+  FaChevronDown,
+  FaChevronUp,
+  FaChevronLeft,
+  FaChevronRight,
+  FaEllipsis,
+  FaEllipsisVertical,
+  FaSpinner,
+  FaCircleNotch,
+  FaArrowsRotate,
+  FaClock,
+  FaCalendar,
+  FaBell,
+  FaEnvelope,
+  FaPhone,
+  FaLocationDot,
+  FaHeart,
+  FaStar,
+  FaAsterisk,
+  FaAws,
+  FaGoogle,
+  FaDocker,
+  FaSlack,
+  FaDiscord,
+  FaTwitter,
+  FaLinkedin,
+  FaFacebook,
+  FaBuilding,
+};
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/**
+ * Get an Ant Design icon by name
+ * Returns the icon component if found, otherwise returns FallbackIcon
+ *
+ * @param name - The name of the icon (e.g., "QuestionCircleOutlined")
+ * @returns The icon component or FallbackIcon if not found
+ */
+export function getIcon(name: string): React.ComponentType<any> {
+  return antdIcons[name] || FallbackIcon;
+}
+
+/**
+ * Get a FontAwesome icon by name
+ * Returns the icon component if found, otherwise returns FallbackIcon
+ *
+ * @param name - The name of the icon (e.g., "FaHome")
+ * @returns The icon component or FallbackIcon if not found
+ */
+export function getFaIcon(name: string): React.ComponentType<any> {
+  return faIcons[name] || FallbackIcon;
+}
+
+// ============================================================================
+// RE-EXPORTS FOR CONVENIENCE
+// ============================================================================
+// Export all Ant Design icons
+export {
+  QuestionCircleOutlined,
+  CheckCircleOutlined,
+  CloseCircleOutlined,
+  ExclamationCircleOutlined,
+  InfoCircleOutlined,
+  MinusCircleOutlined,
+  PauseCircleOutlined,
+  DeleteOutlined,
+  EditOutlined,
+  PlusOutlined,
+  CopyOutlined,
+  DownloadOutlined,
+  UploadOutlined,
+  ExportOutlined,
+  ImportOutlined,
+  SearchOutlined,
+  SettingOutlined,
+  ArrowLeftOutlined,
+  ArrowRightOutlined,
+  ArrowUpOutlined,
+  ArrowDownOutlined,
+  DownOutlined,
+  MenuOutlined,
+  HomeOutlined,
+  UserOutlined,
+  PoweroffOutlined,
+  GithubOutlined,
+  GitlabOutlined,
+  BankOutlined,
+  TeamOutlined,
+  FileJpgOutlined,
+  CloudOutlined,
+  CloudServerOutlined,
+  CloudUploadOutlined,
+  ClockCircleOutlined,
+  LoadingOutlined,
+  SyncOutlined,
+  PlayCircleOutlined,
+  StopOutlined,
+  CheckOutlined,
+  CloseOutlined,
+  UnorderedListOutlined,
+  TagOutlined,
+  LinkOutlined,
+  RollbackOutlined,
+  AppstoreOutlined,
+  VerticalAlignBottomOutlined,
+  CodeOutlined,
+  CommentOutlined,
+  CrownOutlined,
+  EyeOutlined,
+  HourglassOutlined,
+  LockOutlined,
+  UnlockOutlined,
+  ProfileOutlined,
+  SafetyCertificateOutlined,
+  ThunderboltOutlined,
+  BarsOutlined,
+};
+
+// Export all FontAwesome icons
+export {
+  FaHouse,
+  FaUser,
+  FaGear,
+  FaMagnifyingGlass,
+  FaPlus,
+  FaTrash,
+  FaPencil,
+  FaDownload,
+  FaUpload,
+  FaLink,
+  FaGithub,
+  FaGitlab,
+  FaCheck,
+  FaXmark,
+  FaTriangleExclamation,
+  FaCircleInfo,
+  FaCircleQuestion,
+  FaArrowLeft,
+  FaArrowRight,
+  FaArrowUp,
+  FaArrowDown,
+  FaCopy,
+  FaEye,
+  FaEyeSlash,
+  FaLock,
+  FaUnlock,
+  FaCloud,
+  FaServer,
+  FaDatabase,
+  FaTerminal,
+  FaCode,
+  FaFile,
+  FaFolder,
+  FaFolderOpen,
+  FaChevronDown,
+  FaChevronUp,
+  FaChevronLeft,
+  FaChevronRight,
+  FaEllipsis,
+  FaEllipsisVertical,
+  FaSpinner,
+  FaCircleNotch,
+  FaArrowsRotate,
+  FaClock,
+  FaCalendar,
+  FaBell,
+  FaEnvelope,
+  FaPhone,
+  FaLocationDot,
+  FaHeart,
+  FaStar,
+  FaAsterisk,
+  FaAws,
+  FaGoogle,
+  FaDocker,
+  FaSlack,
+  FaDiscord,
+  FaTwitter,
+  FaLinkedin,
+  FaFacebook,
+  FaBuilding,
+};

--- a/ui/src/config/themeConfig.ts
+++ b/ui/src/config/themeConfig.ts
@@ -3,22 +3,167 @@ import { ThemeConfig, theme } from "antd";
 export type ColorSchemeOption = "default" | "terrakube";
 export type ThemeMode = "light" | "dark";
 
+const darkThemeTokens = {
+  // Backgrounds - rich dark, not pure black
+  colorBgBase: "#0d1117",
+  colorBgContainer: "#161b22",
+  colorBgElevated: "#1c2128",
+  colorBgLayout: "#0d1117",
+  colorBgSpotlight: "#21262d",
+
+  // Borders - subtle but visible
+  colorBorder: "#30363d",
+  colorBorderSecondary: "#21262d",
+
+  // Text - high contrast
+  colorText: "#e6edf3",
+  colorTextSecondary: "#8b949e",
+  colorTextTertiary: "#6e7681",
+  colorTextQuaternary: "#484f58",
+
+  // Fill colors
+  colorFill: "#21262d",
+  colorFillSecondary: "#30363d",
+  colorFillTertiary: "#161b22",
+  colorFillQuaternary: "#0d1117",
+
+  // Split/divider
+  colorSplit: "#21262d",
+};
+
 export const getThemeConfig = (colorScheme: ColorSchemeOption, themeMode: ThemeMode): ThemeConfig => {
   const colorPrimary = colorScheme === "default" ? "#1890ff" : "#722ED1";
 
+  if (typeof document !== "undefined" && document.documentElement) {
+    document.documentElement.setAttribute("data-theme", themeMode);
+    document.documentElement.setAttribute("data-color-scheme", colorScheme);
+  }
+
+  if (themeMode === "dark") {
+    const isTerrakube = colorScheme === "terrakube";
+    return {
+      algorithm: theme.darkAlgorithm,
+      token: {
+        colorPrimary,
+        ...darkThemeTokens,
+        colorPrimaryBg: isTerrakube ? "#1a0a2e" : "#0d2942",
+        colorPrimaryBgHover: isTerrakube ? "#2d1548" : "#113a5d",
+      },
+      components: {
+        Layout: {
+          headerBg: "#161b22",
+          bodyBg: "#0d1117",
+          footerBg: "#0d1117",
+        },
+        Menu: {
+          darkItemBg: "#161b22",
+          darkPopupBg: "#161b22",
+          darkItemSelectedBg: "#21262d",
+          darkItemHoverBg: "#21262d",
+          itemBg: "#161b22",
+          popupBg: "#161b22",
+        },
+        Card: {
+          colorBgContainer: "#161b22",
+          colorBorderSecondary: "#30363d",
+        },
+        Input: {
+          colorBgContainer: "#0d1117",
+          colorBorder: "#30363d",
+        },
+        Select: {
+          colorBgContainer: "#0d1117",
+          colorBgElevated: "#1c2128",
+          optionSelectedBg: "#21262d",
+        },
+        Button: {
+          defaultBg: "#21262d",
+          defaultBorderColor: "#30363d",
+          defaultColor: "#e6edf3",
+        },
+        Table: {
+          colorBgContainer: "#161b22",
+          headerBg: "#1c2128",
+          rowHoverBg: "#21262d",
+        },
+        Modal: {
+          contentBg: "#1c2128",
+          headerBg: "#1c2128",
+        },
+        Drawer: {
+          colorBgElevated: "#1c2128",
+        },
+        Dropdown: {
+          colorBgElevated: "#1c2128",
+        },
+        Popover: {
+          colorBgElevated: "#1c2128",
+        },
+        Segmented: {
+          itemSelectedBg: "#30363d",
+          trackBg: "#161b22",
+        },
+        Tabs: {
+          itemColor: "#8b949e",
+          itemSelectedColor: "#e6edf3",
+          itemHoverColor: "#e6edf3",
+        },
+        Tag: {
+          defaultBg: "#21262d",
+          defaultColor: "#e6edf3",
+        },
+        Badge: {
+          colorBgContainer: "#161b22",
+        },
+        Divider: {
+          colorSplit: "#30363d",
+        },
+        Breadcrumb: {
+          itemColor: "#8b949e",
+          linkColor: "#8b949e",
+          linkHoverColor: "#e6edf3",
+          separatorColor: "#6e7681",
+        },
+        Typography: {
+          colorText: "#e6edf3",
+          colorTextSecondary: "#8b949e",
+        },
+        Form: {
+          labelColor: "#e6edf3",
+        },
+        Alert: {
+          colorText: "#e6edf3",
+          defaultPadding: "8px 12px",
+        },
+        Checkbox: {
+          colorBgContainer: "#0d1117",
+          colorBorder: "#30363d",
+        },
+        Radio: {
+          colorBgContainer: "#0d1117",
+          colorBorder: "#30363d",
+        },
+        Pagination: {
+          itemActiveBg: "#21262d",
+          itemBg: "#0d1117",
+        },
+      },
+    };
+  }
+
   return {
-    algorithm: themeMode === "dark" ? theme.darkAlgorithm : theme.defaultAlgorithm,
+    algorithm: theme.defaultAlgorithm,
     token: {
       colorPrimary,
     },
     components: {
       Menu: {
-        darkItemBg: "#000000",
-        darkPopupBg: "#000000",
-        darkSubMenuItemBg: "#000000",
+        darkItemBg: "#1e2837",
+        darkPopupBg: "#1e2837",
+        darkSubMenuItemBg: "#1e2837",
       },
       Layout: {
-        headerBg: "#000000",
+        headerBg: "#1e2837",
       },
     },
   };

--- a/ui/src/context/ThemeContext.tsx
+++ b/ui/src/context/ThemeContext.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, ReactNode, useContext, useState } from "react";
+import { ColorSchemeOption, ThemeMode, defaultColorScheme, defaultThemeMode } from "../config/themeConfig";
+
+interface ThemeContextType {
+  colorScheme: ColorSchemeOption;
+  themeMode: ThemeMode;
+  setColorScheme: (scheme: ColorSchemeOption) => void;
+  setThemeMode: (mode: ThemeMode) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const getStoredColorScheme = (): ColorSchemeOption => {
+  if (typeof window === "undefined") {
+    return defaultColorScheme;
+  }
+
+  const saved = localStorage.getItem("terrakube-color-scheme") as ColorSchemeOption | null;
+  return saved || defaultColorScheme;
+};
+
+const getStoredThemeMode = (): ThemeMode => {
+  if (typeof window === "undefined") {
+    return defaultThemeMode;
+  }
+
+  const saved = localStorage.getItem("terrakube-theme-mode") as ThemeMode | null;
+  return saved || defaultThemeMode;
+};
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [colorScheme, setColorSchemeState] = useState<ColorSchemeOption>(getStoredColorScheme);
+  const [themeMode, setThemeModeState] = useState<ThemeMode>(getStoredThemeMode);
+
+  const setColorScheme = (scheme: ColorSchemeOption) => {
+    localStorage.setItem("terrakube-color-scheme", scheme);
+    setColorSchemeState(scheme);
+  };
+
+  const setThemeMode = (mode: ThemeMode) => {
+    localStorage.setItem("terrakube-theme-mode", mode);
+    setThemeModeState(mode);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ colorScheme, themeMode, setColorScheme, setThemeMode }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+
+  return context;
+};

--- a/ui/src/domain/Home/App.tsx
+++ b/ui/src/domain/Home/App.tsx
@@ -1,35 +1,71 @@
 import { Layout, ConfigProvider } from "antd";
-import { useState, useEffect } from "react";
-import { RouterProvider, createBrowserRouter, Outlet, useParams } from "react-router-dom";
-import { useAuth } from "../../config/authConfig";
+import { lazy, Suspense, useState, useEffect, type Dispatch, type SetStateAction } from "react";
+import { AxiosResponse } from "axios";
 import {
-  getThemeConfig,
-  ColorSchemeOption,
-  ThemeMode,
-  defaultColorScheme,
-  defaultThemeMode,
-} from "../../config/themeConfig";
+  RouterProvider,
+  createBrowserRouter,
+  Outlet,
+  useParams,
+  useNavigate,
+  useOutletContext,
+} from "react-router-dom";
+import { useAuth } from "../../config/authConfig";
+import { getThemeConfig } from "../../config/themeConfig";
+import { ThemeProvider, useTheme } from "../../context/ThemeContext";
 import Login from "../Login/Login";
-import { CreateModule } from "../Modules/Create";
-import { ModuleDetails } from "../Modules/Details";
-import { PublicRegistrySearch } from "../Modules/PublicRegistrySearch";
-import { ProviderDetails } from "../Providers/ProviderDetails";
-import { Registry } from "../Modules/Registry";
-import { CreateOrganization } from "../Organizations/Create";
-import { OrganizationSettings } from "../Settings/Settings";
-import { CreateWorkspace } from "../Workspaces/Create";
-import { WorkspaceDetails } from "../Workspaces/Details";
-import { ImportWorkspace } from "../Workspaces/Import";
 import "./App.css";
 import MainMenu from "./MainMenu";
-import { ProfilePicture } from "./ProfilePicture";
+import { HelpMenu } from "@/components/HelpMenu";
+import LoadingFallback from "@/components/LoadingFallback";
+import { UserMenu } from "@/components/UserMenu";
+import { OrganizationSelector } from "@/components/OrganizationSelector";
 import logo from "./white_logo.png";
-import { UserSettingsPage } from "@/modules/user/UserSettingsPage";
-import OrganizationsPickerPage from "@/modules/organizations/OrganizationsPickerPage";
-import OrganizationsDetailPage from "@/modules/organizations/OrganizationDetailsPage";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "../../config/actionTypes";
 import axiosInstance from "../../config/axiosConfig";
+import { ApiResponse, FlatOrganization, Organization } from "../types";
 const { Header, Footer } = Layout;
+
+type AppRouteContext = {
+  organizationName: string;
+  setOrganizationName: Dispatch<SetStateAction<string>>;
+};
+
+// Organizations
+const CreateOrganization = lazy(() =>
+  import("../Organizations/Create").then((module) => ({ default: module.CreateOrganization }))
+);
+const OrganizationsPickerPage = lazy(() => import("@/modules/organizations/OrganizationsPickerPage"));
+const OrganizationsDetailPage = lazy(() => import("@/modules/organizations/OrganizationDetailsPage"));
+
+// Workspaces
+const CreateWorkspace = lazy(() =>
+  import("../Workspaces/Create").then((module) => ({ default: module.CreateWorkspace }))
+);
+const ImportWorkspace = lazy(() =>
+  import("../Workspaces/Import").then((module) => ({ default: module.ImportWorkspace }))
+);
+const WorkspaceDetails = lazy(() =>
+  import("../Workspaces/Details").then((module) => ({ default: module.WorkspaceDetails }))
+);
+
+// Modules and registry
+const CreateModule = lazy(() => import("../Modules/Create").then((module) => ({ default: module.CreateModule })));
+const Registry = lazy(() => import("../Modules/Registry").then((module) => ({ default: module.Registry })));
+const PublicRegistrySearch = lazy(() =>
+  import("../Modules/PublicRegistrySearch").then((module) => ({ default: module.PublicRegistrySearch }))
+);
+const ProviderDetails = lazy(() =>
+  import("../Providers/ProviderDetails").then((module) => ({ default: module.ProviderDetails }))
+);
+const ModuleDetails = lazy(() => import("../Modules/Details").then((module) => ({ default: module.ModuleDetails })));
+
+// Settings
+const OrganizationSettings = lazy(() =>
+  import("../Settings/Settings").then((module) => ({ default: module.OrganizationSettings }))
+);
+const UserSettingsPage = lazy(() =>
+  import("@/modules/user/UserSettingsPage").then((module) => ({ default: module.UserSettingsPage }))
+);
 
 // Helper component to extract URL parameters for collection routes
 const CollectionSettingsWrapper = ({ mode }: { mode: "edit" | "detail" }) => {
@@ -37,25 +73,50 @@ const CollectionSettingsWrapper = ({ mode }: { mode: "edit" | "detail" }) => {
   return <OrganizationSettings selectedTab="9" collectionMode={mode} collectionId={collectionid} />;
 };
 
-const App = () => {
-  const auth = useAuth();
+const useAppRouteContext = () => useOutletContext<AppRouteContext>();
+
+const CreateOrganizationRoute = () => {
+  const { setOrganizationName } = useAppRouteContext();
+  return <CreateOrganization setOrganizationName={setOrganizationName} />;
+};
+
+const OrganizationsDetailRoute = () => {
+  const { organizationName, setOrganizationName } = useAppRouteContext();
+  return <OrganizationsDetailPage setOrganizationName={setOrganizationName} organizationName={organizationName} />;
+};
+
+const WorkspaceDetailsRoute = ({ selectedTab }: { selectedTab?: string }) => {
+  const { setOrganizationName } = useAppRouteContext();
+  return <WorkspaceDetails setOrganizationName={setOrganizationName} selectedTab={selectedTab} />;
+};
+
+const RegistryRoute = () => {
+  const { organizationName, setOrganizationName } = useAppRouteContext();
+  return <Registry setOrganizationName={setOrganizationName} organizationName={organizationName} />;
+};
+
+const PublicRegistrySearchRoute = () => {
+  const { organizationName } = useAppRouteContext();
+  return <PublicRegistrySearch organizationName={organizationName} />;
+};
+
+const ProviderDetailsRoute = () => {
+  const { organizationName } = useAppRouteContext();
+  return <ProviderDetails organizationName={organizationName} />;
+};
+
+const ModuleDetailsRoute = () => {
+  const { organizationName } = useAppRouteContext();
+  return <ModuleDetails organizationName={organizationName} />;
+};
+
+const AppLayout = () => {
+  const navigate = useNavigate();
   const [organizationName, setOrganizationName] = useState<string>("");
-  const [colorScheme, setColorScheme] = useState<ColorSchemeOption>(defaultColorScheme);
-  const [themeMode, setThemeMode] = useState<ThemeMode>(defaultThemeMode);
-  const expiry = auth?.user?.expires_at;
+  const [orgs, setOrgs] = useState<FlatOrganization[]>([]);
+  const { colorScheme, themeMode } = useTheme();
 
   useEffect(() => {
-    // Load color scheme and theme mode preferences from localStorage
-    const savedScheme = localStorage.getItem("terrakube-color-scheme") as ColorSchemeOption;
-    const savedThemeMode = localStorage.getItem("terrakube-theme-mode") as ThemeMode;
-    if (savedScheme) {
-      setColorScheme(savedScheme);
-    }
-    if (savedThemeMode) {
-      setThemeMode(savedThemeMode);
-    }
-
-    // Initialize organization name from URL or session storage
     const pathname = window.location.pathname;
     const paths = pathname.split("/");
     const orgIdIndex = paths.indexOf("organizations") + 1;
@@ -63,14 +124,12 @@ const App = () => {
     if (orgIdIndex > 0 && orgIdIndex < paths.length) {
       const orgId = paths[orgIdIndex];
       if (orgId) {
-        // Check if we already have the org name in session storage
         const storedOrgName = sessionStorage.getItem(ORGANIZATION_NAME);
         const storedOrgId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
 
         if (storedOrgName && storedOrgId === orgId) {
           setOrganizationName(storedOrgName);
         } else {
-          // Fetch the organization name
           axiosInstance
             .get(`organization/${orgId}`)
             .then((response) => {
@@ -87,13 +146,72 @@ const App = () => {
         }
       }
     } else {
-      // No org ID in URL, use session storage if available
       const storedOrgName = sessionStorage.getItem(ORGANIZATION_NAME);
       if (storedOrgName) {
         setOrganizationName(storedOrgName);
       }
     }
   }, []);
+
+  useEffect(() => {
+    axiosInstance
+      .get("organization")
+      .then((response: AxiosResponse<ApiResponse<Organization[]>>) => {
+        const organizations = prepareOrgs(response.data.data);
+        setOrgs(organizations);
+      })
+      .catch((error) => {
+        console.error("Failed to load organizations:", error);
+      });
+  }, []);
+
+  const handleOrgChange = (orgId: string) => {
+    const org = orgs.find((o) => o.id === orgId);
+    if (org) {
+      sessionStorage.setItem(ORGANIZATION_ARCHIVE, orgId);
+      sessionStorage.setItem(ORGANIZATION_NAME, org.name);
+      setOrganizationName(org.name);
+    }
+    navigate(`/organizations/${orgId}/workspaces`);
+  };
+
+  return (
+    <ConfigProvider key={`${colorScheme}-${themeMode}`} theme={getThemeConfig(colorScheme, themeMode)}>
+      <Layout className="layout mh-100" key={organizationName || "no-org"}>
+        <Header>
+          <a>
+            <img className="logo" src={logo} alt="Logo"></img>
+          </a>
+          <OrganizationSelector
+            organizationName={organizationName}
+            organizations={orgs}
+            onOrgChange={handleOrgChange}
+            onManageOrgs={() => navigate("/organizations")}
+          />
+          <div className="menu">
+            <MainMenu
+              organizationName={organizationName}
+              setOrganizationName={setOrganizationName}
+              themeMode={themeMode}
+            />
+          </div>
+          <div className="user">
+            <HelpMenu />
+            <UserMenu />
+          </div>
+        </Header>
+        <Outlet context={{ organizationName, setOrganizationName }} />
+        <Footer style={{ textAlign: "center" }}>
+          Terrakube {window._env_.REACT_APP_TERRAKUBE_VERSION} ©{new Date().getFullYear()}
+        </Footer>
+      </Layout>
+    </ConfigProvider>
+  );
+};
+
+const App = () => {
+  const auth = useAuth();
+  const expiry = auth?.user?.expires_at;
 
   // Checking with the expiry time in the localstorage and when it has crossed the access has been revoked so It will clear the local storage and by default with no localstorage object it will route to login page.
   if (auth.isAuthenticated && auth?.user && expiry !== undefined && Math.floor(Date.now() / 1000) > expiry) {
@@ -111,45 +229,23 @@ const App = () => {
   const router = createBrowserRouter([
     {
       path: "/",
-      element: (
-        <ConfigProvider theme={getThemeConfig(colorScheme, themeMode)}>
-          <Layout className="layout mh-100">
-            <Header>
-              <a>
-                <img className="logo" src={logo} alt="Logo"></img>
-              </a>
-              <div className="menu">
-                <MainMenu
-                  organizationName={organizationName}
-                  setOrganizationName={setOrganizationName}
-                  themeMode={themeMode}
-                />
-              </div>
-              <div className="user">
-                <ProfilePicture />
-              </div>
-            </Header>
-            <Outlet />
-            <Footer style={{ textAlign: "center" }}>
-              Terrakube {window._env_.REACT_APP_TERRAKUBE_VERSION} ©{new Date().getFullYear()}
-            </Footer>
-          </Layout>
-        </ConfigProvider>
-      ),
+      element: <AppLayout />,
       children: [
         {
           path: "/",
           element: <OrganizationsPickerPage />,
         },
         {
+          path: "/organizations",
+          element: <OrganizationsPickerPage />,
+        },
+        {
           path: "/organizations/create",
-          element: <CreateOrganization setOrganizationName={setOrganizationName} />,
+          element: <CreateOrganizationRoute />,
         },
         {
           path: "/organizations/:id/workspaces",
-          element: (
-            <OrganizationsDetailPage setOrganizationName={setOrganizationName} organizationName={organizationName} />
-          ),
+          element: <OrganizationsDetailRoute />,
         },
         {
           path: "/workspaces/create",
@@ -161,67 +257,67 @@ const App = () => {
         },
         {
           path: "/workspaces/:id",
-          element: <WorkspaceDetails setOrganizationName={setOrganizationName} />,
+          element: <WorkspaceDetailsRoute />,
         },
         {
           path: "/organizations/:orgid/workspaces/:id",
-          element: <WorkspaceDetails setOrganizationName={setOrganizationName} />,
+          element: <WorkspaceDetailsRoute />,
         },
         {
           path: "/workspaces/:id/runs",
-          element: <WorkspaceDetails setOrganizationName={setOrganizationName} selectedTab="2" />,
+          element: <WorkspaceDetailsRoute selectedTab="2" />,
         },
         {
           path: "/organizations/:orgid/workspaces/:id/runs",
-          element: <WorkspaceDetails setOrganizationName={setOrganizationName} selectedTab="2" />,
+          element: <WorkspaceDetailsRoute selectedTab="2" />,
         },
         {
           path: "/workspaces/:id/runs/:runid",
-          element: <WorkspaceDetails setOrganizationName={setOrganizationName} selectedTab="2" />,
+          element: <WorkspaceDetailsRoute selectedTab="2" />,
         },
         {
           path: "/organizations/:orgid/workspaces/:id/runs/:runid",
-          element: <WorkspaceDetails setOrganizationName={setOrganizationName} selectedTab="2" />,
+          element: <WorkspaceDetailsRoute selectedTab="2" />,
         },
         {
           path: "/workspaces/:id/states",
-          element: <WorkspaceDetails setOrganizationName={setOrganizationName} selectedTab="3" />,
+          element: <WorkspaceDetailsRoute selectedTab="3" />,
         },
         {
           path: "/organizations/:orgid/workspaces/:id/states",
-          element: <WorkspaceDetails setOrganizationName={setOrganizationName} selectedTab="3" />,
+          element: <WorkspaceDetailsRoute selectedTab="3" />,
         },
         {
           path: "/workspaces/:id/variables",
-          element: <WorkspaceDetails setOrganizationName={setOrganizationName} selectedTab="4" />,
+          element: <WorkspaceDetailsRoute selectedTab="4" />,
         },
         {
           path: "/organizations/:orgid/workspaces/:id/variables",
-          element: <WorkspaceDetails setOrganizationName={setOrganizationName} selectedTab="4" />,
+          element: <WorkspaceDetailsRoute selectedTab="4" />,
         },
         {
           path: "/workspaces/:id/schedules",
-          element: <WorkspaceDetails setOrganizationName={setOrganizationName} selectedTab="5" />,
+          element: <WorkspaceDetailsRoute selectedTab="5" />,
         },
         {
           path: "/organizations/:orgid/workspaces/:id/schedules",
-          element: <WorkspaceDetails setOrganizationName={setOrganizationName} selectedTab="5" />,
+          element: <WorkspaceDetailsRoute selectedTab="5" />,
         },
         {
           path: "/workspaces/:id/settings",
-          element: <WorkspaceDetails setOrganizationName={setOrganizationName} selectedTab="6" />,
+          element: <WorkspaceDetailsRoute selectedTab="6" />,
         },
         {
           path: "/organizations/:orgid/workspaces/:id/settings",
-          element: <WorkspaceDetails setOrganizationName={setOrganizationName} selectedTab="6" />,
+          element: <WorkspaceDetailsRoute selectedTab="6" />,
         },
         {
           path: "/organizations/:orgid/registry",
-          element: <Registry setOrganizationName={setOrganizationName} organizationName={organizationName} />,
+          element: <RegistryRoute />,
         },
         {
           path: "/organizations/:orgid/registry/search",
-          element: <PublicRegistrySearch organizationName={organizationName} />,
+          element: <PublicRegistrySearchRoute />,
         },
         {
           path: "/organizations/:orgid/registry/create",
@@ -229,11 +325,11 @@ const App = () => {
         },
         {
           path: "/organizations/:orgid/registry/providers/:providerid",
-          element: <ProviderDetails organizationName={organizationName} />,
+          element: <ProviderDetailsRoute />,
         },
         {
           path: "/organizations/:orgid/registry/:id",
-          element: <ModuleDetails organizationName={organizationName} />,
+          element: <ModuleDetailsRoute />,
         },
         {
           path: "/organizations/:orgid/settings",
@@ -295,7 +391,21 @@ const App = () => {
     },
   ]);
 
-  return <RouterProvider router={router} />;
+  return (
+    <ThemeProvider>
+      <Suspense fallback={<LoadingFallback />}>
+        <RouterProvider router={router} />
+      </Suspense>
+    </ThemeProvider>
+  );
 };
+
+function prepareOrgs(organizations: Organization[]): FlatOrganization[] {
+  return organizations.map((element) => ({
+    id: element.id,
+    name: element.attributes.name,
+    description: element.attributes.description,
+  }));
+}
 
 export default App;

--- a/ui/src/domain/Home/Home.css
+++ b/ui/src/domain/Home/Home.css
@@ -4,23 +4,35 @@
   margin-block: 10px;
 }
 
+.ant-layout-header {
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+}
+
 .logo {
-  float: left;
   width: 35px;
-  margin-top: 16px;
-  margin-right: 10px;
+  margin-right: 16px;
 }
 
 .user {
-  float: right;
-  height: 51px;
-  margin: 4px 0 10px 0;
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  gap: 8px;
 }
 
 .menu {
-  float: left;
-  width: 60%;
+  flex: 1;
+  min-width: 0;
+  margin-left: 16px;
 }
+
+.org-selector-container {
+  margin-right: 16px;
+}
+
 .site-layout-content {
   min-height: 600px;
   padding: 24px;
@@ -33,4 +45,20 @@
 
 .avatar-hover-effect:hover {
   color: #fff;
+}
+
+/* Round corners on selected menu item and add spacing */
+.ant-layout-header .ant-menu-horizontal .ant-menu-item {
+  border-radius: 8px !important;
+  margin: 0 4px !important;
+}
+
+.ant-layout-header .ant-menu-horizontal .ant-menu-item-selected {
+  border-radius: 8px !important;
+  background-color: var(--ant-color-primary) !important;
+  border: none !important;
+}
+
+.menu {
+  margin-left: 32px !important;
 }

--- a/ui/src/domain/Home/MainMenu.tsx
+++ b/ui/src/domain/Home/MainMenu.tsx
@@ -1,10 +1,4 @@
-import {
-  AppstoreOutlined,
-  CloudOutlined,
-  DownCircleOutlined,
-  PlusCircleOutlined,
-  SettingOutlined,
-} from "@ant-design/icons";
+import { AppstoreOutlined, CloudOutlined, SettingOutlined } from "@ant-design/icons";
 import { Menu } from "antd";
 import "antd/dist/reset.css";
 import { AxiosResponse } from "axios";
@@ -132,43 +126,15 @@ export const MainMenu = ({ organizationName, setOrganizationName, themeMode }: P
 
   const handleSectionNavigation = (section: string) => {
     // Use the helper function for section navigation
-    ensureOrganizationName(organizationId!, organizationName, setOrganizationName, () => {
+    ensureOrganizationName(orgIdFromUrl!, organizationName, setOrganizationName, () => {
       // Navigate within the same organization
-      navigate(`/organizations/${organizationId}/${section}`);
+      navigate(`/organizations/${orgIdFromUrl}/${section}`);
       setDefaultSelected([section]);
     });
   };
 
   const items = [
-    {
-      label: organizationName,
-      key: "organization-name",
-      icon: <DownCircleOutlined />,
-      children: [
-        {
-          label: "Create new organization",
-          key: "new",
-          icon: <PlusCircleOutlined />,
-          onClick: handleClick,
-        },
-        {
-          type: "divider",
-        },
-        {
-          type: "group",
-          label: "Organizations",
-          children: orgs
-            .sort((a, b) => a.name.localeCompare(b.name))
-            .map((org) => ({
-              label: org.name,
-              key: org.id,
-              onClick: handleClick,
-            })),
-        },
-      ],
-    },
-
-    ...(organizationId
+    ...(orgIdFromUrl
       ? [
           {
             label: "Workspaces",

--- a/ui/src/domain/Jobs/Create.tsx
+++ b/ui/src/domain/Jobs/Create.tsx
@@ -139,7 +139,8 @@ export const CreateJob = ({ changeJob, planJob = true }: Props) => {
               name="templateId"
               label="Choose job type"
               rules={[{ required: true }]}
-              initialValue={defaultTemplate}>
+              initialValue={defaultTemplate}
+            >
               {loading || !templates ? (
                 <p>Data loading...</p>
               ) : (

--- a/ui/src/domain/Jobs/Details.tsx
+++ b/ui/src/domain/Jobs/Details.tsx
@@ -6,8 +6,6 @@ import {
   CloseOutlined,
   CommentOutlined,
   ExclamationCircleOutlined,
-  LoadingOutlined,
-  MinusCircleOutlined,
   StopOutlined,
   SyncOutlined,
   UserOutlined,
@@ -16,9 +14,10 @@ import { Avatar, Button, Card, Collapse, message, Radio, RadioChangeEvent, Space
 import { AxiosResponse } from "axios";
 import parse from "html-react-parser";
 import { DateTime } from "luxon";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ORGANIZATION_ARCHIVE } from "../../config/actionTypes";
 import axiosInstance, { axiosClient } from "../../config/axiosConfig";
+import { useAbortController, usePolling } from "../../hooks";
 import { Job, JobStep } from "../types";
 import { TerminalOutput } from "./TerminalOutput";
 
@@ -37,19 +36,30 @@ export const DetailsJob = ({ jobId }: Props) => {
   const [steps, setSteps] = useState<JobStep[]>([]);
   const [uiType, setUIType] = useState("structured");
   const [uiTemplates, setUITemplates] = useState<Record<number, string>>({});
-  const outputLog = async (output: string, status: string) => {
+  const { getSignal: getJobSignal, abort: abortJobRequests } = useAbortController();
+  const { getSignal: getContextSignal, abort: abortContextRequests } = useAbortController();
+  const jobRequestRef = useRef(0);
+  const contextRequestRef = useRef(0);
+  const pollRequestRef = useRef(0);
+
+  const isAbortError = (error: unknown) => {
+    return error instanceof Error && (error.name === "AbortError" || error.name === "CanceledError");
+  };
+
+  const outputLog = async (output: string | undefined, status: string, signal: AbortSignal) => {
     if (output != null) {
       const apiDomain = new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).hostname;
-      if (output.includes(apiDomain))
-        return axiosInstance
-          .get(output)
-          .then((resp) => resp.data)
-          .catch(() => "No logs available");
-      else
-        return axiosClient
-          .get(output)
-          .then((resp) => resp.data)
-          .catch(() => "No logs available");
+      try {
+        if (output.includes(apiDomain)) {
+          const response = await axiosInstance.get(output, { signal });
+          return response.data;
+        }
+
+        const response = await axiosClient.get(output, { signal });
+        return response.data;
+      } catch {
+        return "No logs available";
+      }
     } else {
       if (status === "running") return "Initializing the backend...";
       else return "Waiting logs...";
@@ -167,60 +177,122 @@ export const DetailsJob = ({ jobId }: Props) => {
 
   useEffect(() => {
     setLoading(true);
-    loadJob();
-    loadContext();
-    setLoading(false);
-    const interval = setInterval(() => {
-      loadJob();
-      loadContext();
-    }, 5000);
-    return () => clearInterval(interval);
-  }, [jobId]);
+    abortJobRequests();
+    abortContextRequests();
+  }, [jobId, abortContextRequests, abortJobRequests]);
 
-  const loadJob = () => {
-    const jobSteps: JobStep[] = [];
-    axiosInstance.get(`organization/${organizationId}/job/${jobId}?include=step,workspace`).then((response) => {
-      (async () => {
-        setJob(response.data);
-        if (response.data.included != null) {
-          for (const element of response.data.included) {
-              if (element.type === "step") {
-                  const log = await outputLog(element.attributes.output, element.attributes.status);
-                  jobSteps.push({
-                      id: element.id,
-                      stepNumber: element.attributes.stepNumber,
-                      status: element.attributes.status,
-                      output: element.attributes.output,
-                      name: element.attributes.name,
-                      outputLog: log,
-                  });
-              } else if (element.type === "workspace") {
-                  setWorkspaceSource(element.attributes.source);
-                  setWorkspaceDefaultBranch(element.attributes.branch);
+  const loadJob = useCallback(async () => {
+    const requestId = ++jobRequestRef.current;
+    const signal = getJobSignal();
 
-                axiosInstance.get(`organization/${organizationId}/workspace/${element.id}`).then((vcsResponse) => {
-                    setWorkspaceVcsId(vcsResponse.data.data.relationships.vcs.data?.id);
-                    if (vcsResponse.data.data.relationships.vcs.data?.id) {
-                        axiosInstance.get(`organization/${organizationId}/vcs/${vcsResponse.data.data.relationships.vcs.data.id}`).then((vcsDataResponse) => {
-                            setWorkspaceVcsName(vcsDataResponse.data.data.attributes.name);
-                        });
-                    }
-                })
-              }
-          }
-        }
-        setSteps(jobSteps.sort(sortbyName));
-      })();
-    });
-  };
+    try {
+      const response = await axiosInstance.get(`organization/${organizationId}/job/${jobId}?include=step,workspace`, {
+        signal,
+      });
+      if (requestId !== jobRequestRef.current) return;
 
-  const loadContext = () => {
+      setJob(response.data);
+
+      const included = response.data.included ?? [];
+      const stepEntries = included.filter((item: any) => item.type === "step");
+      const workspaceEntry = included.find((item: any) => item.type === "workspace");
+
+      const stepsPromise = Promise.all(
+        stepEntries.map(async (stepItem: any) => ({
+          id: stepItem.id,
+          stepNumber: stepItem.attributes.stepNumber,
+          status: stepItem.attributes.status,
+          output: stepItem.attributes.output,
+          name: stepItem.attributes.name,
+          outputLog: await outputLog(stepItem.attributes.output, stepItem.attributes.status, signal),
+        }))
+      );
+
+      const workspacePromise = workspaceEntry
+        ? (async () => {
+            const workspaceResponse = await axiosInstance.get(
+              `organization/${organizationId}/workspace/${workspaceEntry.id}`,
+              { signal }
+            );
+            const vcsId = workspaceResponse.data.data.relationships.vcs.data?.id;
+
+            if (!vcsId) {
+              return {
+                source: workspaceEntry.attributes.source,
+                branch: workspaceEntry.attributes.branch,
+                vcsId: undefined,
+                vcsName: undefined,
+              };
+            }
+
+            const vcsDataResponse = await axiosInstance.get(`organization/${organizationId}/vcs/${vcsId}`, {
+              signal,
+            });
+
+            return {
+              source: workspaceEntry.attributes.source,
+              branch: workspaceEntry.attributes.branch,
+              vcsId,
+              vcsName: vcsDataResponse.data.data.attributes.name,
+            };
+          })()
+        : Promise.resolve(undefined);
+
+      const [jobSteps, workspaceData] = await Promise.all([stepsPromise, workspacePromise]);
+      if (requestId !== jobRequestRef.current) return;
+
+      if (workspaceData) {
+        setWorkspaceSource(workspaceData.source);
+        setWorkspaceDefaultBranch(workspaceData.branch);
+        setWorkspaceVcsId(workspaceData.vcsId);
+        setWorkspaceVcsName(workspaceData.vcsName);
+      } else {
+        setWorkspaceSource(undefined);
+        setWorkspaceDefaultBranch(undefined);
+        setWorkspaceVcsId(undefined);
+        setWorkspaceVcsName(undefined);
+      }
+
+      setSteps(jobSteps.sort(sortbyName));
+    } catch (error) {
+      if (isAbortError(error)) return;
+    }
+  }, [getJobSignal, jobId, organizationId]);
+
+  const loadContext = useCallback(async () => {
+    const requestId = ++contextRequestRef.current;
+    const signal = getContextSignal();
     const api = new URL(window._env_.REACT_APP_TERRAKUBE_API_URL);
 
-    axiosInstance.get(`${api.protocol}//${api.host}/context/v1/${jobId}`).then((response) => {
-      if (response?.data?.terrakubeUI) setUITemplates(response?.data?.terrakubeUI);
-    });
-  };
+    try {
+      const response = await axiosInstance.get(`${api.protocol}//${api.host}/context/v1/${jobId}`, { signal });
+      if (requestId !== contextRequestRef.current) return;
+      if (response?.data?.terrakubeUI) {
+        setUITemplates(response?.data?.terrakubeUI);
+      }
+    } catch (error) {
+      if (isAbortError(error)) return;
+    }
+  }, [getContextSignal, jobId]);
+
+  const refreshJobDetails = useCallback(async () => {
+    const requestId = ++pollRequestRef.current;
+    await Promise.all([loadJob(), loadContext()]);
+    if (requestId === pollRequestRef.current) {
+      setLoading(false);
+    }
+  }, [loadContext, loadJob]);
+
+  usePolling(
+    () => {
+      void refreshJobDetails();
+    },
+    {
+      interval: 5000,
+      enabled: Boolean(jobId),
+      immediate: true,
+    }
+  );
   return (
     <div style={{ marginTop: "14px" }}>
       {loading || !job?.data || !steps ? (
@@ -277,55 +349,57 @@ export const DetailsJob = ({ jobId }: Props) => {
                   <span>
                     <Avatar size="small" shape="square" icon={<UserOutlined />} />{" "}
                     <b>{job.data.attributes.createdBy}</b> triggered a run from {job.data.attributes.via || "UI"}{" "}
-                    {DateTime.fromISO(job.data.attributes.createdDate).toRelative()}
-
+                    {job.data.attributes.createdDate
+                      ? DateTime.fromISO(job.data.attributes.createdDate || "").toRelative()
+                      : ""}
                   </span>
                 ),
-                children: <p>
-
+                children: (
+                  <p>
                     <table>
-                        <tbody>
+                      <tbody>
                         <tr>
-                            <td>JobId:</td>
-                            <td>{ job.data.id }</td>
+                          <td>JobId:</td>
+                          <td>{job.data.id}</td>
                         </tr>
                         {workspaceDefaultBranch !== "remote-content" ? (
-                            <>
-                                <tr>
-                                    <td>Workspace source:</td>
-                                    <td>{workspaceSource}</td>
-                                </tr>
-                                <tr>
-                                    <td>Workspace default branch:</td>
-                                    <td>{workspaceDefaultBranch}</td>
-                                </tr>
-                                <tr>
-                                    <td>Job branch:</td>
-                                    <td>{ job.data.attributes.overrideBranch }</td>
-                                </tr>
-                                <tr>
-                                    <td>Commit:</td>
-                                    <td>{ job.data.attributes.commitId }</td>
-                                </tr>
-                                <tr>
-                                    <td>VcsId:</td>
-                                    <td>{ workspaceVcsId }</td>
-                                </tr>
-                                <tr>
-                                    <td>VcsName:</td>
-                                    <td>{ workspaceVcsName }</td>
-                                </tr>
-                            </>
-                        ):(
-                            <>
-                                <tr>
-                                    <td>Using CLI driven workflow</td>
-                                </tr>
-                            </>
+                          <>
+                            <tr>
+                              <td>Workspace source:</td>
+                              <td>{workspaceSource}</td>
+                            </tr>
+                            <tr>
+                              <td>Workspace default branch:</td>
+                              <td>{workspaceDefaultBranch}</td>
+                            </tr>
+                            <tr>
+                              <td>Job branch:</td>
+                              <td>{(job.data.attributes as any).overrideBranch}</td>
+                            </tr>
+                            <tr>
+                              <td>Commit:</td>
+                              <td>{job.data.attributes.commitId}</td>
+                            </tr>
+                            <tr>
+                              <td>VcsId:</td>
+                              <td>{workspaceVcsId}</td>
+                            </tr>
+                            <tr>
+                              <td>VcsName:</td>
+                              <td>{workspaceVcsName}</td>
+                            </tr>
+                          </>
+                        ) : (
+                          <>
+                            <tr>
+                              <td>Using CLI driven workflow</td>
+                            </tr>
+                          </>
                         )}
-                        </tbody>
+                      </tbody>
                     </table>
-                </p>,
+                  </p>
+                ),
               },
             ]}
           />

--- a/ui/src/domain/Login/Login.css
+++ b/ui/src/domain/Login/Login.css
@@ -1,18 +1,39 @@
-.login-wrapper {
-  width: 328px;
-  margin: 0px auto;
-  padding-top: 200px;
-}
-
 .login-container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
   background-image: url(/background-image.svg);
   background-repeat: no-repeat;
   background-position: center 110px;
   background-size: 100%;
-  height: 100vh;
 }
 
-.loginLogo {
-  width: 230px;
+.login-card {
+  max-width: 400px;
+  width: 100%;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  padding: 48px 40px;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.login-logo {
+  width: 200px;
+  margin: 0 auto 8px;
+  display: block;
+}
+
+/* Logo text color */
+.login-logo {
+  color: #0a0a0a;
+}
+
+[data-theme="dark"] .login-logo {
+  color: #ffffff;
 }

--- a/ui/src/domain/Login/Login.tsx
+++ b/ui/src/domain/Login/Login.tsx
@@ -1,27 +1,43 @@
-import { Button, Card, Space } from "antd";
+import { Button, ConfigProvider, Typography, theme } from "antd";
 import { mgr } from "../../config/authConfig";
+import {
+  ColorSchemeOption,
+  ThemeMode,
+  defaultColorScheme,
+  defaultThemeMode,
+  getThemeConfig,
+} from "../../config/themeConfig";
+import logo from "./logo.svg";
 import "./Login.css";
-import logo from "./logo.jpg";
+
+const { Title, Text } = Typography;
 
 const Login = () => {
+  const savedScheme = (localStorage.getItem("terrakube-color-scheme") as ColorSchemeOption) || defaultColorScheme;
+  const savedThemeMode = (localStorage.getItem("terrakube-theme-mode") as ThemeMode) || defaultThemeMode;
+
   return (
-    <div className="login-container">
-      <div className="login-wrapper">
-        <Card title={<img alt="logo" className="loginLogo" src={logo} />}>
-          <Space orientation="vertical">
-            Sign in to Terrakube
-            <Button type="primary" onClick={() => App()}>
-              Login
-            </Button>
-          </Space>
-        </Card>
-      </div>{" "}
-    </div>
+    <ConfigProvider theme={getThemeConfig(savedScheme, savedThemeMode)}>
+      <LoginContent />
+    </ConfigProvider>
   );
 };
 
-function App() {
-  mgr.signinRedirect();
-}
+const LoginContent = () => {
+  const { token } = theme.useToken();
+
+  return (
+    <div className="login-container" style={{ backgroundColor: token.colorBgLayout }}>
+      <div className="login-card" style={{ backgroundColor: token.colorBgContainer }}>
+        <img src={logo} alt="Terrakube" className="login-logo" />
+        <Title level={3}>Sign in to Terrakube</Title>
+        <Text type="secondary">Click below to continue with your identity provider.</Text>
+        <Button type="primary" block size="large" onClick={() => mgr.signinRedirect()}>
+          Sign in
+        </Button>
+      </div>
+    </div>
+  );
+};
 
 export default Login;

--- a/ui/src/domain/Login/logo.svg
+++ b/ui/src/domain/Login/logo.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="240" height="48" viewBox="0 0 240 48" xmlns="http://www.w3.org/2000/svg">
+  <!-- Pointy-top hexagonal cube, center (24,24), radius 22 -->
+  <!-- Upper-left face (lightest) -->
+  <polygon points="5,35 5,13 24,2 24,24" fill="#D9C7E9" />
+  <!-- Upper-right face (medium) -->
+  <polygon points="24,2 43,13 43,35 24,24" fill="#B694D7" />
+  <!-- Bottom face (darkest) -->
+  <polygon points="43,35 24,46 5,35 24,24" fill="#7A47B7" />
+  <!-- Wordmark -->
+  <text
+    x="58"
+    y="32"
+    font-family="'Montserrat', 'Barlow', system-ui, sans-serif"
+    font-weight="800"
+    font-size="22"
+    letter-spacing="1"
+    fill="currentColor"
+  >TERRAKUBE</text>
+</svg>

--- a/ui/src/domain/Modules/Create.tsx
+++ b/ui/src/domain/Modules/Create.tsx
@@ -113,13 +113,13 @@ export const CreateModule = () => {
             &nbsp;&nbsp;
           </IconContext.Provider>
         );
-        case "AZURE_SP_MI":
-            return (
-                <IconContext.Provider value={{ size: "20px" }}>
-                    <VscAzureDevops />
-                    &nbsp;&nbsp;
-                </IconContext.Provider>
-            );
+      case "AZURE_SP_MI":
+        return (
+          <IconContext.Provider value={{ size: "20px" }}>
+            <VscAzureDevops />
+            &nbsp;&nbsp;
+          </IconContext.Provider>
+        );
       default:
         return <GithubOutlined style={{ fontSize: "20px" }} />;
     }

--- a/ui/src/domain/Modules/Details.tsx
+++ b/ui/src/domain/Modules/Details.tsx
@@ -24,24 +24,38 @@ import {
   Typography,
 } from "antd";
 import { Buffer } from "buffer";
-import * as hcl from "hcl2-parser";
 import { DateTime } from "luxon";
-import { useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { IconContext } from "react-icons";
-import { FaAws } from "react-icons/fa";
+import { FaAws } from "@/config/iconList";
 import { SiBitbucket } from "react-icons/si";
 import { VscAzure, VscAzureDevops } from "react-icons/vsc";
-import Markdown from "react-markdown";
 import { useNavigate, useParams } from "react-router-dom";
+import LoadingFallback from "@/components/LoadingFallback";
 import PageWrapper from "@/modules/layout/PageWrapper/PageWrapper";
-import remarkGfm from "remark-gfm";
-import rehypeRaw from "rehype-raw";
-import { unzip } from "unzipit";
 import { ORGANIZATION_ARCHIVE } from "../../config/actionTypes";
 import axiosInstance, { getErrorMessage } from "../../config/axiosConfig";
 import { ModuleModel, ModuleVersionAttributes, VcsType } from "../types";
 import { compareVersions } from "../Workspaces/Workspaces";
 import "./Module.css";
+
+const Markdown = lazy(async () => {
+  const [{ default: ReactMarkdown }, { default: remarkGfm }, { default: rehypeRaw }] = await Promise.all([
+    import("react-markdown"),
+    import("remark-gfm"),
+    import("rehype-raw"),
+  ]);
+
+  const MarkdownWithPlugins = ({ children }: { children: string }) => {
+    return (
+      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
+        {children}
+      </ReactMarkdown>
+    );
+  };
+
+  return { default: MarkdownWithPlugins };
+});
 
 type Props = {
   organizationName: string;
@@ -131,6 +145,7 @@ export const ModuleDetails = ({ organizationName }: Props) => {
   // if submodule is empty then load the root module
   // if submodule is not empty then load the specific submodule tf files
   async function readFiles(url: string, submodule = "") {
+    const { unzip } = await import("unzipit");
     const { entries } = await unzip(url);
     let hclString = "";
     const modules: string[] = [];
@@ -160,6 +175,7 @@ export const ModuleDetails = ({ organizationName }: Props) => {
       }
     }
 
+    const hcl = await import("hcl2-parser");
     const hclResult = hcl.parseToObject(hclString);
     if (hclResult) {
       setHclObject(hclResult[0]);
@@ -227,19 +243,23 @@ export const ModuleDetails = ({ organizationName }: Props) => {
     setLoading(true);
     setError(null);
     sessionStorage.setItem(ORGANIZATION_ARCHIVE, orgid!);
-    axiosInstance.get(`organization/${orgid}/module/${id}?include=vcs,version`).then((response) => {
-      setModule(response.data.data);
-      setModuleName(response.data.data.attributes.name);
-      const latestVersion = response.data.data.attributes.latestVersion;
-      setVersion(latestVersion);
-      loadReadme(response.data.data.attributes.registryPath, latestVersion);
-      loadModuleDetails(response.data.data.attributes.registryPath, latestVersion);
-      setModuleInclude(response.data.included, setVCSProvider, setAllVersions);
-    }).catch((err) => {
-      setError(getErrorMessage(err));
-    }).finally(() => {
-      setLoading(false);
-    });
+    axiosInstance
+      .get(`organization/${orgid}/module/${id}?include=vcs,version`)
+      .then((response) => {
+        setModule(response.data.data);
+        setModuleName(response.data.data.attributes.name);
+        const latestVersion = response.data.data.attributes.latestVersion;
+        setVersion(latestVersion);
+        loadReadme(response.data.data.attributes.registryPath, latestVersion);
+        loadModuleDetails(response.data.data.attributes.registryPath, latestVersion);
+        setModuleInclude(response.data.included, setVCSProvider, setAllVersions);
+      })
+      .catch((err) => {
+        setError(getErrorMessage(err));
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   }, [orgid, id]);
 
   const loadModuleDetails = async (path: string, version: string, submodule = "") => {
@@ -311,68 +331,93 @@ export const ModuleDetails = ({ organizationName }: Props) => {
       contentClassName="registry-centered"
     >
       {module && (
-          <div>
-            <Row>
-              <Col span={16}>
-                <Space direction="vertical" style={{ marginTop: "10px", width: "95%" }}>
-                  {submodule === "" && (
-                    <>
-                      <Space size="large" wrap>
-                        <Typography.Text type="secondary">
-                          Published by {organizationName}
-                        </Typography.Text>
-                        <Typography.Text type="secondary">
-                          Provider {renderLogo(module.attributes.provider)} {module.attributes.provider}
-                        </Typography.Text>
-                        <Typography.Text type="secondary">
-                          Version {version}{" "}
-                          <Dropdown
-                            menu={{
-                              items: allVersions
-                                .sort((a, b) => compareVersions(a.version, b.version))
-                                .reverse()
-                                .map((v) => ({ key: v.version, label: v.version })),
-                              onClick: handleClick,
+        <div>
+          <Row>
+            <Col span={16}>
+              <Space direction="vertical" style={{ marginTop: "10px", width: "95%" }}>
+                {submodule === "" && (
+                  <>
+                    <Space size="large" wrap>
+                      <Typography.Text type="secondary">Published by {organizationName}</Typography.Text>
+                      <Typography.Text type="secondary">
+                        Provider {renderLogo(module.attributes.provider)} {module.attributes.provider}
+                      </Typography.Text>
+                      <Typography.Text type="secondary">
+                        Version {version}{" "}
+                        <Dropdown
+                          menu={{
+                            items: allVersions
+                              .sort((a, b) => compareVersions(a.version, b.version))
+                              .reverse()
+                              .map((v) => ({ key: v.version, label: v.version })),
+                            onClick: handleClick,
+                          }}
+                          trigger={["click"]}
+                        >
+                          <button
+                            type="button"
+                            style={{
+                              background: "none",
+                              border: "none",
+                              padding: 0,
+                              color: "#1677ff",
+                              cursor: "pointer",
                             }}
-                            trigger={["click"]}
                           >
-                            <button
-                              type="button"
-                              style={{
-                                background: "none",
-                                border: "none",
-                                padding: 0,
-                                color: "#1677ff",
-                                cursor: "pointer",
-                              }}
-                            >
-                              Change <DownOutlined />
-                            </button>
-                          </Dropdown>
-                        </Typography.Text>
-                        <Typography.Text type="secondary">
-                          <ClockCircleOutlined /> Published {DateTime.fromISO(module.attributes.createdDate ?? "").toRelative()}
-                        </Typography.Text>
-                        <Typography.Text type="secondary">
-                          Source{" "}
-                          {renderVCSLogo(vcsProvider)}{" "}
-                          {module.attributes.source && (
-                            <a
-                              href={fixSshURL(module.attributes.source)}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              {new URL(fixSshURL(module.attributes.source)).pathname
-                                .replace(".git", "")
-                                .substring(1)}
-                            </a>
-                          )}
-                        </Typography.Text>
-                      </Space>
-                      <Divider style={{ margin: "16px 0" }} />
-                      <Typography.Title level={4} style={{ margin: 0 }}>Module Details</Typography.Title>
-                      <Typography.Text type="secondary">Explore relevant submodules and examples</Typography.Text>
-                      {submodules.length > 0 && (
+                            Change <DownOutlined />
+                          </button>
+                        </Dropdown>
+                      </Typography.Text>
+                      <Typography.Text type="secondary">
+                        <ClockCircleOutlined /> Published{" "}
+                        {DateTime.fromISO(module.attributes.createdDate ?? "").toRelative()}
+                      </Typography.Text>
+                      <Typography.Text type="secondary">
+                        Source {renderVCSLogo(vcsProvider)}{" "}
+                        {module.attributes.source && (
+                          <a href={fixSshURL(module.attributes.source)} target="_blank" rel="noopener noreferrer">
+                            {new URL(fixSshURL(module.attributes.source)).pathname.replace(".git", "").substring(1)}
+                          </a>
+                        )}
+                      </Typography.Text>
+                    </Space>
+                    <Divider style={{ margin: "16px 0" }} />
+                    <Typography.Title level={4} style={{ margin: 0 }}>
+                      Module Details
+                    </Typography.Title>
+                    <Typography.Text type="secondary">Explore relevant submodules and examples</Typography.Text>
+                    {submodules.length > 0 && (
+                      <Dropdown
+                        menu={{
+                          items: submodules.map((name) => ({ key: name, label: name })),
+                          onClick: onClickSubmodule,
+                        }}
+                        trigger={["click"]}
+                      >
+                        <Button style={{ marginTop: "10px", fontSize: ".75rem" }}>
+                          <Space>
+                            Submodules
+                            <DownOutlined />
+                          </Space>
+                        </Button>
+                      </Dropdown>
+                    )}
+                  </>
+                )}
+
+                {submodule !== "" && (
+                  <>
+                    <div>
+                      <Button
+                        style={{ paddingLeft: "0px", marginBottom: "10px" }}
+                        type="link"
+                        onClick={handleClickBack}
+                        icon={<ArrowLeftOutlined />}
+                      >
+                        Back to {moduleName}
+                      </Button>
+                      <h2 className="moduleTitle">
+                        submodules/
                         <Dropdown
                           menu={{
                             items: submodules.map((name) => ({ key: name, label: name })),
@@ -380,407 +425,374 @@ export const ModuleDetails = ({ organizationName }: Props) => {
                           }}
                           trigger={["click"]}
                         >
-                          <Button style={{ marginTop: "10px", fontSize: ".75rem" }}>
-                            <Space>
-                              Submodules
-                              <DownOutlined />
-                            </Space>
-                          </Button>
-                        </Dropdown>
-                      )}
-                    </>
-                  )}
-
-                  {submodule !== "" && (
-                    <>
-                      <div>
-                        <Button
-                          style={{ paddingLeft: "0px", marginBottom: "10px" }}
-                          type="link"
-                          onClick={handleClickBack}
-                          icon={<ArrowLeftOutlined />}
-                        >
-                          Back to {moduleName}
-                        </Button>
-                        <h2 className="moduleTitle">
-                          submodules/
-                          <Dropdown
-                            menu={{
-                              items: submodules.map((name) => ({ key: name, label: name })),
-                              onClick: onClickSubmodule,
+                          <button
+                            type="button"
+                            style={{
+                              color: "black",
+                              background: "none",
+                              border: "none",
+                              padding: 0,
+                              cursor: "pointer",
+                              font: "inherit",
                             }}
-                            trigger={["click"]}
                           >
-                            <button
-                              type="button"
+                            {submodule} <DownOutlined />
+                          </button>
+                        </Dropdown>
+                      </h2>
+                    </div>
+                  </>
+                )}
+
+                <Tabs
+                  className="moduleTabs"
+                  defaultActiveKey="1"
+                  items={[
+                    {
+                      label: "Readme",
+                      key: "1",
+                      children: (
+                        <div className="markdown-body" style={{ backgroundColor: colorBgContainer }}>
+                          <Suspense fallback={<LoadingFallback />}>
+                            <Markdown>{markdown}</Markdown>
+                          </Suspense>
+                        </div>
+                      ),
+                      className: "markdown-body",
+                    },
+                    {
+                      label: inputs,
+                      key: "2",
+                      children:
+                        hclObject && hclObject?.variable ? (
+                          <Space direction="vertical">
+                            <h3>Inputs</h3>
+                            <span>These variables should be set in the module block when using this module.</span>
+                            <table
                               style={{
-                                color: "black",
-                                background: "none",
-                                border: "none",
-                                padding: 0,
-                                cursor: "pointer",
-                                font: "inherit",
+                                width: "100%",
+                                tableLayout: "fixed",
+                                whiteSpace: "normal",
+                                wordBreak: "break-word",
+                                borderCollapse: "collapse",
+                                border: `1px solid ${colorBorder}`,
+                                backgroundColor: colorBgContainer,
                               }}
                             >
-                              {submodule} <DownOutlined />
-                            </button>
-                          </Dropdown>
-                        </h2>
-                      </div>
-                    </>
-                  )}
-
-                  <Tabs
-                    className="moduleTabs"
-                    defaultActiveKey="1"
-                    items={[
-                      {
-                        label: "Readme",
-                        key: "1",
-                        children: (
-                          <div className="markdown-body" style={{ backgroundColor: colorBgContainer }}>
-                            <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>{markdown}</Markdown>
-                          </div>
+                              <thead>
+                                <tr>
+                                  <th
+                                    style={{
+                                      width: "40%",
+                                      textAlign: "left",
+                                      verticalAlign: "top",
+                                      padding: "8px",
+                                      border: `1px solid ${colorBorder}`,
+                                      backgroundColor: colorFillSecondary,
+                                    }}
+                                  >
+                                    Name
+                                  </th>
+                                  <th
+                                    style={{
+                                      width: "20%",
+                                      textAlign: "left",
+                                      verticalAlign: "top",
+                                      padding: "8px",
+                                      border: `1px solid ${colorBorder}`,
+                                      backgroundColor: colorFillSecondary,
+                                    }}
+                                  >
+                                    Type
+                                  </th>
+                                  <th
+                                    style={{
+                                      width: "35%",
+                                      textAlign: "left",
+                                      verticalAlign: "top",
+                                      padding: "8px",
+                                      border: `1px solid ${colorBorder}`,
+                                      backgroundColor: colorFillSecondary,
+                                    }}
+                                  >
+                                    Description
+                                  </th>
+                                  <th
+                                    style={{
+                                      width: "15%",
+                                      textAlign: "left",
+                                      verticalAlign: "top",
+                                      padding: "8px",
+                                      border: `1px solid ${colorBorder}`,
+                                      backgroundColor: colorFillSecondary,
+                                    }}
+                                  >
+                                    Default
+                                  </th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {Object.keys(hclObject?.variable).map((keyName, i) => (
+                                  <tr
+                                    key={i}
+                                    style={{ backgroundColor: i % 2 === 0 ? colorBgContainer : colorFillTertiary }}
+                                  >
+                                    <td
+                                      style={{
+                                        textAlign: "left",
+                                        verticalAlign: "top",
+                                        padding: "8px",
+                                        border: `1px solid ${colorBorder}`,
+                                      }}
+                                    >
+                                      <Typography.Text copyable strong>
+                                        {keyName}
+                                      </Typography.Text>
+                                    </td>
+                                    <td
+                                      style={{
+                                        textAlign: "left",
+                                        verticalAlign: "top",
+                                        padding: "8px",
+                                        border: `1px solid ${colorBorder}`,
+                                      }}
+                                    >
+                                      <span
+                                        style={{
+                                          padding: "4px 8px",
+                                          borderRadius: "4px",
+                                          display: "inline-block",
+                                        }}
+                                      >
+                                        {hclObject?.variable[keyName][0]?.type?.replace(/{|}|\$/g, "")}
+                                      </span>
+                                    </td>
+                                    <td
+                                      style={{
+                                        textAlign: "left",
+                                        verticalAlign: "top",
+                                        padding: "8px",
+                                        border: `1px solid ${colorBorder}`,
+                                      }}
+                                    >
+                                      {JSON.stringify(hclObject?.variable[keyName][0]?.description)?.replaceAll(
+                                        '"',
+                                        ""
+                                      )}
+                                    </td>
+                                    <td
+                                      style={{
+                                        textAlign: "left",
+                                        verticalAlign: "top",
+                                        padding: "8px",
+                                        border: `1px solid ${colorBorder}`,
+                                      }}
+                                    >
+                                      {JSON.stringify(hclObject?.variable[keyName][0]?.default)}
+                                    </td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          </Space>
+                        ) : (
+                          <p>{loadingInputs}</p>
                         ),
-                        className: "markdown-body",
-                      },
-                      {
-                        label: inputs,
-                        key: "2",
-                        children:
-                          hclObject && hclObject?.variable ? (
-                            <Space direction="vertical">
-                              <h3>Inputs</h3>
-                              <span>These variables should be set in the module block when using this module.</span>
-                              <table
-                                style={{
-                                  width: "100%",
-                                  tableLayout: "fixed",
-                                  whiteSpace: "normal",
-                                  wordBreak: "break-word",
-                                  borderCollapse: "collapse",
-                                  border: `1px solid ${colorBorder}`,
-                                  backgroundColor: colorBgContainer,
-                                }}
-                              >
-                                <thead>
-                                  <tr>
-                                    <th
+                    },
+                    {
+                      label: outputs,
+                      key: "3",
+                      children:
+                        hclObject && hclObject?.output ? (
+                          <Space direction="vertical">
+                            <h3>Outputs</h3>
+                            <span>These outputs are returned by this module.</span>
+                            <table
+                              style={{
+                                width: "100%",
+                                tableLayout: "fixed",
+                                whiteSpace: "normal",
+                                wordBreak: "break-word",
+                                borderCollapse: "collapse",
+                                border: `1px solid ${colorBorder}`,
+                                backgroundColor: colorBgContainer,
+                              }}
+                            >
+                              <thead>
+                                <tr>
+                                  <th
+                                    style={{
+                                      width: "30%",
+                                      textAlign: "left",
+                                      verticalAlign: "top",
+                                      padding: "8px",
+                                      border: `1px solid ${colorBorder}`,
+                                      backgroundColor: colorFillSecondary,
+                                    }}
+                                  >
+                                    Name
+                                  </th>
+                                  <th
+                                    style={{
+                                      width: "70%",
+                                      textAlign: "left",
+                                      verticalAlign: "top",
+                                      padding: "8px",
+                                      border: `1px solid ${colorBorder}`,
+                                      backgroundColor: colorFillSecondary,
+                                    }}
+                                  >
+                                    Description
+                                  </th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {Object.keys(hclObject?.output).map((keyName, i) => (
+                                  <tr
+                                    key={i}
+                                    style={{ backgroundColor: i % 2 === 0 ? colorBgContainer : colorFillTertiary }}
+                                  >
+                                    <td
                                       style={{
-                                        width: "40%",
                                         textAlign: "left",
                                         verticalAlign: "top",
                                         padding: "8px",
                                         border: `1px solid ${colorBorder}`,
-                                        backgroundColor: colorFillSecondary,
                                       }}
                                     >
-                                      Name
-                                    </th>
-                                    <th
+                                      <Typography.Text copyable strong>
+                                        {keyName}
+                                      </Typography.Text>
+                                    </td>
+                                    <td
                                       style={{
-                                        width: "20%",
                                         textAlign: "left",
                                         verticalAlign: "top",
                                         padding: "8px",
                                         border: `1px solid ${colorBorder}`,
-                                        backgroundColor: colorFillSecondary,
                                       }}
                                     >
-                                      Type
-                                    </th>
-                                    <th
-                                      style={{
-                                        width: "35%",
-                                        textAlign: "left",
-                                        verticalAlign: "top",
-                                        padding: "8px",
-                                        border: `1px solid ${colorBorder}`,
-                                        backgroundColor: colorFillSecondary,
-                                      }}
-                                    >
-                                      Description
-                                    </th>
-                                    <th
-                                      style={{
-                                        width: "15%",
-                                        textAlign: "left",
-                                        verticalAlign: "top",
-                                        padding: "8px",
-                                        border: `1px solid ${colorBorder}`,
-                                        backgroundColor: colorFillSecondary,
-                                      }}
-                                    >
-                                      Default
-                                    </th>
+                                      {JSON.stringify(hclObject?.output[keyName][0]?.description)?.replaceAll('"', "")}
+                                    </td>
                                   </tr>
-                                </thead>
-                                <tbody>
-                                  {Object.keys(hclObject?.variable).map((keyName, i) => (
-                                    <tr
-                                      key={i}
-                                      style={{ backgroundColor: i % 2 === 0 ? colorBgContainer : colorFillTertiary }}
-                                    >
-                                      <td
-                                        style={{
-                                          textAlign: "left",
-                                          verticalAlign: "top",
-                                          padding: "8px",
-                                          border: `1px solid ${colorBorder}`,
-                                        }}
-                                      >
-                                        <Typography.Text copyable strong>
-                                          {keyName}
-                                        </Typography.Text>
-                                      </td>
-                                      <td
-                                        style={{
-                                          textAlign: "left",
-                                          verticalAlign: "top",
-                                          padding: "8px",
-                                          border: `1px solid ${colorBorder}`,
-                                        }}
-                                      >
-                                        <span
-                                          style={{
-                                            padding: "4px 8px",
-                                            borderRadius: "4px",
-                                            display: "inline-block",
-                                          }}
-                                        >
-                                          {hclObject?.variable[keyName][0]?.type?.replace(/{|}|\$/g, "")}
-                                        </span>
-                                      </td>
-                                      <td
-                                        style={{
-                                          textAlign: "left",
-                                          verticalAlign: "top",
-                                          padding: "8px",
-                                          border: `1px solid ${colorBorder}`,
-                                        }}
-                                      >
-                                        {JSON.stringify(hclObject?.variable[keyName][0]?.description)?.replaceAll(
-                                          '"',
-                                          ""
-                                        )}
-                                      </td>
-                                      <td
-                                        style={{
-                                          textAlign: "left",
-                                          verticalAlign: "top",
-                                          padding: "8px",
-                                          border: `1px solid ${colorBorder}`,
-                                        }}
-                                      >
-                                        {JSON.stringify(hclObject?.variable[keyName][0]?.default)}
-                                      </td>
-                                    </tr>
-                                  ))}
-                                </tbody>
-                              </table>
-                            </Space>
-                          ) : (
-                            <p>{loadingInputs}</p>
-                          ),
-                      },
-                      {
-                        label: outputs,
-                        key: "3",
-                        children:
-                          hclObject && hclObject?.output ? (
-                            <Space direction="vertical">
-                              <h3>Outputs</h3>
-                              <span>These outputs are returned by this module.</span>
-                              <table
-                                style={{
-                                  width: "100%",
-                                  tableLayout: "fixed",
-                                  whiteSpace: "normal",
-                                  wordBreak: "break-word",
-                                  borderCollapse: "collapse",
-                                  border: `1px solid ${colorBorder}`,
-                                  backgroundColor: colorBgContainer,
+                                ))}
+                              </tbody>
+                            </table>
+                          </Space>
+                        ) : (
+                          <p>{loadingOutputs}</p>
+                        ),
+                    },
+                    {
+                      label: resources,
+                      key: "5",
+                      children:
+                        hclObject && hclObject?.resource ? (
+                          <Space direction="vertical">
+                            <h3>Resources</h3>
+                            <span>This is the list of resources this module can create.</span>
+                            <span>This module defines {Object.keys(hclObject?.resource)?.length} resources.</span>
+                            <ul>
+                              {Object.keys(hclObject?.resource).map((resourceType, i) =>
+                                Object.keys(hclObject?.resource[resourceType]).map((resourceName, j) => (
+                                  <li key={`${i}-${j}`}>
+                                    <Tag>
+                                      {resourceType}.{resourceName}
+                                    </Tag>
+                                  </li>
+                                ))
+                              )}
+                            </ul>
+                          </Space>
+                        ) : (
+                          <p>{loadingResources}</p>
+                        ),
+                    },
+                  ]}
+                />
+              </Space>
+            </Col>
+            <Col span={8}>
+              <Card>
+                <Space style={{ paddingRight: "10px", width: "100%" }} direction="vertical">
+                  <div style={{ width: "100%" }}>
+                    <Dropdown
+                      menu={{
+                        items: [
+                          {
+                            key: "delete",
+                            label: (
+                              <Popconfirm
+                                title={
+                                  <p>
+                                    Module <b>{module.attributes.name}</b> will be permanently deleted.
+                                    <br />
+                                    Are you sure?
+                                  </p>
+                                }
+                                onConfirm={() => {
+                                  onDelete(id!);
                                 }}
+                                okText="Yes"
+                                cancelText="No"
+                                placement="left"
                               >
-                                <thead>
-                                  <tr>
-                                    <th
-                                      style={{
-                                        width: "30%",
-                                        textAlign: "left",
-                                        verticalAlign: "top",
-                                        padding: "8px",
-                                        border: `1px solid ${colorBorder}`,
-                                        backgroundColor: colorFillSecondary,
-                                      }}
-                                    >
-                                      Name
-                                    </th>
-                                    <th
-                                      style={{
-                                        width: "70%",
-                                        textAlign: "left",
-                                        verticalAlign: "top",
-                                        padding: "8px",
-                                        border: `1px solid ${colorBorder}`,
-                                        backgroundColor: colorFillSecondary,
-                                      }}
-                                    >
-                                      Description
-                                    </th>
-                                  </tr>
-                                </thead>
-                                <tbody>
-                                  {Object.keys(hclObject?.output).map((keyName, i) => (
-                                    <tr
-                                      key={i}
-                                      style={{ backgroundColor: i % 2 === 0 ? colorBgContainer : colorFillTertiary }}
-                                    >
-                                      <td
-                                        style={{
-                                          textAlign: "left",
-                                          verticalAlign: "top",
-                                          padding: "8px",
-                                          border: `1px solid ${colorBorder}`,
-                                        }}
-                                      >
-                                        <Typography.Text copyable strong>
-                                          {keyName}
-                                        </Typography.Text>
-                                      </td>
-                                      <td
-                                        style={{
-                                          textAlign: "left",
-                                          verticalAlign: "top",
-                                          padding: "8px",
-                                          border: `1px solid ${colorBorder}`,
-                                        }}
-                                      >
-                                        {JSON.stringify(hclObject?.output[keyName][0]?.description)?.replaceAll(
-                                          '"',
-                                          ""
-                                        )}
-                                      </td>
-                                    </tr>
-                                  ))}
-                                </tbody>
-                              </table>
-                            </Space>
-                          ) : (
-                            <p>{loadingOutputs}</p>
-                          ),
-                      },
-                      {
-                        label: resources,
-                        key: "5",
-                        children:
-                          hclObject && hclObject?.resource ? (
-                            <Space direction="vertical">
-                              <h3>Resources</h3>
-                              <span>This is the list of resources this module can create.</span>
-                              <span>This module defines {Object.keys(hclObject?.resource)?.length} resources.</span>
-                              <ul>
-                                {Object.keys(hclObject?.resource).map((resourceType, i) =>
-                                  Object.keys(hclObject?.resource[resourceType]).map((resourceName, j) => (
-                                    <li key={`${i}-${j}`}>
-                                      <Tag>
-                                        {resourceType}.{resourceName}
-                                      </Tag>
-                                    </li>
-                                  ))
-                                )}
-                              </ul>
-                            </Space>
-                          ) : (
-                            <p>{loadingResources}</p>
-                          ),
-                      },
-                    ]}
-                  />
-                </Space>
-              </Col>
-              <Col span={8}>
-                <Card>
-                  <Space style={{ paddingRight: "10px", width: "100%" }} direction="vertical">
-                    <div style={{ width: "100%" }}>
-                      <Dropdown
-                        menu={{
-                          items: [
-                            {
-                              key: "delete",
-                              label: (
-                                <Popconfirm
-                                  title={
-                                    <p>
-                                      Module <b>{module.attributes.name}</b> will be permanently deleted.
-                                      <br />
-                                      Are you sure?
-                                    </p>
-                                  }
-                                  onConfirm={() => {
-                                    onDelete(id!);
-                                  }}
-                                  okText="Yes"
-                                  cancelText="No"
-                                  placement="left"
-                                >
-                                  <Space>
-                                    <DeleteOutlined style={{ color: "#ff4d4f" }} />
-                                    <span style={{ color: "#ff4d4f" }}>Remove from organization</span>
-                                  </Space>
-                                </Popconfirm>
-                              ),
-                            },
-                          ],
-                        }}
-                        trigger={["click"]}
-                      >
-                        <Button style={{ width: "100%" }} icon={<SettingOutlined />}>
-                          Manage Module <DownOutlined />
-                        </Button>
-                      </Dropdown>
-                      <Divider />
+                                <Space>
+                                  <DeleteOutlined style={{ color: "#ff4d4f" }} />
+                                  <span style={{ color: "#ff4d4f" }}>Remove from organization</span>
+                                </Space>
+                              </Popconfirm>
+                            ),
+                          },
+                        ],
+                      }}
+                      trigger={["click"]}
+                    >
+                      <Button style={{ width: "100%" }} icon={<SettingOutlined />}>
+                        Manage Module <DownOutlined />
+                      </Button>
+                    </Dropdown>
+                    <Divider />
+                  </div>
+                  <p className="moduleSubtitles">Usage Instructions</p>
+                  <p className="moduleInstructions">
+                    Copy and paste into your Terraform configuration and set values for the input variables.
+                  </p>
+                  <div style={{ width: "100%" }}>
+                    <Divider />
+                    <p className="moduleSubtitles">Copy configuration details</p>
+                  </div>
+                  <pre className="moduleCode">
+                    module &quot;{module.attributes.name}&quot; {"{"}
+                    <br />
+                    &nbsp;&nbsp;source = &quot;{new URL(window._env_.REACT_APP_REGISTRY_URI).hostname}/
+                    {module.attributes.registryPath}
+                    {submodulePath}&quot;
+                    <br />
+                    &nbsp;&nbsp;version = &quot;{version}&quot;
+                    <br />
+                    &nbsp;&nbsp;# insert required variables here
+                    <br />
+                    {"}"}
+                  </pre>
+                  <Tag style={{ width: "100%", fontSize: "13px" }} color="blue">
+                    <div style={{ whiteSpace: "normal", wordWrap: "break-word" }}>
+                      When running Terraform on the CLI, you must configure credentials in .terraformrc or terraform.rc
+                      to access this module:
                     </div>
-                    <p className="moduleSubtitles">Usage Instructions</p>
-                    <p className="moduleInstructions">
-                      Copy and paste into your Terraform configuration and set values for the input variables.
-                    </p>
-                    <div style={{ width: "100%" }}>
-                      <Divider />
-                      <p className="moduleSubtitles">Copy configuration details</p>
-                    </div>
-                    <pre className="moduleCode">
-                      module &quot;{module.attributes.name}&quot; {"{"}
+                    <pre className="moduleCredentials">
+                      credentials &quot;{new URL(window._env_.REACT_APP_REGISTRY_URI).hostname}&quot; {" {"}
                       <br />
-                      &nbsp;&nbsp;source = &quot;{new URL(window._env_.REACT_APP_REGISTRY_URI).hostname}/
-                      {module.attributes.registryPath}
-                      {submodulePath}&quot;
-                      <br />
-                      &nbsp;&nbsp;version = &quot;{version}&quot;
-                      <br />
-                      &nbsp;&nbsp;# insert required variables here
+                      &nbsp;&nbsp;token = &quot;xxxxxx.yyyyyy.zzzzzzzzzzzzz&quot;
                       <br />
                       {"}"}
                     </pre>
-                    <Tag style={{ width: "100%", fontSize: "13px" }} color="blue">
-                      <div style={{ whiteSpace: "normal", wordWrap: "break-word" }}>
-                        When running Terraform on the CLI, you must configure credentials in .terraformrc or
-                        terraform.rc to access this module:
-                      </div>
-                      <pre className="moduleCredentials">
-                        credentials &quot;{new URL(window._env_.REACT_APP_REGISTRY_URI).hostname}&quot; {" {"}
-                        <br />
-                        &nbsp;&nbsp;token = &quot;xxxxxx.yyyyyy.zzzzzzzzzzzzz&quot;
-                        <br />
-                        {"}"}
-                      </pre>
-                    </Tag>
-                  </Space>
-                </Card>
-              </Col>
-
-            </Row>
-          </div>
+                  </Tag>
+                </Space>
+              </Card>
+            </Col>
+          </Row>
+        </div>
       )}
     </PageWrapper>
   );

--- a/ui/src/domain/Modules/List.tsx
+++ b/ui/src/domain/Modules/List.tsx
@@ -4,7 +4,7 @@ import { Button, Card, Col, Input, List, Row, Space, Tag, Typography } from "ant
 import { DateTime } from "luxon";
 import { useEffect, useState } from "react";
 import { IconContext } from "react-icons";
-import { FaAws } from "react-icons/fa";
+import { FaAws } from "@/config/iconList";
 import { MdBusiness } from "react-icons/md";
 import { RiFolderHistoryLine } from "react-icons/ri";
 import { VscAzure } from "react-icons/vsc";

--- a/ui/src/domain/Modules/Module.css
+++ b/ui/src/domain/Modules/Module.css
@@ -14,20 +14,20 @@
   margin-right: auto;
 }
 
-
-
 /* Module card — Leaa-inspired: white card, soft shadow, no border */
 .module-card.ant-card {
-  box-shadow: 0 9px 18px 0 rgba(0, 35, 90, 0.06),
-              0 0 2px 0 rgba(0, 35, 90, 0.06);
+  box-shadow:
+    0 9px 18px 0 rgba(0, 35, 90, 0.06),
+    0 0 2px 0 rgba(0, 35, 90, 0.06);
   border: none !important;
   border-radius: 8px;
   transition: box-shadow 0.25s ease;
 }
 
 .module-card.ant-card:hover {
-  box-shadow: 0 9px 24px 0 rgba(0, 35, 90, 0.10),
-              0 0 2px 0 rgba(0, 35, 90, 0.08);
+  box-shadow:
+    0 9px 24px 0 rgba(0, 35, 90, 0.1),
+    0 0 2px 0 rgba(0, 35, 90, 0.08);
 }
 
 /* Uniform card content height */
@@ -46,6 +46,30 @@
   font-size: 13px;
   color: #656d76;
   line-height: 1.5;
+}
+
+/* Module card name */
+.module-card-name {
+  font-size: 16px;
+  color: #222b3d;
+}
+
+[data-theme="dark"] .module-card-name {
+  color: #58a6ff;
+}
+
+/* Dark mode for module card description */
+[data-theme="dark"] .module-card-desc {
+  color: #8b949e;
+}
+
+/* Dark mode for module card border */
+[data-theme="dark"] .module-card .ant-card {
+  border-color: var(--tk-border-primary);
+}
+
+[data-theme="dark"] .module-card-body + div {
+  border-top-color: var(--tk-border-primary) !important;
 }
 
 .module-flat-icon {

--- a/ui/src/domain/Modules/ModuleList.tsx
+++ b/ui/src/domain/Modules/ModuleList.tsx
@@ -2,7 +2,7 @@ import { CloudOutlined, DownloadOutlined } from "@ant-design/icons";
 import { Card, List, Space, Typography } from "antd";
 import { useMemo } from "react";
 import { IconContext } from "react-icons";
-import { FaAws } from "react-icons/fa";
+import { FaAws } from "@/config/iconList";
 import { VscAzure } from "react-icons/vsc";
 import { useNavigate, useParams } from "react-router-dom";
 import { FlatModule } from "../types";
@@ -25,9 +25,10 @@ export const ModuleList = ({ modules, searchFilter }: Props) => {
     if (searchFilter === "") {
       return modules;
     }
-    return modules.filter((module) =>
-      module.name.toLowerCase().includes(searchFilter.toLowerCase()) ||
-      module.description?.toLowerCase().includes(searchFilter.toLowerCase())
+    return modules.filter(
+      (module) =>
+        module.name.toLowerCase().includes(searchFilter.toLowerCase()) ||
+        module.description?.toLowerCase().includes(searchFilter.toLowerCase())
     );
   }, [searchFilter, modules]);
 
@@ -58,23 +59,25 @@ export const ModuleList = ({ modules, searchFilter }: Props) => {
       renderItem={(item) => (
         <List.Item
           style={{ cursor: "pointer", padding: "6px 0" }}
-          onClick={() =>
-            navigate(`/organizations/${orgid}/registry/${item.id}`)
-          }
+          onClick={() => navigate(`/organizations/${orgid}/registry/${item.id}`)}
         >
-          <Card
-            hoverable
-            className="module-card"
-            style={{ width: "100%" }}
-            styles={{ body: { padding: 0 } }}
-          >
+          <Card hoverable className="module-card" style={{ width: "100%" }} styles={{ body: { padding: 0 } }}>
             <div className="module-card-body">
               <div style={{ display: "flex", gap: 14, alignItems: "flex-start" }}>
-                <div style={{ flexShrink: 0, width: 36, height: 36, display: "flex", alignItems: "center", justifyContent: "center" }}>
+                <div
+                  style={{
+                    flexShrink: 0,
+                    width: 36,
+                    height: 36,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
                   {renderLogo(item.provider)}
                 </div>
                 <div style={{ flex: 1, minWidth: 0 }}>
-                  <Typography.Text strong style={{ fontSize: 16, color: "#222b3d" }}>
+                  <Typography.Text strong className="module-card-name">
                     {item.name}
                   </Typography.Text>
                   <div className="module-card-desc">
@@ -83,13 +86,19 @@ export const ModuleList = ({ modules, searchFilter }: Props) => {
                 </div>
               </div>
             </div>
-            <div style={{ borderTop: "1px solid #f0f0f0", padding: "10px 24px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <div
+              style={{
+                borderTop: "1px solid #f0f0f0",
+                padding: "10px 24px",
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+              }}
+            >
               <Space size={16}>
                 <Space size={4}>
                   <DownloadOutlined style={{ fontSize: 13, color: "#8c97a8" }} />
-                  <Typography.Text style={{ fontSize: 13, color: "#8c97a8" }}>
-                    {item.downloadQuantity}
-                  </Typography.Text>
+                  <Typography.Text style={{ fontSize: 13, color: "#8c97a8" }}>{item.downloadQuantity}</Typography.Text>
                 </Space>
               </Space>
               <Space size={6}>

--- a/ui/src/domain/Modules/PublicRegistrySearch.tsx
+++ b/ui/src/domain/Modules/PublicRegistrySearch.tsx
@@ -7,23 +7,10 @@ import {
   PlusOutlined,
   SearchOutlined,
 } from "@ant-design/icons";
-import {
-  Button,
-  Card,
-  Input,
-  List,
-  Modal,
-  Select,
-  Space,
-  Spin,
-  Steps,
-  Tabs,
-  Typography,
-  message,
-} from "antd";
+import { Button, Card, Input, List, Modal, Select, Space, Spin, Steps, Tabs, Typography, message } from "antd";
 import { useEffect, useState } from "react";
 import { IconContext } from "react-icons";
-import { FaAws, FaGoogle } from "react-icons/fa";
+import { FaAws, FaGoogle } from "@/config/iconList";
 import { VscAzure } from "react-icons/vsc";
 import { useNavigate, useParams } from "react-router-dom";
 import PageWrapper from "@/modules/layout/PageWrapper/PageWrapper";
@@ -146,7 +133,7 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
     { step: 1, status: "waiting", message: "Create version" },
     { step: 2, status: "waiting", message: "Add platform implementations" },
   ]);
-  
+
   // Existing items in the organization's registry
   const [existingProviders, setExistingProviders] = useState<Set<string>>(new Set());
   const [existingModules, setExistingModules] = useState<Set<string>>(new Set());
@@ -156,15 +143,13 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
   useEffect(() => {
     const fetchExistingItems = async () => {
       if (!orgid) return;
-      
+
       setLoadingExisting(true);
       try {
         // Fetch existing providers
         const providersResponse = await listProviders(orgid);
         const providerNames = new Set(
-          providersResponse.data.map((p: ProviderModel) => 
-            p.attributes.name.toLowerCase()
-          )
+          providersResponse.data.map((p: ProviderModel) => p.attributes.name.toLowerCase())
         );
         setExistingProviders(providerNames);
 
@@ -215,31 +200,26 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
     setLoading(true);
     try {
       // Use backend proxy to avoid CORS issues
-      const response = await axiosRegistry.get<ProviderSearchResponse>(
-        "/registry/v1/providers",
-        {
-          params: {
-            q: query,
-            limit: 20,
-          },
-        }
-      );
+      const response = await axiosRegistry.get<ProviderSearchResponse>("/registry/v1/providers", {
+        params: {
+          q: query,
+          limit: 20,
+        },
+      });
 
-      const mappedProviders: TerraformRegistryProvider[] = (response.data.providers || []).map(
-        (item) => ({
-          id: item.id,
-          namespace: item.namespace,
-          name: item.name,
-          alias: item.alias || "",
-          version: item.version,
-          description: item.description,
-          source: item.source,
-          published_at: item.published_at,
-          downloads: item.downloads,
-          tier: item.tier,
-          logo_url: item.logo_url,
-        })
-      );
+      const mappedProviders: TerraformRegistryProvider[] = (response.data.providers || []).map((item) => ({
+        id: item.id,
+        namespace: item.namespace,
+        name: item.name,
+        alias: item.alias || "",
+        version: item.version,
+        description: item.description,
+        source: item.source,
+        published_at: item.published_at,
+        downloads: item.downloads,
+        tier: item.tier,
+        logo_url: item.logo_url,
+      }));
 
       setProviders(mappedProviders);
     } catch (error) {
@@ -260,15 +240,12 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
     setLoading(true);
     try {
       // Use backend proxy to avoid CORS issues
-      const response = await axiosRegistry.get<ModuleSearchResponse>(
-        "/registry/v1/modules",
-        {
-          params: {
-            q: query,
-            limit: 20,
-          },
-        }
-      );
+      const response = await axiosRegistry.get<ModuleSearchResponse>("/registry/v1/modules", {
+        params: {
+          q: query,
+          limit: 20,
+        },
+      });
 
       setModules(response.data.modules || []);
     } catch (error) {
@@ -310,13 +287,13 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
       { step: 1, status: "waiting", message: "Create version" },
       { step: 2, status: "waiting", message: "Add platform implementations" },
     ]);
-    
+
     if (type === "provider") {
       const provider = item as TerraformRegistryProvider;
       setLoadingVersions(true);
       setAvailableVersions([]);
       setSelectedVersion("");
-      
+
       try {
         const versionsData = await getProviderVersions(provider.namespace, provider.name);
         setAvailableVersions(versionsData.versions || []);
@@ -345,9 +322,9 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
   };
 
   const updateProgress = (stepIndex: number, status: "waiting" | "process" | "finish" | "error", msg?: string) => {
-    setImportProgress(prev => prev.map((p, i) => 
-      i === stepIndex ? { ...p, status, message: msg || p.message } : p
-    ));
+    setImportProgress((prev) =>
+      prev.map((p, i) => (i === stepIndex ? { ...p, status, message: msg || p.message } : p))
+    );
   };
 
   const handleAddProvider = async () => {
@@ -370,30 +347,29 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
     try {
       // Step 1: Create provider
       updateProgress(0, "process", "Creating provider...");
-      
+
       // Get version info for platforms
-      const versionInfo = availableVersions.find(v => v.version === selectedVersion);
+      const versionInfo = availableVersions.find((v) => v.version === selectedVersion);
       const platformCount = versionInfo?.platforms?.length || 0;
-      
+
       // Build a meaningful description from available data
-      const desc = provider.description
-        || (provider.source ? `Source: ${provider.source}` : "")
-        || `${provider.namespace}/${provider.name}`;
+      const desc =
+        provider.description ||
+        (provider.source ? `Source: ${provider.source}` : "") ||
+        `${provider.namespace}/${provider.name}`;
       // Pass pre-fetched versions to avoid duplicate API call
       const prefetchedVersions = { versions: availableVersions };
       await importProvider(orgid!, provider.namespace, provider.name, selectedVersion, desc, prefetchedVersions);
-      
+
       updateProgress(0, "finish", "Provider created");
       updateProgress(1, "finish", "Version created");
       updateProgress(2, "finish", `${platformCount} platform(s) added`);
 
-      message.success(
-        `Provider ${provider.namespace}/${provider.name} v${selectedVersion} added successfully`
-      );
-      
+      message.success(`Provider ${provider.namespace}/${provider.name} v${selectedVersion} added successfully`);
+
       // Update existing providers set (name is now stored as just the short name)
-      setExistingProviders(prev => new Set([...prev, provider.name.toLowerCase()]));
-      
+      setExistingProviders((prev) => new Set([...prev, provider.name.toLowerCase()]));
+
       // Small delay to show completion
       setTimeout(() => {
         closeModal();
@@ -401,7 +377,7 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
       }, 1000);
     } catch (error: any) {
       console.error("Error importing provider:", error);
-      const currentStep = importProgress.findIndex(p => p.status === "process");
+      const currentStep = importProgress.findIndex((p) => p.status === "process");
       if (currentStep >= 0) {
         updateProgress(currentStep, "error", `Failed: ${error.message || "Unknown error"}`);
       }
@@ -426,7 +402,8 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
             name: module.name,
             description: module.description || `Imported from Terraform Registry: ${module.namespace}/${module.name}`,
             provider: module.provider,
-            source: module.source || `https://github.com/${module.namespace}/terraform-${module.provider}-${module.name}`,
+            source:
+              module.source || `https://github.com/${module.namespace}/terraform-${module.provider}-${module.name}`,
           },
         },
       };
@@ -464,11 +441,7 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
   const renderProviderLogo = (provider: TerraformRegistryProvider) => {
     if (provider.logo_url) {
       return (
-        <img
-          src={provider.logo_url}
-          alt={provider.name}
-          style={{ width: 32, height: 32, objectFit: "contain" }}
-        />
+        <img src={provider.logo_url} alt={provider.name} style={{ width: 32, height: 32, objectFit: "contain" }} />
       );
     }
     return <CloudOutlined style={{ fontSize: 32 }} />;
@@ -503,17 +476,21 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
 
   const renderProviderCard = (provider: TerraformRegistryProvider) => {
     const alreadyImported = isProviderImported(provider);
-    
+
     return (
-      <Card
-        hoverable
-        className="module-card"
-        style={{ width: "100%" }}
-        styles={{ body: { padding: 0 } }}
-      >
+      <Card hoverable className="module-card" style={{ width: "100%" }} styles={{ body: { padding: 0 } }}>
         <div className="module-card-body">
           <div style={{ display: "flex", gap: 14, alignItems: "flex-start" }}>
-            <div style={{ flexShrink: 0, width: 36, height: 36, display: "flex", alignItems: "center", justifyContent: "center" }}>
+            <div
+              style={{
+                flexShrink: 0,
+                width: 36,
+                height: 36,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
               {renderProviderLogo(provider)}
             </div>
             <div style={{ flex: 1, minWidth: 0 }}>
@@ -522,15 +499,16 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
                   {provider.namespace} / {provider.name}
                 </Typography.Text>
                 {alreadyImported && (
-                  <Typography.Text type="secondary" style={{ display: "flex", alignItems: "center", gap: 4, fontSize: 12 }}>
+                  <Typography.Text
+                    type="secondary"
+                    style={{ display: "flex", alignItems: "center", gap: 4, fontSize: 12 }}
+                  >
                     <CheckCircleOutlined style={{ color: "#52c41a" }} />
                     In your Registry
                   </Typography.Text>
                 )}
               </div>
-              <div className="module-card-desc">
-                {provider.description || "No description available"}
-              </div>
+              <div className="module-card-desc">{provider.description || "No description available"}</div>
             </div>
             {!alreadyImported && (
               <Button
@@ -547,7 +525,15 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
           </div>
         </div>
         {/* Footer with separator */}
-        <div style={{ borderTop: "1px solid #f0f0f0", padding: "10px 24px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <div
+          style={{
+            borderTop: "1px solid #f0f0f0",
+            padding: "10px 24px",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
           <Space size={16}>
             <Space size={4}>
               <DownloadOutlined style={{ fontSize: 13, color: "#8c97a8" }} />
@@ -567,17 +553,21 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
 
   const renderModuleCard = (module: TerraformRegistryModule) => {
     const alreadyImported = isModuleImported(module);
-    
+
     return (
-      <Card
-        hoverable
-        className="module-card"
-        style={{ width: "100%" }}
-        styles={{ body: { padding: 0 } }}
-      >
+      <Card hoverable className="module-card" style={{ width: "100%" }} styles={{ body: { padding: 0 } }}>
         <div className="module-card-body">
           <div style={{ display: "flex", gap: 14, alignItems: "flex-start" }}>
-            <div style={{ flexShrink: 0, width: 36, height: 36, display: "flex", alignItems: "center", justifyContent: "center" }}>
+            <div
+              style={{
+                flexShrink: 0,
+                width: 36,
+                height: 36,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
               {renderModuleProviderIcon(module.provider)}
             </div>
             <div style={{ flex: 1, minWidth: 0 }}>
@@ -586,15 +576,16 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
                   {module.namespace} / {module.name}
                 </Typography.Text>
                 {alreadyImported && (
-                  <Typography.Text type="secondary" style={{ display: "flex", alignItems: "center", gap: 4, fontSize: 12 }}>
+                  <Typography.Text
+                    type="secondary"
+                    style={{ display: "flex", alignItems: "center", gap: 4, fontSize: 12 }}
+                  >
                     <CheckCircleOutlined style={{ color: "#52c41a" }} />
                     In your Registry
                   </Typography.Text>
                 )}
               </div>
-              <div className="module-card-desc">
-                {module.description || "No description available"}
-              </div>
+              <div className="module-card-desc">{module.description || "No description available"}</div>
             </div>
             {!alreadyImported && (
               <Button
@@ -611,7 +602,15 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
           </div>
         </div>
         {/* Footer with separator */}
-        <div style={{ borderTop: "1px solid #f0f0f0", padding: "10px 24px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <div
+          style={{
+            borderTop: "1px solid #f0f0f0",
+            padding: "10px 24px",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
           <Space size={16}>
             <Space size={4}>
               <DownloadOutlined style={{ fontSize: 13, color: "#8c97a8" }} />
@@ -630,9 +629,7 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
   };
 
   const getModalTitle = () => {
-    return modalState.type === "provider"
-      ? "Add provider to organization"
-      : "Add module to organization";
+    return modalState.type === "provider" ? "Add provider to organization" : "Add module to organization";
   };
 
   const getModalItemName = () => {
@@ -695,7 +692,11 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
         <Search
           placeholder="Search Terraform Registry..."
           allowClear
-          enterButton={<><SearchOutlined /> Search</>}
+          enterButton={
+            <>
+              <SearchOutlined /> Search
+            </>
+          }
           size="large"
           onSearch={handleSearch}
           loading={loading}
@@ -711,20 +712,24 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
         closable={!importing}
         maskClosable={!importing}
         width={560}
-        footer={importing ? null : [
-          <Button key="cancel" onClick={closeModal}>
-            Cancel
-          </Button>,
-          <Button
-            key="add"
-            type="primary"
-            loading={loadingVersions}
-            disabled={modalState.type === "provider" && !selectedVersion}
-            onClick={modalState.type === "provider" ? handleAddProvider : handleAddModule}
-          >
-            Import {modalState.type === "provider" ? "Provider" : "Module"}
-          </Button>,
-        ]}
+        footer={
+          importing
+            ? null
+            : [
+                <Button key="cancel" onClick={closeModal}>
+                  Cancel
+                </Button>,
+                <Button
+                  key="add"
+                  type="primary"
+                  loading={loadingVersions}
+                  disabled={modalState.type === "provider" && !selectedVersion}
+                  onClick={modalState.type === "provider" ? handleAddProvider : handleAddModule}
+                >
+                  Import {modalState.type === "provider" ? "Provider" : "Module"}
+                </Button>,
+              ]
+        }
       >
         {importing ? (
           <div style={{ padding: "20px 0" }}>
@@ -734,22 +739,26 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
             <Steps
               direction="vertical"
               size="small"
-              current={importProgress.findIndex(p => p.status === "process")}
+              current={importProgress.findIndex((p) => p.status === "process")}
               items={importProgress.map((p) => ({
                 title: p.message,
                 status: p.status,
-                icon: p.status === "process" ? <LoadingOutlined /> : 
-                      p.status === "finish" ? <CheckCircleOutlined /> : undefined,
+                icon:
+                  p.status === "process" ? (
+                    <LoadingOutlined />
+                  ) : p.status === "finish" ? (
+                    <CheckCircleOutlined />
+                  ) : undefined,
               }))}
             />
           </div>
         ) : (
           <>
             <Typography.Paragraph>
-              Import this {modalState.type} from the public Terraform Registry to your private
-              registry in <strong>{organizationName}</strong>.
+              Import this {modalState.type} from the public Terraform Registry to your private registry in{" "}
+              <strong>{organizationName}</strong>.
             </Typography.Paragraph>
-            
+
             <div style={{ background: "#f5f5f5", padding: 16, borderRadius: 8, marginBottom: 16 }}>
               <Typography.Text strong style={{ fontSize: 16 }}>
                 {getModalItemName()}
@@ -787,7 +796,7 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
                         }
                         return 0;
                       })
-                      .map(v => ({
+                      .map((v) => ({
                         value: v.version,
                         label: `v${v.version}`,
                       }))}
@@ -797,8 +806,8 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
             )}
 
             <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
-              This will create the {modalState.type} in your private registry, allowing you to use it
-              in your Terraform configurations with your organization's registry URL.
+              This will create the {modalState.type} in your private registry, allowing you to use it in your Terraform
+              configurations with your organization's registry URL.
             </Typography.Paragraph>
           </>
         )}

--- a/ui/src/domain/Modules/Registry.tsx
+++ b/ui/src/domain/Modules/Registry.tsx
@@ -1,5 +1,11 @@
 import { Tabs, Button, Dropdown, Input, Space } from "antd";
-import { SearchOutlined, CloudUploadOutlined, DownOutlined, AppstoreOutlined, CloudServerOutlined } from "@ant-design/icons";
+import {
+  SearchOutlined,
+  CloudUploadOutlined,
+  DownOutlined,
+  AppstoreOutlined,
+  CloudServerOutlined,
+} from "@ant-design/icons";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import PageWrapper from "@/modules/layout/PageWrapper/PageWrapper";
@@ -33,9 +39,7 @@ async function fetchModules(orgId: string): Promise<FlatModule[]> {
 }
 
 async function fetchProviders(orgId: string): Promise<FlatProvider[]> {
-  const response = await axiosInstance.get(
-    `organization/${orgId}/provider?include=version`
-  );
+  const response = await axiosInstance.get(`organization/${orgId}/provider?include=version`);
   const data = response.data.data || [];
   const included = response.data.included || [];
 
@@ -72,9 +76,7 @@ async function fetchProviders(orgId: string): Promise<FlatProvider[]> {
 }
 
 async function fetchOrgName(orgId: string): Promise<string> {
-  const response = await axiosInstance.get(
-    `organization/${orgId}?fields[organization]=name`
-  );
+  const response = await axiosInstance.get(`organization/${orgId}?fields[organization]=name`);
   return response.data.data.attributes.name;
 }
 
@@ -193,12 +195,7 @@ export const Registry = ({ setOrganizationName, organizationName }: Props) => {
           Modules
         </span>
       ),
-      children: (
-        <ModuleList
-          modules={modules}
-          searchFilter={searchFilter}
-        />
-      ),
+      children: <ModuleList modules={modules} searchFilter={searchFilter} />,
     },
     {
       key: "providers",
@@ -228,11 +225,7 @@ export const Registry = ({ setOrganizationName, organizationName }: Props) => {
       contentClassName="registry-centered"
       actions={
         <Space>
-          <Button
-            type="default"
-            icon={<SearchOutlined />}
-            onClick={handleSearchPublicRegistry}
-          >
+          <Button type="default" icon={<SearchOutlined />} onClick={handleSearchPublicRegistry}>
             Search public registry
           </Button>
           <Dropdown menu={{ items: publishMenuItems }} trigger={["click"]}>
@@ -253,12 +246,7 @@ export const Registry = ({ setOrganizationName, organizationName }: Props) => {
           onChange={(e) => setSearchFilter(e.target.value)}
           style={{ width: "100%", maxWidth: 500, marginBottom: 24 }}
         />
-        <Tabs
-          activeKey={activeTab}
-          onChange={handleTabChange}
-          items={tabItems}
-          size="large"
-        />
+        <Tabs activeKey={activeTab} onChange={handleTabChange} items={tabItems} size="large" />
       </div>
     </PageWrapper>
   );

--- a/ui/src/domain/Organizations/IconSelector.tsx
+++ b/ui/src/domain/Organizations/IconSelector.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Input, Popover } from "antd";
 import { SearchOutlined } from "@ant-design/icons";
-import * as FaIcons from "react-icons/fa6";
+import { faIcons, getFaIcon } from "../../config/iconList";
 
 // Get all FontAwesome 6 icon names from react-icons/fa6
-const allFa6Icons = Object.keys(FaIcons).filter((key) => key.startsWith("Fa"));
+const allFa6Icons = Object.keys(faIcons).filter((key) => key.startsWith("Fa"));
 
 // Sort for easier browsing
 allFa6Icons.sort();
@@ -48,7 +48,7 @@ export const IconSelector = ({ value, color = "#000000", onChange }: IconSelecto
         }}
       >
         {filteredIcons.map((icon) => {
-          const IconComponent = FaIcons[icon as keyof typeof FaIcons];
+          const IconComponent = faIcons[icon as keyof typeof faIcons];
           return (
             <div
               key={icon}
@@ -99,7 +99,7 @@ export const IconSelector = ({ value, color = "#000000", onChange }: IconSelecto
     </div>
   );
 
-  const SelectedIconComponent = selectedIcon ? FaIcons[selectedIcon as keyof typeof FaIcons] : null;
+  const SelectedIconComponent = selectedIcon ? getFaIcon(selectedIcon) : null;
 
   return (
     <Popover content={content} trigger="click" placement="bottomLeft">

--- a/ui/src/domain/Providers/ProviderDetails.tsx
+++ b/ui/src/domain/Providers/ProviderDetails.tsx
@@ -1,36 +1,13 @@
-import {
-  CopyOutlined,
-  DeleteOutlined,
-  DownOutlined,
-  LinkOutlined,
-  SettingOutlined,
-} from "@ant-design/icons";
-import {
-  Button,
-  Card,
-  Col,
-  Divider,
-  Dropdown,
-  message,
-  Popconfirm,
-  Row,
-  Space,
-  Typography,
-} from "antd";
+import { CopyOutlined, DeleteOutlined, DownOutlined, LinkOutlined, SettingOutlined } from "@ant-design/icons";
+import { Button, Card, Col, Divider, Dropdown, message, Popconfirm, Row, Space, Typography } from "antd";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { IconContext } from "react-icons";
 import { RiFolderHistoryLine } from "react-icons/ri";
 import { useNavigate, useParams } from "react-router-dom";
 import PageWrapper from "@/modules/layout/PageWrapper/PageWrapper";
 import { ORGANIZATION_ARCHIVE } from "../../config/actionTypes";
-import {
-  getProvider,
-  deleteProviderCascade,
-} from "./providerService";
-import {
-  ProviderModel,
-  ProviderVersionModel,
-} from "./types";
+import { getProvider, deleteProviderCascade } from "./providerService";
+import { ProviderModel, ProviderVersionModel } from "./types";
 
 type Props = {
   organizationName: string;
@@ -154,7 +131,12 @@ export const ProviderDetails = ({ organizationName }: Props) => {
   return (
     <PageWrapper
       title={shortName || "Provider"}
-      subTitle={provider?.attributes.description?.replace(/https?:\/\/[^\s]+/g, "").replace(/Source:?\s*/i, "").trim() || undefined}
+      subTitle={
+        provider?.attributes.description
+          ?.replace(/https?:\/\/[^\s]+/g, "")
+          .replace(/Source:?\s*/i, "")
+          .trim() || undefined
+      }
       loading={loading}
       loadingText="Loading Provider..."
       breadcrumbs={[
@@ -166,202 +148,176 @@ export const ProviderDetails = ({ organizationName }: Props) => {
       fluid
       innerClassName="registry-centered"
       contentClassName="registry-centered"
-
     >
       {provider && (
-          <div>
-            {/* Metadata row */}
-            <Space
-              size="large"
-              style={{ marginTop: 12, marginBottom: 24 }}
-              wrap
-            >
-              {namespace && (
-                <Typography.Text type="secondary">
-                  By <strong>{namespace}</strong>
-                </Typography.Text>
-              )}
-              {selectedVersion && (
-                <Space size={4}>
-                  <IconContext.Provider value={{ size: "1.1em" }}>
-                    <RiFolderHistoryLine />
-                  </IconContext.Provider>
-                  <Typography.Text type="secondary">
-                    Version{" "}
-                  </Typography.Text>
-                  <Dropdown
-                    menu={{
-                      items: versions.map((v) => ({
-                        key: v.versionNumber,
-                        label: v.versionNumber,
-                      })),
-                      onClick: ({ key }) => setSelectedVersion(key),
-                      selectedKeys: [selectedVersion],
-                    }}
-                    trigger={["click"]}
-                  >
-                    <Typography.Link style={{ fontWeight: 600 }}>
-                      {selectedVersion} <DownOutlined style={{ fontSize: 10 }} />
-                    </Typography.Link>
-                  </Dropdown>
-                </Space>
-              )}
-              {sourceUrl && (
-                <Space size={4}>
-                  <LinkOutlined />
-                  <Typography.Text type="secondary">
-                    Source{" "}
-                    <Typography.Link
-                      href={sourceUrl}
-                      target="_blank"
-                    >
-                      {sourceRepoName} <LinkOutlined />
-                    </Typography.Link>
-                  </Typography.Text>
-                </Space>
-              )}
-
-            </Space>
-
-            {/* Overview content */}
-            <Row gutter={32} style={{ marginTop: 16 }}>
-              <Col span={16}>
-                <Typography.Title level={4}>
-                  Provider details
-                </Typography.Title>
-                <Typography.Paragraph type="secondary">
-                  Select a version from the metadata above and copy the
-                  configuration from the sidebar.
-                </Typography.Paragraph>
-
-              </Col>
-              <Col span={8}>
-                <Card
-                  style={{ borderRadius: 12, border: "1px solid #e8e8e8" }}
-                  styles={{ body: { padding: "20px 24px" } }}
+        <div>
+          {/* Metadata row */}
+          <Space size="large" style={{ marginTop: 12, marginBottom: 24 }} wrap>
+            {namespace && (
+              <Typography.Text type="secondary">
+                By <strong>{namespace}</strong>
+              </Typography.Text>
+            )}
+            {selectedVersion && (
+              <Space size={4}>
+                <IconContext.Provider value={{ size: "1.1em" }}>
+                  <RiFolderHistoryLine />
+                </IconContext.Provider>
+                <Typography.Text type="secondary">Version </Typography.Text>
+                <Dropdown
+                  menu={{
+                    items: versions.map((v) => ({
+                      key: v.versionNumber,
+                      label: v.versionNumber,
+                    })),
+                    onClick: ({ key }) => setSelectedVersion(key),
+                    selectedKeys: [selectedVersion],
+                  }}
+                  trigger={["click"]}
                 >
-                  {/* Manage Provider dropdown */}
-                  <Dropdown
-                    menu={{
-                      items: [
-                        {
-                          key: "delete",
-                          label: (
-                            <Popconfirm
-                              title={
-                                <p>
-                                  Provider <b>{providerName}</b> and all
-                                  its versions will be permanently
-                                  deleted.
-                                  <br />
-                                  Are you sure?
-                                </p>
-                              }
-                              onConfirm={handleDelete}
-                              okText="Yes"
-                              cancelText="No"
-                              placement="left"
-                            >
-                              <Space>
-                                <DeleteOutlined
-                                  style={{ color: "#ff4d4f" }}
-                                />
-                                <span style={{ color: "#ff4d4f" }}>
-                                  Remove from organization
-                                </span>
-                              </Space>
-                            </Popconfirm>
-                          ),
-                        },
-                      ],
-                    }}
-                    trigger={["click"]}
-                  >
-                    <Button
-                      style={{ width: "100%" }}
-                      icon={<SettingOutlined />}
-                      loading={deleting}
-                    >
-                      Manage Provider <DownOutlined />
-                    </Button>
-                  </Dropdown>
+                  <Typography.Link style={{ fontWeight: 600 }}>
+                    {selectedVersion} <DownOutlined style={{ fontSize: 10 }} />
+                  </Typography.Link>
+                </Dropdown>
+              </Space>
+            )}
+            {sourceUrl && (
+              <Space size={4}>
+                <LinkOutlined />
+                <Typography.Text type="secondary">
+                  Source{" "}
+                  <Typography.Link href={sourceUrl} target="_blank">
+                    {sourceRepoName} <LinkOutlined />
+                  </Typography.Link>
+                </Typography.Text>
+              </Space>
+            )}
+          </Space>
 
-                  <Divider />
-
-                  {/* Usage Instructions */}
-                  <Typography.Title level={5} style={{ marginTop: 0 }}>
-                    Usage Instructions
-                  </Typography.Title>
-                  <Typography.Text type="secondary" style={{ fontSize: 13 }}>
-                    Copy and paste into your Terraform configuration and run{" "}
-                    <Typography.Text code style={{ fontSize: 12 }}>terraform init</Typography.Text>.
-                  </Typography.Text>
-
-                  <pre
-                    style={{
-                      background: "#f5f5f5",
-                      border: "1px solid #e8e8e8",
-                      borderRadius: 6,
-                      padding: 12,
-                      marginTop: 12,
-                      fontSize: 12,
-                      lineHeight: 1.6,
-                      overflow: "auto",
-                      color: "#333",
-                    }}
-                  >
-                    {terraformSnippet}
-                  </pre>
-
-                  <Button
-                    icon={<CopyOutlined />}
-                    onClick={handleCopySnippet}
-                    style={{ marginTop: 8 }}
-                  >
-                    Copy configuration
+          {/* Overview content */}
+          <Row gutter={32} style={{ marginTop: 16 }}>
+            <Col span={16}>
+              <Typography.Title level={4}>Provider details</Typography.Title>
+              <Typography.Paragraph type="secondary">
+                Select a version from the metadata above and copy the configuration from the sidebar.
+              </Typography.Paragraph>
+            </Col>
+            <Col span={8}>
+              <Card
+                style={{ borderRadius: 12, border: "1px solid #e8e8e8" }}
+                styles={{ body: { padding: "20px 24px" } }}
+              >
+                {/* Manage Provider dropdown */}
+                <Dropdown
+                  menu={{
+                    items: [
+                      {
+                        key: "delete",
+                        label: (
+                          <Popconfirm
+                            title={
+                              <p>
+                                Provider <b>{providerName}</b> and all its versions will be permanently deleted.
+                                <br />
+                                Are you sure?
+                              </p>
+                            }
+                            onConfirm={handleDelete}
+                            okText="Yes"
+                            cancelText="No"
+                            placement="left"
+                          >
+                            <Space>
+                              <DeleteOutlined style={{ color: "#ff4d4f" }} />
+                              <span style={{ color: "#ff4d4f" }}>Remove from organization</span>
+                            </Space>
+                          </Popconfirm>
+                        ),
+                      },
+                    ],
+                  }}
+                  trigger={["click"]}
+                >
+                  <Button style={{ width: "100%" }} icon={<SettingOutlined />} loading={deleting}>
+                    Manage Provider <DownOutlined />
                   </Button>
+                </Dropdown>
 
-                  <Divider />
+                <Divider />
 
-                  {/* Helpful links */}
-                  <Typography.Text strong style={{ fontSize: 13 }}>Helpful links</Typography.Text>
-                  <div style={{ marginTop: 8 }}>
-                    <Space direction="vertical" size={4}>
-                      {namespace && shortName && (
-                        <Typography.Link
-                          href={`https://registry.terraform.io/providers/${namespace}/${shortName}/latest/docs`}
-                          target="_blank"
-                          style={{ fontSize: 13 }}
-                        >
-                          Provider Documentation <LinkOutlined />
-                        </Typography.Link>
-                      )}
+                {/* Usage Instructions */}
+                <Typography.Title level={5} style={{ marginTop: 0 }}>
+                  Usage Instructions
+                </Typography.Title>
+                <Typography.Text type="secondary" style={{ fontSize: 13 }}>
+                  Copy and paste into your Terraform configuration and run{" "}
+                  <Typography.Text code style={{ fontSize: 12 }}>
+                    terraform init
+                  </Typography.Text>
+                  .
+                </Typography.Text>
+
+                <pre
+                  style={{
+                    background: "#f5f5f5",
+                    border: "1px solid #e8e8e8",
+                    borderRadius: 6,
+                    padding: 12,
+                    marginTop: 12,
+                    fontSize: 12,
+                    lineHeight: 1.6,
+                    overflow: "auto",
+                    color: "#333",
+                  }}
+                >
+                  {terraformSnippet}
+                </pre>
+
+                <Button icon={<CopyOutlined />} onClick={handleCopySnippet} style={{ marginTop: 8 }}>
+                  Copy configuration
+                </Button>
+
+                <Divider />
+
+                {/* Helpful links */}
+                <Typography.Text strong style={{ fontSize: 13 }}>
+                  Helpful links
+                </Typography.Text>
+                <div style={{ marginTop: 8 }}>
+                  <Space direction="vertical" size={4}>
+                    {namespace && shortName && (
                       <Typography.Link
-                        href="https://www.terraform.io/docs/language/providers/configuration.html"
+                        href={`https://registry.terraform.io/providers/${namespace}/${shortName}/latest/docs`}
                         target="_blank"
                         style={{ fontSize: 13 }}
                       >
-                        Using Providers <LinkOutlined />
+                        Provider Documentation <LinkOutlined />
                       </Typography.Link>
-                    </Space>
+                    )}
+                    <Typography.Link
+                      href="https://www.terraform.io/docs/language/providers/configuration.html"
+                      target="_blank"
+                      style={{ fontSize: 13 }}
+                    >
+                      Using Providers <LinkOutlined />
+                    </Typography.Link>
+                  </Space>
+                </div>
+                {sourceUrl && (
+                  <div style={{ marginTop: 12 }}>
+                    <Typography.Link
+                      href={`${sourceUrl}/issues`}
+                      target="_blank"
+                      style={{ color: "#ff4d4f", fontSize: 13 }}
+                    >
+                      Report an issue <LinkOutlined />
+                    </Typography.Link>
                   </div>
-                  {sourceUrl && (
-                    <div style={{ marginTop: 12 }}>
-                      <Typography.Link
-                        href={`${sourceUrl}/issues`}
-                        target="_blank"
-                        style={{ color: "#ff4d4f", fontSize: 13 }}
-                      >
-                        Report an issue <LinkOutlined />
-                      </Typography.Link>
-                    </div>
-                  )}
-                </Card>
-              </Col>
-            </Row>
-
-
-          </div>
+                )}
+              </Card>
+            </Col>
+          </Row>
+        </div>
       )}
     </PageWrapper>
   );

--- a/ui/src/domain/Providers/ProviderList.tsx
+++ b/ui/src/domain/Providers/ProviderList.tsx
@@ -18,16 +18,12 @@ type Props = {
  * Extract a source repo owner/repo string and URL from a description that
  * may contain an embedded URL (e.g. "https://github.com/owner/repo").
  */
-const extractSourceRepo = (
-  description: string
-): { repoLabel: string; repoUrl: string } | null => {
+const extractSourceRepo = (description: string): { repoLabel: string; repoUrl: string } | null => {
   const urlMatch = description.match(/https?:\/\/[^\s]+/);
   if (!urlMatch) return null;
   const url = urlMatch[0];
   try {
-    const repoName = new URL(url).pathname
-      .replace(/^\//, "")
-      .replace(/\.git$/, "");
+    const repoName = new URL(url).pathname.replace(/^\//, "").replace(/\.git$/, "");
     if (repoName) return { repoLabel: repoName, repoUrl: url };
   } catch {
     /* invalid URL – ignore */
@@ -53,11 +49,7 @@ export const ProviderList = ({ providers, searchFilter }: Props) => {
   if (filteredProviders.length === 0) {
     return (
       <Empty
-        description={
-          searchFilter
-            ? "No providers match your search"
-            : "No providers found in this organization"
-        }
+        description={searchFilter ? "No providers match your search" : "No providers found in this organization"}
       />
     );
   }
@@ -71,31 +63,34 @@ export const ProviderList = ({ providers, searchFilter }: Props) => {
         const desc = item.description || "";
         const source = extractSourceRepo(desc);
         const descriptionText = source
-          ? desc.replace(source.repoUrl, "").replace(/Source:?\s*/i, "").trim()
+          ? desc
+              .replace(source.repoUrl, "")
+              .replace(/Source:?\s*/i, "")
+              .trim()
           : desc.replace(/Source:?\s*/i, "").trim();
 
         return (
           <List.Item
             style={{ cursor: "pointer", padding: "6px 0" }}
-            onClick={() =>
-              navigate(
-                `/organizations/${orgid}/registry/providers/${item.id}`
-              )
-            }
+            onClick={() => navigate(`/organizations/${orgid}/registry/providers/${item.id}`)}
           >
-            <Card
-              hoverable
-              className="module-card"
-              style={{ width: "100%" }}
-              styles={{ body: { padding: 0 } }}
-            >
+            <Card hoverable className="module-card" style={{ width: "100%" }} styles={{ body: { padding: 0 } }}>
               <div className="module-card-body">
                 <div style={{ display: "flex", gap: 14, alignItems: "flex-start" }}>
-                  <div style={{ flexShrink: 0, width: 36, height: 36, display: "flex", alignItems: "center", justifyContent: "center" }}>
+                  <div
+                    style={{
+                      flexShrink: 0,
+                      width: 36,
+                      height: 36,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
                     <CloudOutlined style={{ fontSize: 18, color: "#7b61ff" }} />
                   </div>
                   <div style={{ flex: 1, minWidth: 0 }}>
-                    <Typography.Text strong style={{ fontSize: 16, color: "#222b3d" }}>
+                    <Typography.Text strong className="module-card-name">
                       {item.name}
                     </Typography.Text>
                     <div className="module-card-desc">
@@ -104,12 +99,18 @@ export const ProviderList = ({ providers, searchFilter }: Props) => {
                   </div>
                 </div>
               </div>
-              <div style={{ borderTop: "1px solid #f0f0f0", padding: "10px 24px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <div
+                style={{
+                  borderTop: "1px solid #f0f0f0",
+                  padding: "10px 24px",
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                }}
+              >
                 <Space size={16}>
                   {item.latestVersion && (
-                    <Typography.Text style={{ fontSize: 13, color: "#8c97a8" }}>
-                      v{item.latestVersion}
-                    </Typography.Text>
+                    <Typography.Text style={{ fontSize: 13, color: "#8c97a8" }}>v{item.latestVersion}</Typography.Text>
                   )}
                 </Space>
                 <Space size={6}>

--- a/ui/src/domain/Providers/providerService.ts
+++ b/ui/src/domain/Providers/providerService.ts
@@ -12,12 +12,8 @@ const JSON_API_CONTENT_TYPE = "application/vnd.api+json";
 
 // Terrakube API functions
 
-export const listProviders = async (
-  orgId: string
-): Promise<{ data: ProviderModel[] }> => {
-  const response = await axiosInstance.get(
-    `organization/${orgId}/provider`
-  );
+export const listProviders = async (orgId: string): Promise<{ data: ProviderModel[] }> => {
+  const response = await axiosInstance.get(`organization/${orgId}/provider`);
   return response.data;
 };
 
@@ -28,9 +24,7 @@ export const getProvider = async (
   data: ProviderModel;
   included?: (ProviderVersionModel | ProviderImplementationModel)[];
 }> => {
-  const response = await axiosInstance.get(
-    `organization/${orgId}/provider/${providerId}?include=version`
-  );
+  const response = await axiosInstance.get(`organization/${orgId}/provider/${providerId}?include=version`);
   return response.data;
 };
 
@@ -134,10 +128,7 @@ export const createImplementation = async (
  * Delete a provider and all its children (implementations, then versions).
  * The backend has no cascade delete, so we must delete children first.
  */
-export const deleteProviderCascade = async (
-  orgId: string,
-  providerId: string
-): Promise<void> => {
+export const deleteProviderCascade = async (orgId: string, providerId: string): Promise<void> => {
   // 1. Get provider with versions and implementations
   const response = await axiosInstance.get(
     `organization/${orgId}/provider/${providerId}?include=version,version.implementation`
@@ -172,15 +163,11 @@ export const deleteProviderCascade = async (
 
   // 3. Delete all versions
   for (const versionId of versionIds) {
-    await axiosInstance.delete(
-      `organization/${orgId}/provider/${providerId}/version/${versionId}`
-    );
+    await axiosInstance.delete(`organization/${orgId}/provider/${providerId}/version/${versionId}`);
   }
 
   // 4. Delete the provider itself
-  await axiosInstance.delete(
-    `organization/${orgId}/provider/${providerId}`
-  );
+  await axiosInstance.delete(`organization/${orgId}/provider/${providerId}`);
 };
 
 // Keep simple delete for backward compatibility
@@ -188,9 +175,7 @@ export const deleteProvider = deleteProviderCascade;
 
 // Terraform Registry API functions (via backend proxy to avoid CORS)
 
-export const searchTerraformRegistry = async (
-  query: string
-): Promise<TerraformRegistrySearchResult> => {
+export const searchTerraformRegistry = async (query: string): Promise<TerraformRegistrySearchResult> => {
   const response = await axiosRegistry.get("/registry/v1/providers", {
     params: {
       q: query,
@@ -204,9 +189,7 @@ export const getProviderVersions = async (
   namespace: string,
   name: string
 ): Promise<TerraformRegistryProviderVersions> => {
-  const response = await axiosRegistry.get(
-    `/registry/v1/providers/${namespace}/${name}/versions`
-  );
+  const response = await axiosRegistry.get(`/registry/v1/providers/${namespace}/${name}/versions`);
   return response.data;
 };
 
@@ -233,7 +216,7 @@ export const importProvider = async (
   prefetchedVersions?: TerraformRegistryProviderVersions
 ): Promise<{ provider: ProviderModel; version: ProviderVersionModel }> => {
   // 1. Get versions from registry (or use pre-fetched data to avoid duplicate call)
-  const versionsData = prefetchedVersions || await getProviderVersions(namespace, name);
+  const versionsData = prefetchedVersions || (await getProviderVersions(namespace, name));
   const versionInfo = versionsData.versions.find((v) => v.version === version);
 
   if (!versionInfo) {
@@ -242,12 +225,10 @@ export const importProvider = async (
 
   // 2. Create provider in Terrakube (use only the short name, not namespace/name)
   const desc = description || `${namespace}/${name}`;
-  const providerResult = await createProvider(
-    orgId,
-    name,
-    desc.substring(0, 256),
-    { imported: true, registryNamespace: namespace }
-  );
+  const providerResult = await createProvider(orgId, name, desc.substring(0, 256), {
+    imported: true,
+    registryNamespace: namespace,
+  });
   const providerId = providerResult.data.id;
 
   // 3. Create version in Terrakube
@@ -266,23 +247,18 @@ export const importProvider = async (
 
   // Filter to only available platforms
   const availablePlatforms = platforms.filter((platform) =>
-    versionInfo.platforms?.some(
-      (p) => p.os === platform.os && p.arch === platform.arch
-    )
+    versionInfo.platforms?.some((p) => p.os === platform.os && p.arch === platform.arch)
   );
 
   // Fetch all download info in parallel
   const downloadResults = await Promise.allSettled(
-    availablePlatforms.map((platform) =>
-      getProviderDownload(namespace, name, version, platform.os, platform.arch)
-    )
+    availablePlatforms.map((platform) => getProviderDownload(namespace, name, version, platform.os, platform.arch))
   );
 
   // Create all implementations in parallel
   const implementationPromises = downloadResults
     .filter(
-      (result): result is PromiseFulfilledResult<TerraformRegistryProviderDownload> =>
-        result.status === "fulfilled"
+      (result): result is PromiseFulfilledResult<TerraformRegistryProviderDownload> => result.status === "fulfilled"
     )
     .map((result) => {
       const downloadInfo = result.value;
@@ -308,10 +284,7 @@ export const importProvider = async (
         source: source.substring(0, 64) || "unknown",
         sourceUrl: sourceUrl.substring(0, 512) || "https://unknown",
       }).catch((error) => {
-        console.warn(
-          `Failed to create implementation for ${downloadInfo.os}/${downloadInfo.arch}:`,
-          error
-        );
+        console.warn(`Failed to create implementation for ${downloadInfo.os}/${downloadInfo.arch}:`, error);
       });
     });
 
@@ -322,5 +295,3 @@ export const importProvider = async (
     version: versionResult.data,
   };
 };
-
-

--- a/ui/src/domain/Providers/types.ts
+++ b/ui/src/domain/Providers/types.ts
@@ -96,5 +96,3 @@ export type TerraformRegistryProviderDownload = {
 export type TerraformRegistrySearchResult = {
   providers: TerraformRegistryProvider[];
 };
-
-

--- a/ui/src/domain/Settings/Actions.tsx
+++ b/ui/src/domain/Settings/Actions.tsx
@@ -7,7 +7,21 @@ import {
   QuestionCircleOutlined,
 } from "@ant-design/icons";
 import { Editor, type OnMount } from "@monaco-editor/react";
-import { Alert, Button, Form, Input, message, Popconfirm, Select, Space, Switch, Table, Tooltip, Typography, theme } from "antd";
+import {
+  Alert,
+  Button,
+  Form,
+  Input,
+  message,
+  Popconfirm,
+  Select,
+  Space,
+  Switch,
+  Table,
+  Tooltip,
+  Typography,
+  theme,
+} from "antd";
 import { Buffer } from "buffer";
 import { useEffect, useRef, useState } from "react";
 import axiosInstance, { getErrorMessage, isPermissionError } from "../../config/axiosConfig";
@@ -129,19 +143,22 @@ export const ActionSettings = ({ managePermission = true }: Props) => {
     setMode("edit");
     setActionId(id);
     setIsEditing(true);
-    axiosInstance.get(`action/${id}`).then((response) => {
-      const action = response.data.data;
-      form.setFieldsValue({
-        id: action.id,
-        ...action.attributes,
-        displayCriteria: JSON.parse(action.attributes.displayCriteria),
+    axiosInstance
+      .get(`action/${id}`)
+      .then((response) => {
+        const action = response.data.data;
+        form.setFieldsValue({
+          id: action.id,
+          ...action.attributes,
+          displayCriteria: JSON.parse(action.attributes.displayCriteria),
+        });
+        const actionDecoded = Buffer.from(action.attributes.action, "base64").toString("ascii");
+        editorRef.current.setValue(actionDecoded);
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
+        setIsEditing(false);
       });
-      const actionDecoded = Buffer.from(action.attributes.action, "base64").toString("ascii");
-      editorRef.current.setValue(actionDecoded);
-    }).catch((err) => {
-      message.error(getErrorMessage(err));
-      setIsEditing(false);
-    });
   };
 
   const onNew = () => {
@@ -151,12 +168,15 @@ export const ActionSettings = ({ managePermission = true }: Props) => {
   };
 
   const onDelete = (id: string) => {
-    axiosInstance.delete(`action/${id}`).then(() => {
-      message.success("Action deleted successfully");
-      loadActions();
-    }).catch((err) => {
-      message.error(getErrorMessage(err));
-    });
+    axiosInstance
+      .delete(`action/${id}`)
+      .then(() => {
+        message.success("Action deleted successfully");
+        loadActions();
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
+      });
   };
 
   const onCreate = (values: CreateActionForm) => {
@@ -214,14 +234,18 @@ export const ActionSettings = ({ managePermission = true }: Props) => {
   };
 
   const loadActions = () => {
-    axiosInstance.get(`action`).then((response) => {
-      setActions(response.data.data);
-      setError(null);
-    }).catch((err) => {
-      setError(getErrorMessage(err));
-    }).finally(() => {
-      setLoading(false);
-    });
+    axiosInstance
+      .get(`action`)
+      .then((response) => {
+        setActions(response.data.data);
+        setError(null);
+      })
+      .catch((err) => {
+        setError(getErrorMessage(err));
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   };
 
   useEffect(() => {

--- a/ui/src/domain/Settings/AddVCS.tsx
+++ b/ui/src/domain/Settings/AddVCS.tsx
@@ -454,12 +454,7 @@ export const AddVCS = ({ setMode, loadVCS }: Props) => {
           <div>
             <Typography.Text type="secondary" className="paragraph">
               1. On {renderVCSType(vcsType)},{" "}
-              <Button
-                className="link"
-                target="_blank"
-                href="https://aex.dev.azure.com/me?mkt=es-ES"
-                type="link"
-              >
+              <Button className="link" target="_blank" href="https://aex.dev.azure.com/me?mkt=es-ES" type="link">
                 grant accesses to the managed identity &nbsp; <HiOutlineExternalLink />
               </Button>
               . Enter the following information:
@@ -470,19 +465,13 @@ export const AddVCS = ({ setMode, loadVCS }: Props) => {
                 <ul className="disc-list">
                   <li>
                     <b>Organization Setup:</b>{" "}
-                    <Typography.Paragraph
-                      type="secondary"
-                      style={{ display: "inline", margin: 0, paddingLeft: "5px" }}
-                    >
+                    <Typography.Paragraph type="secondary" style={{ display: "inline", margin: 0, paddingLeft: "5px" }}>
                       Add the manage identity to the organization and grant "Basic" access level
                     </Typography.Paragraph>
                   </li>
                   <li>
                     <b>Repository setup:</b>{" "}
-                    <Typography.Paragraph
-                      type="secondary"
-                      style={{ display: "inline", margin: 0, paddingLeft: "5px" }}
-                    >
+                    <Typography.Paragraph type="secondary" style={{ display: "inline", margin: 0, paddingLeft: "5px" }}>
                       Add the manage identity to the repository and grant "Contributor" access level
                     </Typography.Paragraph>
                   </li>
@@ -834,10 +823,20 @@ export const AddVCS = ({ setMode, loadVCS }: Props) => {
             >
               <Input placeholder={renderVCSType(vcsType)} />
             </Form.Item>
-            <Form.Item name="endpoint" label="HTTPS URL" rules={[{ required: !httpsHidden(vcsType) }]} hidden={httpsHidden(vcsType)}>
+            <Form.Item
+              name="endpoint"
+              label="HTTPS URL"
+              rules={[{ required: !httpsHidden(vcsType) }]}
+              hidden={httpsHidden(vcsType)}
+            >
               <Input placeholder={getHttpsPlaceholder(vcsType)} />
             </Form.Item>
-            <Form.Item name="apiUrl" label="API URL" rules={[{ required: !apiUrlHidden(vcsType) }]} hidden={apiUrlHidden(vcsType)}>
+            <Form.Item
+              name="apiUrl"
+              label="API URL"
+              rules={[{ required: !apiUrlHidden(vcsType) }]}
+              hidden={apiUrlHidden(vcsType)}
+            >
               <Input placeholder={getAPIUrlPlaceholder(vcsType)} />
             </Form.Item>
             <Form.Item name="clientId" label={getClientIdName(vcsType)} rules={[{ required: true }]}>

--- a/ui/src/domain/Settings/Agents.tsx
+++ b/ui/src/domain/Settings/Agents.tsx
@@ -46,11 +46,14 @@ export const AgentSettings = ({ managePermission = true }: Props) => {
   };
 
   const onDelete = (id: string) => {
-    axiosInstance.delete(`organization/${orgid}/agent/${id}`).then(() => {
-      loadAgents();
-    }).catch((err) => {
-      message.error(getErrorMessage(err));
-    });
+    axiosInstance
+      .delete(`organization/${orgid}/agent/${id}`)
+      .then(() => {
+        loadAgents();
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
+      });
   };
 
   const onCreate = (values: AddAgentForm) => {
@@ -135,96 +138,96 @@ export const AgentSettings = ({ managePermission = true }: Props) => {
       {error ? (
         <Alert message="Access Denied" description={error} type="error" showIcon />
       ) : (
-      <>
-      <h1>Agents</h1>
-      <div>
-        <Typography.Text type="secondary" className="App-text">
-          Terrakube uses these agents to execute terraform commands. Terrakube allow to have one or multiple agents to
-          run jobs, you can have as many agents as you want for a single organization.
-        </Typography.Text>
-      </div>
-      <Button type="primary" onClick={onNew} htmlType="button" icon={<PlusOutlined />} disabled={!managePermission}>
-        Create agent pool
-      </Button>
-      <br></br>
+        <>
+          <h1>Agents</h1>
+          <div>
+            <Typography.Text type="secondary" className="App-text">
+              Terrakube uses these agents to execute terraform commands. Terrakube allow to have one or multiple agents
+              to run jobs, you can have as many agents as you want for a single organization.
+            </Typography.Text>
+          </div>
+          <Button type="primary" onClick={onNew} htmlType="button" icon={<PlusOutlined />} disabled={!managePermission}>
+            Create agent pool
+          </Button>
+          <br></br>
 
-      <h3 style={{ marginTop: "30px" }}>Agents</h3>
-      {loading ? (
-        <p>Data loading...</p>
-      ) : (
-        <List
-          itemLayout="horizontal"
-          dataSource={Agents}
-          renderItem={(item) => (
-            <List.Item
-              actions={[
-                <Popconfirm
-                  onConfirm={() => {
-                    onDelete(item.id);
-                  }}
-                  style={{ width: "20px" }}
-                  title={
-                    <p>
-                      This will permanently delete this Terrakube Agent <br />
-                      <br />
-                      Are you sure?
-                    </p>
-                  }
-                  okText="Yes"
-                  cancelText="No"
+          <h3 style={{ marginTop: "30px" }}>Agents</h3>
+          {loading ? (
+            <p>Data loading...</p>
+          ) : (
+            <List
+              itemLayout="horizontal"
+              dataSource={Agents}
+              renderItem={(item) => (
+                <List.Item
+                  actions={[
+                    <Popconfirm
+                      onConfirm={() => {
+                        onDelete(item.id);
+                      }}
+                      style={{ width: "20px" }}
+                      title={
+                        <p>
+                          This will permanently delete this Terrakube Agent <br />
+                          <br />
+                          Are you sure?
+                        </p>
+                      }
+                      okText="Yes"
+                      cancelText="No"
+                    >
+                      {" "}
+                      <Button icon={<DeleteOutlined />} type="link" danger disabled={!managePermission}>
+                        Delete
+                      </Button>
+                    </Popconfirm>,
+                  ]}
                 >
-                  {" "}
-                  <Button icon={<DeleteOutlined />} type="link" danger disabled={!managePermission}>
-                    Delete
-                  </Button>
-                </Popconfirm>,
-              ]}
-            >
-              <List.Item.Meta description={item.attributes.description} title={item.attributes.name} />
-            </List.Item>
+                  <List.Item.Meta description={item.attributes.description} title={item.attributes.name} />
+                </List.Item>
+              )}
+            />
           )}
-        />
-      )}
 
-      <Modal
-        width="650px"
-        open={visible}
-        title={mode === "edit" ? "Edit Terrakube Agent  " + AgentName : "Add a new Terrakube Agent"}
-        okText="Save Terrakube Agent "
-        onCancel={onCancel}
-        cancelText="Cancel"
-        onOk={() => {
-          form
-            .validateFields()
-            .then((values) => {
-              if (mode === "create") onCreate(values as AddAgentForm);
-              else onUpdate(values);
-            })
-            .catch((info) => {
-              console.log("Validate Failed:", info);
-            });
-        }}
-      >
-        <Space style={{ width: "100%" }} direction="vertical">
-          <Form name="Agent" form={form} layout="vertical">
-            {mode === "create" ? (
-              <Form.Item name="name" label="Name" rules={[{ required: true }]}>
-                <Input />
-              </Form.Item>
-            ) : (
-              ""
-            )}
+          <Modal
+            width="650px"
+            open={visible}
+            title={mode === "edit" ? "Edit Terrakube Agent  " + AgentName : "Add a new Terrakube Agent"}
+            okText="Save Terrakube Agent "
+            onCancel={onCancel}
+            cancelText="Cancel"
+            onOk={() => {
+              form
+                .validateFields()
+                .then((values) => {
+                  if (mode === "create") onCreate(values as AddAgentForm);
+                  else onUpdate(values);
+                })
+                .catch((info) => {
+                  console.log("Validate Failed:", info);
+                });
+            }}
+          >
+            <Space style={{ width: "100%" }} direction="vertical">
+              <Form name="Agent" form={form} layout="vertical">
+                {mode === "create" ? (
+                  <Form.Item name="name" label="Name" rules={[{ required: true }]}>
+                    <Input />
+                  </Form.Item>
+                ) : (
+                  ""
+                )}
 
-            <Form.Item name="description" label="Description" rules={[{ required: true }]}>
-              <Input />
-            </Form.Item>
-            <Form.Item name="url" label="Url" rules={[{ required: true }]}>
-              <Input />
-            </Form.Item>
-          </Form>
-        </Space>
-      </Modal>
-      </>
+                <Form.Item name="description" label="Description" rules={[{ required: true }]}>
+                  <Input />
+                </Form.Item>
+                <Form.Item name="url" label="Url" rules={[{ required: true }]}>
+                  <Input />
+                </Form.Item>
+              </Form>
+            </Space>
+          </Modal>
+        </>
       )}
     </div>
   );

--- a/ui/src/domain/Settings/CollectionReferences.tsx
+++ b/ui/src/domain/Settings/CollectionReferences.tsx
@@ -151,23 +151,24 @@ export const CollectionReferencesSettings = ({ collectionId, collectionName }: P
     });
   };
 
-  const loadWorkspaces = () => {
-    axiosInstance.get(`organization/${orgid}/workspace`).then((response) => {
-      setWorkspaces(response.data.data);
+  useEffect(() => {
+    setLoading(true);
+    // Parallel load: references and workspaces
+    Promise.all([
+      axiosInstance.get(`organization/${orgid}/collection/${collectionId}/reference`),
+      axiosInstance.get(`organization/${orgid}/workspace`),
+    ]).then(([refsRes, workspacesRes]) => {
+      setReferences(refsRes.data.data);
+      setWorkspaces(workspacesRes.data.data);
 
       // Create a map of workspace IDs to names for easier lookup
       const map: { [key: string]: string } = {};
-      response.data.data.forEach((workspace: Workspace) => {
+      workspacesRes.data.data.forEach((workspace: Workspace) => {
         map[workspace.id] = workspace.attributes.name;
       });
       setWorkspacesMap(map);
+      setLoading(false);
     });
-  };
-
-  useEffect(() => {
-    setLoading(true);
-    loadReferences();
-    loadWorkspaces();
   }, [orgid, collectionId]);
 
   return (

--- a/ui/src/domain/Settings/CreateEditCollection.tsx
+++ b/ui/src/domain/Settings/CreateEditCollection.tsx
@@ -42,7 +42,11 @@ type CreateEditCollectionProps = {
   managePermission?: boolean;
 };
 
-export const CreateEditCollection = ({ mode, collectionId: propCollectionId, managePermission = true }: CreateEditCollectionProps) => {
+export const CreateEditCollection = ({
+  mode,
+  collectionId: propCollectionId,
+  managePermission = true,
+}: CreateEditCollectionProps) => {
   const { orgid, collectionid: urlCollectionId } = useParams();
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
@@ -61,47 +65,46 @@ export const CreateEditCollection = ({ mode, collectionId: propCollectionId, man
   const collectionid = propCollectionId || urlCollectionId;
 
   // Load collection data if in edit mode
+  // Load collection data if in edit mode
   useEffect(() => {
     setLoading(true);
 
-    // Load workspaces
-    axiosInstance.get(`organization/${orgid}/workspace`).then((response) => {
-      setWorkspaces(response.data.data);
-    });
-
     if (mode === "edit" && collectionid) {
-      // Load collection data
-      axiosInstance.get(`organization/${orgid}/collection/${collectionid}`).then((response) => {
-        const collectionData = response.data.data;
+      // Parallel load: workspaces, collection data, collection items, and collection references
+      Promise.all([
+        axiosInstance.get(`organization/${orgid}/workspace`),
+        axiosInstance.get(`organization/${orgid}/collection/${collectionid}`),
+        axiosInstance.get(`organization/${orgid}/collection/${collectionid}/item`),
+        axiosInstance.get(`organization/${orgid}/collection/${collectionid}/reference`),
+      ]).then(([workspacesRes, collectionRes, itemsRes, refsRes]) => {
+        setWorkspaces(workspacesRes.data.data);
 
+        const collectionData = collectionRes.data.data;
         collectionForm.setFieldsValue({
           name: collectionData.attributes.name,
           description: collectionData.attributes.description,
           priority: collectionData.attributes.priority || 10,
         });
 
-        // Load collection variables
-        axiosInstance.get(`organization/${orgid}/collection/${collectionid}/item`).then((response) => {
-          setVariables(response.data.data);
-        });
+        setVariables(itemsRes.data.data);
 
-        // Load collection workspace references
-        axiosInstance.get(`organization/${orgid}/collection/${collectionid}/reference`).then((response) => {
-          const workspaceIds = response.data.data
-              .filter((ref: any) => ref.relationships?.workspace?.data?.id != null)
-              .map((ref: any) => ref.relationships.workspace.data.id);
-          setSelectedWorkspaces(workspaceIds);
-        });
+        const workspaceIds = refsRes.data.data
+          .filter((ref: any) => ref.relationships?.workspace?.data?.id != null)
+          .map((ref: any) => ref.relationships.workspace.data.id);
+        setSelectedWorkspaces(workspaceIds);
 
         setLoading(false);
       });
     } else {
-      // For create mode, initialize with empty variables
-      setVariables([]);
-      setSelectedWorkspaces([]);
-      setLoading(false);
+      // For create mode, just load workspaces
+      axiosInstance.get(`organization/${orgid}/workspace`).then((response) => {
+        setWorkspaces(response.data.data);
+        setVariables([]);
+        setSelectedWorkspaces([]);
+        setLoading(false);
+      });
     }
-  }, [orgid, collectionid, mode]);
+  }, [orgid, collectionid, mode, collectionForm]);
 
   const handleCancel = () => {
     navigate(`/organizations/${orgid}/settings/collection`);
@@ -183,14 +186,14 @@ export const CreateEditCollection = ({ mode, collectionId: propCollectionId, man
 
         const existingRefs = refsResponse.data.data;
         const existingWorkspaceIds = existingRefs
-            .filter((ref: any) => ref.relationships?.workspace?.data?.id != null)
-            .map((ref: any) => ref.relationships.workspace.data.id);
+          .filter((ref: any) => ref.relationships?.workspace?.data?.id != null)
+          .map((ref: any) => ref.relationships.workspace.data.id);
 
         // Delete references that are not in the new selection or where the workspace is null because it was deleted
         for (const ref of existingRefs) {
           const workspaceId = ref.relationships?.workspace?.data?.id;
           if (workspaceId == null) {
-              await axiosInstance.delete(`organization/${orgid}/collection/${collectionid}/reference/${ref.id}`);
+            await axiosInstance.delete(`organization/${orgid}/collection/${collectionid}/reference/${ref.id}`);
           } else if (!selectedWorkspaces.includes(workspaceId)) {
             await axiosInstance.delete(`organization/${orgid}/collection/${collectionid}/reference/${ref.id}`);
           }
@@ -578,8 +581,7 @@ export const CreateEditCollection = ({ mode, collectionId: propCollectionId, man
     <div>
       <div style={{ marginBottom: "15px" }}>
         <Typography.Text>
-          You can add any number of variables. Terrakube will use these variables for jobs in the specified
-          workspaces.
+          You can add any number of variables. Terrakube will use these variables for jobs in the specified workspaces.
         </Typography.Text>
       </div>
 
@@ -696,9 +698,7 @@ export const CreateEditCollection = ({ mode, collectionId: propCollectionId, man
 
           {mode === "create" ? (
             <div style={{ marginBottom: "15px" }}>
-              <Typography.Text>
-                Create the collection first. Then you can add variables to it.
-              </Typography.Text>
+              <Typography.Text>Create the collection first. Then you can add variables to it.</Typography.Text>
             </div>
           ) : (
             variableListing

--- a/ui/src/domain/Settings/EditTeam.tsx
+++ b/ui/src/domain/Settings/EditTeam.tsx
@@ -1,17 +1,5 @@
 import { InfoCircleOutlined } from "@ant-design/icons";
-import {
-  Alert,
-  Button,
-  Divider,
-  Form,
-  Input,
-  Space,
-  Spin,
-  Tooltip,
-  Typography,
-  message,
-  theme,
-} from "antd";
+import { Alert, Button, Divider, Form, Input, Space, Spin, Tooltip, Typography, message, theme } from "antd";
 import CreatePatModal from "@/modules/token/modals/CreatePatModal";
 import { CreateTokenForm } from "@/modules/user/types";
 import TokenGrid from "@/modules/token/TokenGrid";

--- a/ui/src/domain/Settings/EditTemplate.tsx
+++ b/ui/src/domain/Settings/EditTemplate.tsx
@@ -50,15 +50,19 @@ export const EditTemplate = ({ setMode, templateId, loadTemplates }: Props) => {
   }
 
   const loadTemplate = (templateId: string) => {
-    axiosInstance.get(`organization/${orgid}/template/${templateId}`).then((response) => {
-      setTemplate(response.data.data);
-      const buff = Buffer.from(response.data.data.attributes.tcl, "base64");
-      setTCL(buff.toString("ascii"));
-    }).catch((err) => {
-      setError(getErrorMessage(err));
-    }).finally(() => {
-      setLoading(false);
-    });
+    axiosInstance
+      .get(`organization/${orgid}/template/${templateId}`)
+      .then((response) => {
+        setTemplate(response.data.data);
+        const buff = Buffer.from(response.data.data.attributes.tcl, "base64");
+        setTCL(buff.toString("ascii"));
+      })
+      .catch((err) => {
+        setError(getErrorMessage(err));
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   };
 
   const onFinish = (values: EditTemplateForm) => {

--- a/ui/src/domain/Settings/General.tsx
+++ b/ui/src/domain/Settings/General.tsx
@@ -155,8 +155,12 @@ export const GeneralSettings = ({ managePermission = true }: Props) => {
             <Form.Item name="name" label="Name">
               <Input />
             </Form.Item>
-            <Form.Item name="description" label="Description">
-              <Input.TextArea />
+            <Form.Item
+              name="description"
+              label="Description"
+              extra={<Typography.Text type="secondary">A brief description of this organization.</Typography.Text>}
+            >
+              <Input.TextArea rows={3} />
             </Form.Item>
             <Form.Item name="executionMode" label="Default Execution Mode for New Workspaces (informational only)">
               <Radio.Group>
@@ -201,11 +205,14 @@ export const GeneralSettings = ({ managePermission = true }: Props) => {
           </Form>
         </Spin>
       )}
-      <h1>Delete this Organization</h1>
-      <div>
+      <h1>Destruction and Deletion</h1>
+      <h3>Delete this Organization</h3>
+      <div style={{ textAlign: "left", marginBottom: "16px" }}>
         <Typography.Text type="secondary" className="App-text">
-          Deleting the organization will permanently delete all workspaces associated with it. Please be certain that
-          you understand this.
+          Deleting the <strong>{organization?.attributes?.name}</strong> organization will permanently delete all
+          workspaces associated with it.
+          <br />
+          Please be certain that you understand this. This action cannot be undone.
         </Typography.Text>
       </div>
       <Popconfirm
@@ -224,11 +231,13 @@ export const GeneralSettings = ({ managePermission = true }: Props) => {
         cancelText="No"
         placement="bottom"
       >
-        <Button type="default" danger style={{ width: "100%" }} disabled={!managePermission}>
-          <Space>
-            <DeleteOutlined />
-            Delete from Terrakube
-          </Space>
+        <Button
+          type="primary"
+          danger
+          style={{ width: "fit-content", padding: "8px 24px", height: "auto" }}
+          disabled={!managePermission}
+        >
+          Delete this organization
         </Button>
       </Popconfirm>
     </div>

--- a/ui/src/domain/Settings/GlobalVariables.tsx
+++ b/ui/src/domain/Settings/GlobalVariables.tsx
@@ -1,5 +1,20 @@
 import { DeleteOutlined, EditOutlined, InfoCircleOutlined, PlusOutlined } from "@ant-design/icons";
-import { Alert, Button, Form, Input, message, Modal, Popconfirm, Select, Space, Switch, Table, Tag, Typography, Spin } from "antd";
+import {
+  Alert,
+  Button,
+  Form,
+  Input,
+  message,
+  Modal,
+  Popconfirm,
+  Select,
+  Space,
+  Switch,
+  Table,
+  Tag,
+  Typography,
+  Spin,
+} from "antd";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import axiosInstance, { getErrorMessage, isPermissionError } from "../../config/axiosConfig";
@@ -123,11 +138,14 @@ export const GlobalVariablesSettings = ({ managePermission = true }: Props) => {
   };
 
   const onDelete = (id: string) => {
-    axiosInstance.delete(`organization/${orgid}/globalvar/${id}`).then((response) => {
-      loadGlobalVariables();
-    }).catch((err) => {
-      message.error(getErrorMessage(err));
-    });
+    axiosInstance
+      .delete(`organization/${orgid}/globalvar/${id}`)
+      .then((response) => {
+        loadGlobalVariables();
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
+      });
   };
 
   const onCreate = (values: CreateVariableForm) => {
@@ -218,92 +236,92 @@ export const GlobalVariablesSettings = ({ managePermission = true }: Props) => {
       {error ? (
         <Alert message="Access Denied" description={error} type="error" showIcon />
       ) : (
-      <>
-      <h1>Global Variables</h1>
-      <div>
-        <Typography.Text type="secondary" className="App-text">
-          Global Variables allow you to define and apply variables one time across multiple workspaces within an
-          organization.
-        </Typography.Text>
-      </div>
-      <Button type="primary" onClick={onNew} htmlType="button" icon={<PlusOutlined />} disabled={!managePermission}>
-        Create global variable
-      </Button>
-      <br></br>
+        <>
+          <h1>Global Variables</h1>
+          <div>
+            <Typography.Text type="secondary" className="App-text">
+              Global Variables allow you to define and apply variables one time across multiple workspaces within an
+              organization.
+            </Typography.Text>
+          </div>
+          <Button type="primary" onClick={onNew} htmlType="button" icon={<PlusOutlined />} disabled={!managePermission}>
+            Create global variable
+          </Button>
+          <br></br>
 
-      <h3 style={{ marginTop: "30px" }}>Global Variables</h3>
-      <Spin spinning={loading} tip="Loading Global Variables...">
-        <Table dataSource={globalVariables} columns={VARIABLES_COLUMS(onEdit)} rowKey="key" />
-      </Spin>
+          <h3 style={{ marginTop: "30px" }}>Global Variables</h3>
+          <Spin spinning={loading} tip="Loading Global Variables...">
+            <Table dataSource={globalVariables} columns={VARIABLES_COLUMS(onEdit)} rowKey="key" />
+          </Spin>
 
-      <Modal
-        width="600px"
-        open={visible}
-        title={mode === "edit" ? "Edit global variable " + variableKey : "Create new global variable"}
-        okText="Save global variable"
-        onCancel={onCancel}
-        cancelText="Cancel"
-        onOk={() => {
-          form
-            .validateFields()
-            .then((values) => {
-              if (mode === "create") onCreate(values);
-              else onUpdate(values);
-            })
-            .catch((info) => {
-              console.log("Validate Failed:", info);
-            });
-        }}
-      >
-        <Space style={{ width: "100%" }} direction="vertical">
-          <Form name="globalVariable" form={form} layout="vertical">
-            <Form.Item name="key" label="Key" rules={[{ required: true }]}>
-              <Input />
-            </Form.Item>
-            <Form.Item name="value" label="Value" rules={[{ required: true }]}>
-              <Input.TextArea rows={1} autoSize={{ maxRows: 5 }} />
-            </Form.Item>
-            <Form.Item name="category" label="Category" rules={[{ required: true }]}>
-              <Select placeholder="Please select a category">
-                <Select.Option value="TERRAFORM">Terraform Variable</Select.Option>
-                <Select.Option value="ENV">Environment Variable</Select.Option>
-              </Select>
-            </Form.Item>
-            <Form.Item name="description" rules={[{ required: true }]} label="Description">
-              <Input.TextArea style={{ width: "800px" }} />
-            </Form.Item>
-            <Form.Item
-              name="hcl"
-              valuePropName="checked"
-              label="HCL"
-              tooltip={{
-                title:
-                  "Parse this field as HashiCorp Configuration Language (HCL). This allows you to interpolate values at runtime.",
-                icon: <InfoCircleOutlined />,
-              }}
-            >
-              <Switch />
-            </Form.Item>
-            {mode === "create" ? (
-              <Form.Item
-                name="sensitive"
-                valuePropName="checked"
-                label="Sensitive"
-                tooltip={{
-                  title:
-                    "Sensitive variables are never shown in the UI or API. They may appear in Terraform logs if your configuration is designed to output them.",
-                  icon: <InfoCircleOutlined />,
-                }}
-              >
-                <Switch />
-              </Form.Item>
-            ) : (
-              ""
-            )}
-          </Form>
-        </Space>
-      </Modal>
-      </>
+          <Modal
+            width="600px"
+            open={visible}
+            title={mode === "edit" ? "Edit global variable " + variableKey : "Create new global variable"}
+            okText="Save global variable"
+            onCancel={onCancel}
+            cancelText="Cancel"
+            onOk={() => {
+              form
+                .validateFields()
+                .then((values) => {
+                  if (mode === "create") onCreate(values);
+                  else onUpdate(values);
+                })
+                .catch((info) => {
+                  console.log("Validate Failed:", info);
+                });
+            }}
+          >
+            <Space style={{ width: "100%" }} direction="vertical">
+              <Form name="globalVariable" form={form} layout="vertical">
+                <Form.Item name="key" label="Key" rules={[{ required: true }]}>
+                  <Input />
+                </Form.Item>
+                <Form.Item name="value" label="Value" rules={[{ required: true }]}>
+                  <Input.TextArea rows={1} autoSize={{ maxRows: 5 }} />
+                </Form.Item>
+                <Form.Item name="category" label="Category" rules={[{ required: true }]}>
+                  <Select placeholder="Please select a category">
+                    <Select.Option value="TERRAFORM">Terraform Variable</Select.Option>
+                    <Select.Option value="ENV">Environment Variable</Select.Option>
+                  </Select>
+                </Form.Item>
+                <Form.Item name="description" rules={[{ required: true }]} label="Description">
+                  <Input.TextArea style={{ width: "800px" }} />
+                </Form.Item>
+                <Form.Item
+                  name="hcl"
+                  valuePropName="checked"
+                  label="HCL"
+                  tooltip={{
+                    title:
+                      "Parse this field as HashiCorp Configuration Language (HCL). This allows you to interpolate values at runtime.",
+                    icon: <InfoCircleOutlined />,
+                  }}
+                >
+                  <Switch />
+                </Form.Item>
+                {mode === "create" ? (
+                  <Form.Item
+                    name="sensitive"
+                    valuePropName="checked"
+                    label="Sensitive"
+                    tooltip={{
+                      title:
+                        "Sensitive variables are never shown in the UI or API. They may appear in Terraform logs if your configuration is designed to output them.",
+                      icon: <InfoCircleOutlined />,
+                    }}
+                  >
+                    <Switch />
+                  </Form.Item>
+                ) : (
+                  ""
+                )}
+              </Form>
+            </Space>
+          </Modal>
+        </>
       )}
     </div>
   );

--- a/ui/src/domain/Settings/SSHKeys.tsx
+++ b/ui/src/domain/Settings/SSHKeys.tsx
@@ -49,11 +49,14 @@ export const SSHKeysSettings = ({ managePermission = true }: Props) => {
   };
 
   const onDelete = (id: string) => {
-    axiosInstance.delete(`organization/${orgid}/ssh/${id}`).then(() => {
-      loadSSHKeys();
-    }).catch((err) => {
-      message.error(getErrorMessage(err));
-    });
+    axiosInstance
+      .delete(`organization/${orgid}/ssh/${id}`)
+      .then(() => {
+        loadSSHKeys();
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
+      });
   };
 
   const onCreate = (values: AddSshKeyForm) => {
@@ -140,115 +143,115 @@ export const SSHKeysSettings = ({ managePermission = true }: Props) => {
       {error ? (
         <Alert message="Access Denied" description={error} type="error" showIcon />
       ) : (
-      <>
-      <h1>SSH Keys</h1>
-      <div>
-        <Typography.Text type="secondary" className="App-text">
-          Terrakube uses these private SSH keys for downloading private Terraform modules with Git-based sources during
-          a Terraform run. SSH keys for downloading modules are assigned per-workspace.
-        </Typography.Text>
-      </div>
-      <Button type="primary" onClick={onNew} htmlType="button" icon={<PlusOutlined />} disabled={!managePermission}>
-        Add a Private SSH Key
-      </Button>
-      <br></br>
+        <>
+          <h1>SSH Keys</h1>
+          <div>
+            <Typography.Text type="secondary" className="App-text">
+              Terrakube uses these private SSH keys for downloading private Terraform modules with Git-based sources
+              during a Terraform run. SSH keys for downloading modules are assigned per-workspace.
+            </Typography.Text>
+          </div>
+          <Button type="primary" onClick={onNew} htmlType="button" icon={<PlusOutlined />} disabled={!managePermission}>
+            Add a Private SSH Key
+          </Button>
+          <br></br>
 
-      <h3 style={{ marginTop: "30px" }}>SSH Keys</h3>
-      {loading ? (
-        <p>Data loading...</p>
-      ) : (
-        <List
-          itemLayout="horizontal"
-          dataSource={sshKeys}
-          renderItem={(item) => (
-            <List.Item
-              actions={[
-                <Popconfirm
-                  onConfirm={() => {
-                    onDelete(item.id);
-                  }}
-                  style={{ width: "20px" }}
-                  title={
+          <h3 style={{ marginTop: "30px" }}>SSH Keys</h3>
+          {loading ? (
+            <p>Data loading...</p>
+          ) : (
+            <List
+              itemLayout="horizontal"
+              dataSource={sshKeys}
+              renderItem={(item) => (
+                <List.Item
+                  actions={[
+                    <Popconfirm
+                      onConfirm={() => {
+                        onDelete(item.id);
+                      }}
+                      style={{ width: "20px" }}
+                      title={
+                        <p>
+                          This will permanently delete this SSH Key <br />
+                          Any workspaces configured with this SSH key will no longer use it to download Terraform
+                          modules. <br />
+                          Are you sure?
+                        </p>
+                      }
+                      okText="Yes"
+                      cancelText="No"
+                    >
+                      {" "}
+                      <Button icon={<DeleteOutlined />} type="link" danger disabled={!managePermission}>
+                        Delete
+                      </Button>
+                    </Popconfirm>,
+                  ]}
+                >
+                  <List.Item.Meta description={item.attributes.description} title={item.attributes.name} />
+                </List.Item>
+              )}
+            />
+          )}
+
+          <Modal
+            width="650px"
+            open={visible}
+            title={mode === "edit" ? "Edit Private SSH Key " + sshKeyName : "Add a new Private SSH Key"}
+            okText="Save SSH Key"
+            onCancel={onCancel}
+            cancelText="Cancel"
+            onOk={() => {
+              form
+                .validateFields()
+                .then((values) => {
+                  if (mode === "create") onCreate(values as AddSshKeyForm);
+                  else onUpdate(values);
+                })
+                .catch((info) => {
+                  console.log("Validate Failed:", info);
+                });
+            }}
+          >
+            <Space style={{ width: "100%" }} direction="vertical">
+              <Form name="sshKey" form={form} layout="vertical">
+                {mode === "create" ? (
+                  <Form.Item name="name" label="Name" rules={[{ required: true }]}>
+                    <Input />
+                  </Form.Item>
+                ) : (
+                  ""
+                )}
+
+                <Form.Item name="description" label="Description" rules={[{ required: true }]}>
+                  <Input />
+                </Form.Item>
+                <Form.Item name="sshType" label="SSH Type" rules={[{ required: true }]}>
+                  <Select placeholder="Please select a ssh type">
+                    <Select.Option value="rsa">RSA</Select.Option>
+                    <Select.Option value="ed25519">ED25519</Select.Option>
+                  </Select>
+                </Form.Item>
+                <Form.Item
+                  name="privateKey"
+                  rules={[{ required: true }]}
+                  label="Private SSH Key"
+                  extra={
                     <p>
-                      This will permanently delete this SSH Key <br />
-                      Any workspaces configured with this SSH key will no longer use it to download Terraform modules.{" "}
-                      <br />
-                      Are you sure?
+                      Generate a new key with{" "}
+                      <code style={{ backgroundColor: token.colorBgContainer }}>ssh-keygen -t rsa -m PEM</code>, make
+                      sure the private key starts with{" "}
+                      <code style={{ backgroundColor: token.colorBgContainer }}>-----BEGIN RSA PRIVATE KEY-----</code>
                     </p>
                   }
-                  okText="Yes"
-                  cancelText="No"
                 >
-                  {" "}
-                  <Button icon={<DeleteOutlined />} type="link" danger disabled={!managePermission}>
-                    Delete
-                  </Button>
-                </Popconfirm>,
-              ]}
-            >
-              <List.Item.Meta description={item.attributes.description} title={item.attributes.name} />
-            </List.Item>
-          )}
-        />
-      )}
-
-      <Modal
-        width="650px"
-        open={visible}
-        title={mode === "edit" ? "Edit Private SSH Key " + sshKeyName : "Add a new Private SSH Key"}
-        okText="Save SSH Key"
-        onCancel={onCancel}
-        cancelText="Cancel"
-        onOk={() => {
-          form
-            .validateFields()
-            .then((values) => {
-              if (mode === "create") onCreate(values as AddSshKeyForm);
-              else onUpdate(values);
-            })
-            .catch((info) => {
-              console.log("Validate Failed:", info);
-            });
-        }}
-      >
-        <Space style={{ width: "100%" }} direction="vertical">
-          <Form name="sshKey" form={form} layout="vertical">
-            {mode === "create" ? (
-              <Form.Item name="name" label="Name" rules={[{ required: true }]}>
-                <Input />
-              </Form.Item>
-            ) : (
-              ""
-            )}
-
-            <Form.Item name="description" label="Description" rules={[{ required: true }]}>
-              <Input />
-            </Form.Item>
-            <Form.Item name="sshType" label="SSH Type" rules={[{ required: true }]}>
-              <Select placeholder="Please select a ssh type">
-                <Select.Option value="rsa">RSA</Select.Option>
-                <Select.Option value="ed25519">ED25519</Select.Option>
-              </Select>
-            </Form.Item>
-            <Form.Item
-              name="privateKey"
-              rules={[{ required: true }]}
-              label="Private SSH Key"
-              extra={
-                <p>
-                  Generate a new key with{" "}
-                  <code style={{ backgroundColor: token.colorBgContainer }}>ssh-keygen -t rsa -m PEM</code>, make sure
-                  the private key starts with{" "}
-                  <code style={{ backgroundColor: token.colorBgContainer }}>-----BEGIN RSA PRIVATE KEY-----</code>
-                </p>
-              }
-            >
-              <TextArea rows={6} />
-            </Form.Item>
-          </Form>
-        </Space>
-      </Modal>
-      </>
+                  <TextArea rows={6} />
+                </Form.Item>
+              </Form>
+            </Space>
+          </Modal>
+        </>
       )}
     </div>
   );

--- a/ui/src/domain/Settings/Settings.css
+++ b/ui/src/domain/Settings/Settings.css
@@ -47,3 +47,29 @@
 ul.disc-list {
   list-style-type: disc;
 }
+
+/* Limit form input width in settings */
+.setting .ant-form-item {
+  max-width: 500px;
+}
+
+.setting .ant-input,
+.setting .ant-input-textarea,
+.setting textarea.ant-input {
+  max-width: 500px;
+}
+
+/* Dark mode for VCS form */
+[data-theme="dark"] .editor {
+  border-color: var(--tk-border-primary);
+  background-color: var(--tk-bg-base);
+}
+
+/* Dark mode for steps in VCS form */
+[data-theme="dark"] .ant-steps-item-title {
+  color: var(--tk-text-primary) !important;
+}
+
+[data-theme="dark"] .ant-steps-item-description {
+  color: var(--tk-text-secondary) !important;
+}

--- a/ui/src/domain/Settings/Settings.tsx
+++ b/ui/src/domain/Settings/Settings.tsx
@@ -47,7 +47,13 @@ export const OrganizationSettings = ({ selectedTab, vcsMode, collectionMode = "l
       case "new":
         return <CreateEditCollection mode="create" managePermission={permissions.manageCollection} />;
       case "edit":
-        return <CreateEditCollection mode="edit" collectionId={collectionId} managePermission={permissions.manageCollection} />;
+        return (
+          <CreateEditCollection
+            mode="edit"
+            collectionId={collectionId}
+            managePermission={permissions.manageCollection}
+          />
+        );
       case "list":
       default:
         return <VariableCollectionsSettings managePermission={permissions.manageCollection} />;

--- a/ui/src/domain/Settings/Tags.tsx
+++ b/ui/src/domain/Settings/Tags.tsx
@@ -1,5 +1,19 @@
 import { DeleteOutlined, EditOutlined, InfoCircleOutlined, PlusOutlined, TagOutlined } from "@ant-design/icons";
-import { Alert, Avatar, Button, Form, Input, List, message, Modal, Popconfirm, Space, Typography, theme, Spin } from "antd";
+import {
+  Alert,
+  Avatar,
+  Button,
+  Form,
+  Input,
+  List,
+  message,
+  Modal,
+  Popconfirm,
+  Space,
+  Typography,
+  theme,
+  Spin,
+} from "antd";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import axiosInstance, { getErrorMessage, isPermissionError } from "../../config/axiosConfig";
@@ -49,11 +63,14 @@ export const TagsSettings = ({ managePermission = true }: Props) => {
   };
 
   const onDelete = (id: string) => {
-    axiosInstance.delete(`organization/${orgid}/tag/${id}`).then((response) => {
-      loadTags();
-    }).catch((err) => {
-      message.error(getErrorMessage(err));
-    });
+    axiosInstance
+      .delete(`organization/${orgid}/tag/${id}`)
+      .then((response) => {
+        loadTags();
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
+      });
   };
 
   const onCreate = (values: AddTagForm) => {
@@ -135,105 +152,105 @@ export const TagsSettings = ({ managePermission = true }: Props) => {
       {error ? (
         <Alert message="Access Denied" description={error} type="error" showIcon />
       ) : (
-      <>
-      <h1>Tag Management</h1>
-      <div>
-        <Typography.Text type="secondary" className="App-text">
-          Tags are used to help identify and group together workspaces..
-        </Typography.Text>
-      </div>
-      <Button type="primary" onClick={onNew} htmlType="button" icon={<PlusOutlined />} disabled={!managePermission}>
-        Create tag
-      </Button>
-      <br></br>
+        <>
+          <h1>Tag Management</h1>
+          <div>
+            <Typography.Text type="secondary" className="App-text">
+              Tags are used to help identify and group together workspaces..
+            </Typography.Text>
+          </div>
+          <Button type="primary" onClick={onNew} htmlType="button" icon={<PlusOutlined />} disabled={!managePermission}>
+            Create tag
+          </Button>
+          <br></br>
 
-      <h3 style={{ marginTop: "30px" }}>Tags</h3>
-      <Spin spinning={loading} tip="Loading Tags...">
-        <List
-          itemLayout="horizontal"
-          dataSource={tags}
-          renderItem={(item) => (
-            <List.Item
-              actions={[
-                <Button
-                  onClick={() => {
-                    onEdit(item.id);
-                  }}
-                  icon={<EditOutlined />}
-                  type="link"
-                  disabled={!managePermission}
+          <h3 style={{ marginTop: "30px" }}>Tags</h3>
+          <Spin spinning={loading} tip="Loading Tags...">
+            <List
+              itemLayout="horizontal"
+              dataSource={tags}
+              renderItem={(item) => (
+                <List.Item
+                  actions={[
+                    <Button
+                      onClick={() => {
+                        onEdit(item.id);
+                      }}
+                      icon={<EditOutlined />}
+                      type="link"
+                      disabled={!managePermission}
+                    >
+                      Edit
+                    </Button>,
+                    <Popconfirm
+                      onConfirm={() => {
+                        onDelete(item.id);
+                      }}
+                      style={{ width: "20px" }}
+                      title={
+                        <p>
+                          Deleting this tag will also remove it <br />
+                          from all the Workspaces that use it.
+                          <br />
+                          This action cannot be undone. <br />
+                          Are you sure?
+                        </p>
+                      }
+                      okText="Yes"
+                      cancelText="No"
+                    >
+                      {" "}
+                      <Button icon={<DeleteOutlined />} type="link" danger disabled={!managePermission}>
+                        Delete
+                      </Button>
+                    </Popconfirm>,
+                  ]}
                 >
-                  Edit
-                </Button>,
-                <Popconfirm
-                  onConfirm={() => {
-                    onDelete(item.id);
-                  }}
-                  style={{ width: "20px" }}
-                  title={
-                    <p>
-                      Deleting this tag will also remove it <br />
-                      from all the Workspaces that use it.
-                      <br />
-                      This action cannot be undone. <br />
-                      Are you sure?
-                    </p>
-                  }
-                  okText="Yes"
-                  cancelText="No"
-                >
-                  {" "}
-                  <Button icon={<DeleteOutlined />} type="link" danger disabled={!managePermission}>
-                    Delete
-                  </Button>
-                </Popconfirm>,
-              ]}
-            >
-              <List.Item.Meta
-                avatar={<Avatar style={{ backgroundColor: token.colorPrimary }} icon={<TagOutlined />}></Avatar>}
-                title={item.attributes.name}
-              />
-            </List.Item>
-          )}
-        />
-      </Spin>
+                  <List.Item.Meta
+                    avatar={<Avatar style={{ backgroundColor: token.colorPrimary }} icon={<TagOutlined />}></Avatar>}
+                    title={item.attributes.name}
+                  />
+                </List.Item>
+              )}
+            />
+          </Spin>
 
-      <Modal
-        width="600px"
-        open={visible}
-        title={mode === "edit" ? "Edit tag " + tagName : "Create new tag"}
-        okText="Save tag"
-        onCancel={onCancel}
-        cancelText="Cancel"
-        onOk={() => {
-          form
-            .validateFields()
-            .then((values) => {
-              if (mode === "create") onCreate(values);
-              else onUpdate(values);
-            })
-            .catch((info) => {
-              console.log("Validate Failed:", info);
-            });
-        }}
-      >
-        <Space style={{ width: "100%" }} direction="vertical">
-          <Form name="tag" form={form} layout="vertical">
-            <Form.Item
-              name="name"
-              tooltip={{
-                title: "Must be a valid tag name",
-                icon: <InfoCircleOutlined />,
-              }}
-              label="Name"
-              rules={[{ required: true }]}
-            >
-              <Input />
-            </Form.Item>
-          </Form>
-        </Space>
-      </Modal>
-      </>
+          <Modal
+            width="600px"
+            open={visible}
+            title={mode === "edit" ? "Edit tag " + tagName : "Create new tag"}
+            okText="Save tag"
+            onCancel={onCancel}
+            cancelText="Cancel"
+            onOk={() => {
+              form
+                .validateFields()
+                .then((values) => {
+                  if (mode === "create") onCreate(values);
+                  else onUpdate(values);
+                })
+                .catch((info) => {
+                  console.log("Validate Failed:", info);
+                });
+            }}
+          >
+            <Space style={{ width: "100%" }} direction="vertical">
+              <Form name="tag" form={form} layout="vertical">
+                <Form.Item
+                  name="name"
+                  tooltip={{
+                    title: "Must be a valid tag name",
+                    icon: <InfoCircleOutlined />,
+                  }}
+                  label="Name"
+                  rules={[{ required: true }]}
+                >
+                  <Input />
+                </Form.Item>
+              </Form>
+            </Space>
+          </Modal>
+        </>
       )}
     </div>
   );

--- a/ui/src/domain/Settings/TeamPermissionsV2.tsx
+++ b/ui/src/domain/Settings/TeamPermissionsV2.tsx
@@ -1,17 +1,5 @@
 import React, { useEffect } from "react";
-import {
-  Form,
-  Radio,
-  Switch,
-  Table,
-  Tag,
-  Typography,
-  Tooltip,
-  Alert,
-  Space,
-  Divider,
-  Card,
-} from "antd";
+import { Form, Radio, Switch, Table, Tag, Typography, Tooltip, Alert, Space, Divider, Card } from "antd";
 import {
   InfoCircleOutlined,
   CrownOutlined,
@@ -89,42 +77,41 @@ const rolePermissionMatrix: Record<TeamRole, Record<string, boolean>> = {
   custom: {},
 };
 
-const roleDescriptions: Record<
-  TeamRole,
-  { label: string; color: string; icon: React.ReactNode; description: string }
-> = {
-  admin: {
-    label: "Admin",
-    color: "red",
-    icon: <CrownOutlined />,
-    description: "Full control over all resources including workspace settings, team permissions, and infrastructure changes.",
-  },
-  write: {
-    label: "Write",
-    color: "orange",
-    icon: <EditOutlined />,
-    description: "Can plan and apply runs, manage workspaces, and read/write state and variables.",
-  },
-  plan: {
-    label: "Plan",
-    color: "blue",
-    icon: <CodeOutlined />,
-    description:
-      "Can queue plans to propose infrastructure changes, but cannot apply them. Changes require approval from a Write or Admin user.",
-  },
-  read: {
-    label: "Read",
-    color: "default",
-    icon: <EyeOutlined />,
-    description: "Can view workspaces, runs, state, and variables. Cannot make any changes.",
-  },
-  custom: {
-    label: "Custom",
-    color: "purple",
-    icon: <SettingOutlined />,
-    description: "Fine-grained permission control. Select individual permissions below.",
-  },
-};
+const roleDescriptions: Record<TeamRole, { label: string; color: string; icon: React.ReactNode; description: string }> =
+  {
+    admin: {
+      label: "Admin",
+      color: "red",
+      icon: <CrownOutlined />,
+      description:
+        "Full control over all resources including workspace settings, team permissions, and infrastructure changes.",
+    },
+    write: {
+      label: "Write",
+      color: "orange",
+      icon: <EditOutlined />,
+      description: "Can plan and apply runs, manage workspaces, and read/write state and variables.",
+    },
+    plan: {
+      label: "Plan",
+      color: "blue",
+      icon: <CodeOutlined />,
+      description:
+        "Can queue plans to propose infrastructure changes, but cannot apply them. Changes require approval from a Write or Admin user.",
+    },
+    read: {
+      label: "Read",
+      color: "default",
+      icon: <EyeOutlined />,
+      description: "Can view workspaces, runs, state, and variables. Cannot make any changes.",
+    },
+    custom: {
+      label: "Custom",
+      color: "purple",
+      icon: <SettingOutlined />,
+      description: "Fine-grained permission control. Select individual permissions below.",
+    },
+  };
 
 const permissionCategories: PermissionCategory[] = [
   {
@@ -218,7 +205,7 @@ export const TeamPermissionsV2: React.FC<TeamPermissionsV2Props> = ({ managePerm
                   size="small"
                   style={{
                     cursor: managePermissions ? "pointer" : "not-allowed",
-                    borderColor: role === key ? desc.color === "default" ? "#d9d9d9" : desc.color : undefined,
+                    borderColor: role === key ? (desc.color === "default" ? "#d9d9d9" : desc.color) : undefined,
                     borderWidth: role === key ? 2 : 1,
                   }}
                   styles={{ body: { padding: "12px 16px" } }}
@@ -250,12 +237,8 @@ export const TeamPermissionsV2: React.FC<TeamPermissionsV2Props> = ({ managePerm
       <h2 style={{ marginBottom: 4 }}>
         Permissions
         {role !== "custom" && (
-          <Typography.Text
-            type="secondary"
-            style={{ fontSize: 14, marginLeft: 12, fontWeight: "normal" }}
-          >
-            Determined by the{" "}
-            <Tag color={roleDescriptions[role].color}>{roleDescriptions[role].label}</Tag> role
+          <Typography.Text type="secondary" style={{ fontSize: 14, marginLeft: 12, fontWeight: "normal" }}>
+            Determined by the <Tag color={roleDescriptions[role].color}>{roleDescriptions[role].label}</Tag> role
           </Typography.Text>
         )}
       </h2>

--- a/ui/src/domain/Settings/Teams.tsx
+++ b/ui/src/domain/Settings/Teams.tsx
@@ -93,9 +93,7 @@ export const TeamSettings = ({ key, managePermission = true }: Props) => {
     const desc = roleDescriptions[role] || "Custom permissions";
 
     if (role !== "custom") {
-      return (
-        <Typography.Text type="secondary">{desc}</Typography.Text>
-      );
+      return <Typography.Text type="secondary">{desc}</Typography.Text>;
     }
 
     // For custom role, show which permissions are enabled
@@ -114,11 +112,7 @@ export const TeamSettings = ({ key, managePermission = true }: Props) => {
       return <Typography.Text type="secondary">No permissions granted</Typography.Text>;
     }
 
-    return (
-      <Typography.Text type="secondary">
-        Can manage: {enabledPermissions.join(", ")}
-      </Typography.Text>
-    );
+    return <Typography.Text type="secondary">Can manage: {enabledPermissions.join(", ")}</Typography.Text>;
   };
 
   return (
@@ -132,8 +126,8 @@ export const TeamSettings = ({ key, managePermission = true }: Props) => {
           <h1>Team Management</h1>
           <div>
             <Typography.Text type="secondary">
-              Teams let you group users into specific categories to enable finer grained access control policies.
-              Each team is assigned a role that determines what actions its members can perform within the organization.
+              Teams let you group users into specific categories to enable finer grained access control policies. Each
+              team is assigned a role that determines what actions its members can perform within the organization.
             </Typography.Text>
           </div>
           <Button
@@ -184,15 +178,11 @@ export const TeamSettings = ({ key, managePermission = true }: Props) => {
                     ]}
                   >
                     <List.Item.Meta
-                      avatar={
-                        <Avatar style={{ backgroundColor: token.colorPrimary }} icon={<TeamOutlined />} />
-                      }
+                      avatar={<Avatar style={{ backgroundColor: token.colorPrimary }} icon={<TeamOutlined />} />}
                       title={
                         <Space>
                           {item.attributes.name}
-                          <Tag color={roleColors[role] || "default"}>
-                            {roleLabels[role] || role}
-                          </Tag>
+                          <Tag color={roleColors[role] || "default"}>{roleLabels[role] || role}</Tag>
                         </Space>
                       }
                       description={getTeamDescription(item)}

--- a/ui/src/domain/Settings/Templates.tsx
+++ b/ui/src/domain/Settings/Templates.tsx
@@ -67,7 +67,8 @@ export const TemplatesSettings = ({ key, managePermission = true }: Props) => {
     <div className="setting">
       {error ? (
         <Alert message="Access Denied" description={error} type="error" showIcon />
-      ) : (mode === "new" && <AddTemplate setMode={setMode} loadTemplates={loadTemplates} />) ||
+      ) : (
+        (mode === "new" && <AddTemplate setMode={setMode} loadTemplates={loadTemplates} />) ||
         (mode === "edit" && (
           <EditTemplate setMode={setMode} templateId={templateID} loadTemplates={loadTemplates} />
         )) || (
@@ -75,7 +76,14 @@ export const TemplatesSettings = ({ key, managePermission = true }: Props) => {
             {" "}
             <h1 style={{ paddingBottom: "10px" }}>
               Templates
-              <Button type="primary" onClick={onAddVCS} className="addVCS" htmlType="button" icon={<PlusOutlined />} disabled={!managePermission}>
+              <Button
+                type="primary"
+                onClick={onAddVCS}
+                className="addVCS"
+                htmlType="button"
+                icon={<PlusOutlined />}
+                disabled={!managePermission}
+              >
                 Add a Template
               </Button>{" "}
             </h1>
@@ -127,7 +135,8 @@ export const TemplatesSettings = ({ key, managePermission = true }: Props) => {
               />
             )}
           </div>
-        )}
+        )
+      )}
     </div>
   );
 };

--- a/ui/src/domain/Settings/VCS.tsx
+++ b/ui/src/domain/Settings/VCS.tsx
@@ -46,9 +46,9 @@ export const VCSSettings = ({ vcsMode, managePermission = true }: Props) => {
         );
       case "AZURE_SP_MI":
         return (
-                <IconContext.Provider value={{ size: "20px" }}>
-                    <VscAzureDevops />
-                </IconContext.Provider>
+          <IconContext.Provider value={{ size: "20px" }}>
+            <VscAzureDevops />
+          </IconContext.Provider>
         );
       default:
         return <GithubOutlined style={{ fontSize: "20px" }} />;
@@ -64,7 +64,7 @@ export const VCSSettings = ({ vcsMode, managePermission = true }: Props) => {
       case "AZURE_DEVOPS":
         return "Azure Devops";
       case "AZURE_SP_MI":
-          return "Azure Devops";
+        return "Azure Devops";
       default:
         return "GitHub";
     }
@@ -103,11 +103,14 @@ export const VCSSettings = ({ vcsMode, managePermission = true }: Props) => {
             "This VCS is currently in use by one or more workspaces. Please remove the VCS from all workspaces before deleting it."
           );
         } else {
-          axiosInstance.delete(`organization/${orgid}/vcs/${id}`).then(() => {
-            loadVCS();
-          }).catch((err) => {
-            message.error(getErrorMessage(err));
-          });
+          axiosInstance
+            .delete(`organization/${orgid}/vcs/${id}`)
+            .then(() => {
+              loadVCS();
+            })
+            .catch((err) => {
+              message.error(getErrorMessage(err));
+            });
         }
       })
       .catch((err) => {
@@ -150,7 +153,14 @@ export const VCSSettings = ({ vcsMode, managePermission = true }: Props) => {
           {" "}
           <h1 style={{ paddingBottom: "10px" }}>
             VCS Providers
-            <Button type="primary" onClick={onAddVCS} className="addVCS" htmlType="button" icon={<PlusOutlined />} disabled={!managePermission}>
+            <Button
+              type="primary"
+              onClick={onAddVCS}
+              className="addVCS"
+              htmlType="button"
+              icon={<PlusOutlined />}
+              disabled={!managePermission}
+            >
               Add a VCS Provider
             </Button>{" "}
           </h1>

--- a/ui/src/domain/Settings/VariableCollections.tsx
+++ b/ui/src/domain/Settings/VariableCollections.tsx
@@ -63,20 +63,34 @@ export const VariableCollectionsSettings = ({ managePermission = true }: Props) 
     try {
       setDeleteLoading(id);
 
-      // First get all variables and delete them
+      // First get all variables and delete them in parallel
       const variablesResponse = await axiosInstance.get(`organization/${orgid}/collection/${id}/item`);
       const variables = variablesResponse.data.data || [];
 
-      for (const variable of variables) {
-        await axiosInstance.delete(`organization/${orgid}/collection/${id}/item/${variable.id}`);
+      if (variables.length > 0) {
+        const variableDeletePromises = variables.map((variable: { id: string }) =>
+          axiosInstance.delete(`organization/${orgid}/collection/${id}/item/${variable.id}`)
+        );
+        const variableResults = await Promise.allSettled(variableDeletePromises);
+        const variableFailures = variableResults.filter((r) => r.status === "rejected");
+        if (variableFailures.length > 0) {
+          message.warning(`${variableFailures.length} variable(s) failed to delete`);
+        }
       }
 
-      // Then get all references and delete them
+      // Then get all references and delete them in parallel
       const referencesResponse = await axiosInstance.get(`organization/${orgid}/collection/${id}/reference`);
       const references = referencesResponse.data.data || [];
 
-      for (const reference of references) {
-        await axiosInstance.delete(`organization/${orgid}/collection/${id}/reference/${reference.id}`);
+      if (references.length > 0) {
+        const referenceDeletePromises = references.map((reference: { id: string }) =>
+          axiosInstance.delete(`organization/${orgid}/collection/${id}/reference/${reference.id}`)
+        );
+        const referenceResults = await Promise.allSettled(referenceDeletePromises);
+        const referenceFailures = referenceResults.filter((r) => r.status === "rejected");
+        if (referenceFailures.length > 0) {
+          message.warning(`${referenceFailures.length} reference(s) failed to delete`);
+        }
       }
 
       // Finally delete the collection
@@ -94,14 +108,18 @@ export const VariableCollectionsSettings = ({ managePermission = true }: Props) 
   };
 
   const loadCollections = () => {
-    axiosInstance.get(`organization/${orgid}/collection`).then((response) => {
-      setCollections(response.data.data);
-      setError(null);
-    }).catch((err) => {
-      setError(getErrorMessage(err));
-    }).finally(() => {
-      setLoading(false);
-    });
+    axiosInstance
+      .get(`organization/${orgid}/collection`)
+      .then((response) => {
+        setCollections(response.data.data);
+        setError(null);
+      })
+      .catch((err) => {
+        setError(getErrorMessage(err));
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   };
 
   const getWorkspacesAndVariablesCounts = async (collections: Collection[]) => {
@@ -116,9 +134,9 @@ export const VariableCollectionsSettings = ({ managePermission = true }: Props) 
         collection.relationships = {
           ...collection.relationships,
           workspaces: {
-              data: (workspacesResponse.data.data || []).filter(
-                  (item: any) => item.relationships?.workspace?.data?.id != null
-              ),
+            data: (workspacesResponse.data.data || []).filter(
+              (item: any) => item.relationships?.workspace?.data?.id != null
+            ),
           },
         };
 
@@ -190,86 +208,86 @@ export const VariableCollectionsSettings = ({ managePermission = true }: Props) 
           style={{ marginTop: "20px" }}
         />
       ) : (
-      <Spin spinning={loading}>
-        <List
-          grid={{ gutter: 16, column: 1 }}
-          dataSource={paginatedCollections}
-          renderItem={(item) => (
-            <List.Item>
-              <Card hoverable style={{ width: "100%", cursor: "pointer" }} onClick={() => handleViewDetails(item.id)}>
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
-                  <div>
-                    <Typography.Title level={4} style={{ margin: 0 }}>
-                      {item.attributes.name}
-                    </Typography.Title>
-                    <Typography.Paragraph style={{ marginTop: "8px" }}>
-                      {item.attributes.description}
-                    </Typography.Paragraph>
-                    <Space style={{ marginTop: "16px" }}>
-                      <span style={{ display: "inline-flex", alignItems: "center" }}>
-                        <AppstoreOutlined style={{ marginRight: "5px" }} />
-                        {item.relationships?.workspaces?.data?.length || 0} workspaces
-                      </span>
-                      <span style={{ display: "inline-flex", alignItems: "center", marginLeft: "20px" }}>
-                        <UnorderedListOutlined style={{ marginRight: "5px" }} />
-                        {item.relationships?.variables?.data?.length || 0} variables
-                      </span>
-                    </Space>
-                  </div>
-                  <Space>
-                    <Button
-                      type="text"
-                      icon={<EditOutlined />}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleEditCollection(item.id);
-                      }}
-                      disabled={!managePermission}
-                    >
-                      Edit
-                    </Button>
-                    <Popconfirm
-                      title="Delete this variable collection?"
-                      description="This will permanently delete this variable collection and all its variables. Are you sure?"
-                      onConfirm={(e) => {
-                        e?.stopPropagation();
-                        onDelete(item.id);
-                      }}
-                      onCancel={(e) => e?.stopPropagation()}
-                      okText="Yes"
-                      cancelText="No"
-                    >
+        <Spin spinning={loading}>
+          <List
+            grid={{ gutter: 16, column: 1 }}
+            dataSource={paginatedCollections}
+            renderItem={(item) => (
+              <List.Item>
+                <Card hoverable style={{ width: "100%", cursor: "pointer" }} onClick={() => handleViewDetails(item.id)}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+                    <div>
+                      <Typography.Title level={4} style={{ margin: 0 }}>
+                        {item.attributes.name}
+                      </Typography.Title>
+                      <Typography.Paragraph style={{ marginTop: "8px" }}>
+                        {item.attributes.description}
+                      </Typography.Paragraph>
+                      <Space style={{ marginTop: "16px" }}>
+                        <span style={{ display: "inline-flex", alignItems: "center" }}>
+                          <AppstoreOutlined style={{ marginRight: "5px" }} />
+                          {item.relationships?.workspaces?.data?.length || 0} workspaces
+                        </span>
+                        <span style={{ display: "inline-flex", alignItems: "center", marginLeft: "20px" }}>
+                          <UnorderedListOutlined style={{ marginRight: "5px" }} />
+                          {item.relationships?.variables?.data?.length || 0} variables
+                        </span>
+                      </Space>
+                    </div>
+                    <Space>
                       <Button
-                        danger
                         type="text"
-                        icon={<DeleteOutlined />}
-                        onClick={(e) => e.stopPropagation()}
-                        loading={deleteLoading === item.id}
+                        icon={<EditOutlined />}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleEditCollection(item.id);
+                        }}
                         disabled={!managePermission}
                       >
-                        Delete
+                        Edit
                       </Button>
-                    </Popconfirm>
-                  </Space>
-                </div>
-              </Card>
-            </List.Item>
-          )}
-        />
+                      <Popconfirm
+                        title="Delete this variable collection?"
+                        description="This will permanently delete this variable collection and all its variables. Are you sure?"
+                        onConfirm={(e) => {
+                          e?.stopPropagation();
+                          onDelete(item.id);
+                        }}
+                        onCancel={(e) => e?.stopPropagation()}
+                        okText="Yes"
+                        cancelText="No"
+                      >
+                        <Button
+                          danger
+                          type="text"
+                          icon={<DeleteOutlined />}
+                          onClick={(e) => e.stopPropagation()}
+                          loading={deleteLoading === item.id}
+                          disabled={!managePermission}
+                        >
+                          Delete
+                        </Button>
+                      </Popconfirm>
+                    </Space>
+                  </div>
+                </Card>
+              </List.Item>
+            )}
+          />
 
-        <div style={{ display: "flex", justifyContent: "center", marginTop: "20px" }}>
-          {filteredCollections.length > 0 && (
-            <Pagination
-              current={currentPage}
-              pageSize={pageSize}
-              total={filteredCollections.length}
-              onChange={setCurrentPage}
-              showSizeChanger={false}
-              simple={false}
-            />
-          )}
-        </div>
-      </Spin>
+          <div style={{ display: "flex", justifyContent: "center", marginTop: "20px" }}>
+            {filteredCollections.length > 0 && (
+              <Pagination
+                current={currentPage}
+                pageSize={pageSize}
+                total={filteredCollections.length}
+                onChange={setCurrentPage}
+                showSizeChanger={false}
+                simple={false}
+              />
+            )}
+          </div>
+        </Spin>
       )}
     </div>
   );

--- a/ui/src/domain/Workspaces/Create.tsx
+++ b/ui/src/domain/Workspaces/Create.tsx
@@ -145,11 +145,47 @@ export const CreateWorkspace = () => {
   useEffect(() => {
     setOrganizationName(sessionStorage.getItem(ORGANIZATION_NAME));
     setLoading(true);
-    loadVersions(iacType);
-    loadSSHKeys();
-    loadOrgTemplates();
-    loadVCS();
     getIacTypes();
+
+    const versionsApi = `${new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin}/${iacType.id}/index.json`;
+
+    // Parallel load: versions, SSH keys, templates, and VCS
+    Promise.all([
+      axiosInstance.get(versionsApi),
+      axiosInstance.get(`organization/${organizationId}/ssh`),
+      axiosInstance.get(`organization/${organizationId}/template`),
+      axiosInstance.get(`organization/${organizationId}/vcs`),
+    ]).then(([versionsRes, sshRes, templatesRes, vcsRes]) => {
+      // Process versions
+      const tfVersions: string[] = [];
+      if (iacType.id === "tofu") {
+        (versionsRes.data as TofuRelease[]).forEach((release) => {
+          if (!release.tag_name.includes("-")) tfVersions.push(release.tag_name.replace("v", ""));
+        });
+      } else {
+        for (const version in versionsRes.data.versions) {
+          if (!version.includes("-")) tfVersions.push(version);
+        }
+      }
+      tfVersions.sort(compareVersions).reverse();
+      setTerraformVersions(tfVersions);
+      if (tfVersions.length > 0) {
+        form.setFieldsValue({ terraformVersion: tfVersions[0] });
+      }
+
+      // Set SSH keys
+      setSSHKeys(sshRes.data.data);
+
+      // Set templates
+      setOrgTemplates(templatesRes.data.data);
+      if (templatesRes.data.data.length > 0) {
+        form.setFieldsValue({ defaultTemplate: templatesRes.data.data[0].id });
+      }
+
+      // Set VCS
+      setVCS(vcsRes.data.data);
+      setLoading(false);
+    });
   }, []);
   const handleClick = () => {
     setCurrent(2);
@@ -205,38 +241,16 @@ export const CreateWorkspace = () => {
             &nbsp;
           </IconContext.Provider>
         );
-        case "AZURE_SP_MI":
-            return (
-                <IconContext.Provider value={{ size: "20px" }}>
-                    <VscAzureDevops />
-                    &nbsp;
-                </IconContext.Provider>
-            );
+      case "AZURE_SP_MI":
+        return (
+          <IconContext.Provider value={{ size: "20px" }}>
+            <VscAzureDevops />
+            &nbsp;
+          </IconContext.Provider>
+        );
       default:
         return <GithubOutlined style={{ fontSize: "20px" }} />;
     }
-  };
-
-  const loadVCS = () => {
-    axiosInstance.get(`organization/${organizationId}/vcs`).then((response) => {
-      setVCS(response.data.data);
-      setLoading(false);
-    });
-  };
-
-  const loadSSHKeys = () => {
-    axiosInstance.get(`organization/${organizationId}/ssh`).then((response) => {
-      setSSHKeys(response.data.data);
-    });
-  };
-
-  const loadOrgTemplates = () => {
-    axiosInstance.get(`organization/${organizationId}/template`).then((response) => {
-      setOrgTemplates(response.data.data);
-      if(response.data.data.length > 0) {
-        form.setFieldsValue({defaultTemplate: response.data.data[0].id});
-      }
-    });
   };
 
   const [form] = Form.useForm();
@@ -285,7 +299,7 @@ export const CreateWorkspace = () => {
       tfVersions.sort(compareVersions).reverse();
       setTerraformVersions(tfVersions);
       if (tfVersions.length > 0) {
-        form.setFieldsValue({terraformVersion: tfVersions[0]})
+        form.setFieldsValue({ terraformVersion: tfVersions[0] });
       }
     });
   };

--- a/ui/src/domain/Workspaces/Details.tsx
+++ b/ui/src/domain/Workspaces/Details.tsx
@@ -35,9 +35,10 @@ import {
   Input,
   theme,
 } from "antd";
-import { AxiosInstance } from "axios";
+
 import { DateTime } from "luxon";
-import { useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
+import { usePolling } from "../../hooks";
 import { IconContext } from "react-icons";
 import { BiTerminal } from "react-icons/bi";
 import { FiGitCommit } from "react-icons/fi";
@@ -47,7 +48,6 @@ import ActionLoader from "../../ActionLoader.js";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME, WORKSPACE_ARCHIVE } from "../../config/actionTypes";
 import axiosInstance, { getErrorMessage } from "../../config/axiosConfig";
 import { CreateJob } from "../Jobs/Create";
-import { DetailsJob } from "../Jobs/Details";
 import {
   Action,
   ActionWithSettings,
@@ -58,36 +58,29 @@ import {
   IncludedItem,
   Organization,
   Resource,
-  Schedule,
-  StateOutputValue,
-  Template,
   VcsType,
   Workspace,
 } from "../types.js";
 import { CLIDriven } from "../Workspaces/CLIDriven";
 import { ResourceDrawer } from "../Workspaces/ResourceDrawer";
 import { Schedules } from "../Workspaces/Schedules";
-import { States } from "../Workspaces/States";
 import { Tags } from "../Workspaces/Tags";
 import { Variables } from "../Workspaces/Variables";
 import { getServiceIcon } from "./Icons.jsx";
-import { WorkspaceSettings } from "./Settings/WorkspaceSettings";
 import { getIaCIconById, getIaCNameById, renderVCSLogo } from "./Workspaces";
 import "./Workspaces.css";
+import LoadingFallback from "@/components/LoadingFallback";
 import RunList from "@/modules/workspaces/components/RunList";
+
+import { setupWorkspaceIncludes, isValidUrl, fixSshURL, StateOutputVariableWithName } from "./workspaceDataUtils";
+const DetailsJob = lazy(() => import("../Jobs/Details").then((m) => ({ default: m.DetailsJob })));
+const States = lazy(() => import("../Workspaces/States").then((m) => ({ default: m.States })));
+const WorkspaceSettings = lazy(() =>
+  import("./Settings/WorkspaceSettings").then((m) => ({ default: m.WorkspaceSettings }))
+);
+
 const { Paragraph } = Typography;
 
-const include = {
-  VARIABLE: "variable",
-  JOB: "job",
-  HISTORY: "history",
-  SCHEDULE: "schedule",
-  VCS: "vcs",
-  AGENT: "agent",
-  WEBHOOK: "webhook",
-  REFERENCE: "reference",
-  ORGANIZATION: "organization",
-};
 const { Content } = Layout;
 const { TabPane } = Tabs;
 
@@ -101,8 +94,6 @@ type Params = {
   runid: string;
   orgid: string;
 };
-
-type StateOutputVariableWithName = { name: string } & StateOutputValue;
 
 export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) => {
   const navigate = useNavigate();
@@ -238,11 +229,14 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
   };
 
   const loadOrgTemplates = () => {
-    axiosInstance.get(`organization/${organizationId}/template`).then((response) => {
-      setOrgTemplates(response.data.data);
-    }).catch((err) => {
-      console.error("Failed to load org templates:", err);
-    });
+    axiosInstance
+      .get(`organization/${organizationId}/template`)
+      .then((response) => {
+        setOrgTemplates(response.data.data);
+      })
+      .catch((err) => {
+        console.error("Failed to load org templates:", err);
+      });
   };
 
   const showDrawer = (record: Resource) => {
@@ -299,8 +293,8 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
 
   const fetchActions = async () => {
     try {
-      const response = await axiosInstance.get('action', {
-        params: { 'filter[action]': "active==true;type=in=('Workspace/Action')" },
+      const response = await axiosInstance.get("action", {
+        params: { "filter[action]": "active==true;type=in=('Workspace/Action')" },
       });
 
       const fetchedActions = response.data.data || [];
@@ -316,12 +310,17 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
     loadWorkspace(true, true, true);
     loadPermissionSet();
     loadOrgTemplates();
-    const interval = setInterval(() => {
+    // Polling is now handled by usePolling hook below
+  }, [id]);
+
+  // Polling for workspace updates
+  usePolling(
+    () => {
       loadWorkspace(false, false, false);
       loadPermissionSet();
-    }, 10000);
-    return () => clearInterval(interval);
-  }, [id]);
+    },
+    { interval: 10000, enabled: Boolean(id), immediate: false }
+  );
 
   const changeJob = (id: string) => {
     setJobId(id);
@@ -333,95 +332,104 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
     const url = `${
       new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin
     }/access-token/v1/teams/permissions/organization/${organizationId}`;
-    axiosInstance.get(url).then((response) => {
-      setManageState(response.data.manageState);
-      setManageWorkspace(response.data.manageWorkspace);
-      setPlanJob(response.data.planJob);
-      setApproveJob(response.data.approveJob);
+    axiosInstance
+      .get(url)
+      .then((response) => {
+        setManageState(response.data.manageState);
+        setManageWorkspace(response.data.manageWorkspace);
+        setPlanJob(response.data.planJob);
+        setApproveJob(response.data.approveJob);
 
-      if (id !== undefined && id !== null) {
-        const urlWorkspaceAccess = `${
-          new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin
-        }/access-token/v1/teams/permissions/organization/${organizationId}/workspace/${id}`;
-        axiosInstance.get(urlWorkspaceAccess).then((response) => {
-          setManageState(response.data.manageState);
-          setManageWorkspace(response.data.manageWorkspace);
-          setPlanJob(response.data.planJob);
-          setApproveJob(response.data.approveJob);
-        }).catch((err) => {
-          console.error("Failed to load workspace permissions:", err);
-        });
-      }
-    }).catch((err) => {
-      console.error("Failed to load org permissions:", err);
-    });
+        if (id !== undefined && id !== null) {
+          const urlWorkspaceAccess = `${
+            new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin
+          }/access-token/v1/teams/permissions/organization/${organizationId}/workspace/${id}`;
+          axiosInstance
+            .get(urlWorkspaceAccess)
+            .then((response) => {
+              setManageState(response.data.manageState);
+              setManageWorkspace(response.data.manageWorkspace);
+              setPlanJob(response.data.planJob);
+              setApproveJob(response.data.approveJob);
+            })
+            .catch((err) => {
+              console.error("Failed to load workspace permissions:", err);
+            });
+        }
+      })
+      .catch((err) => {
+        console.error("Failed to load org permissions:", err);
+      });
   };
 
   const loadWorkspace = (_loadVersions: boolean, _loadWebhook = false, _loadPermissionSet = false) => {
     let url = `organization/${organizationId}/workspace/${id}?include=job,variable,history,schedule,vcs,agent,organization,reference`;
     if (_loadWebhook) url += ",webhook";
-    axiosInstance.get(`organization/${organizationId}/template`).then((template) => {
-      setTemplates(template.data.data);
-      axiosInstance
-        .get(
-          `organization/${organizationId}/workspace/${id}?include=job,variable,history,schedule,vcs,agent,organization,webhook,reference`
-        )
-        .then(async (response) => {
-          if (_loadPermissionSet) loadPermissionSet();
+    axiosInstance
+      .get(`organization/${organizationId}/template`)
+      .then((template) => {
+        setTemplates(template.data.data);
+        axiosInstance
+          .get(
+            `organization/${organizationId}/workspace/${id}?include=job,variable,history,schedule,vcs,agent,organization,webhook,reference`
+          )
+          .then(async (response) => {
+            if (_loadPermissionSet) loadPermissionSet();
 
-          setWorkspace(response.data.data);
+            setWorkspace(response.data.data);
 
-          if (response.data.included) {
-            await setupWorkspaceIncludes(
-              response.data,
-              setVariables,
-              setJobs,
-              setEnvVariables,
-              setHistory,
-              setSchedule,
-              template.data.data,
-              setLastRun,
-              setVCSProvider,
-              setCurrentStateId,
-              currentStateId,
-              axiosInstance,
-              setResources,
-              setOutputs,
-              setAgent,
-              _loadWebhook,
-              setContextState,
-              setCollectionVariables,
-              setCollectionEnvVariables,
-              setGlobalVariables,
-              setGlobalEnvVariables
+            if (response.data.included) {
+              await setupWorkspaceIncludes(
+                response.data,
+                setVariables,
+                setJobs,
+                setEnvVariables,
+                setHistory,
+                setSchedule,
+                template.data.data,
+                setLastRun,
+                setVCSProvider,
+                setCurrentStateId,
+                currentStateId,
+                axiosInstance,
+                setResources,
+                setOutputs,
+                setAgent,
+                _loadWebhook,
+                setContextState,
+                setCollectionVariables,
+                setCollectionEnvVariables,
+                setGlobalVariables,
+                setGlobalEnvVariables
+              );
+            }
+
+            const organization: Organization | undefined = response.data.included?.find(
+              (item: IncludedItem<Organization>) => item.type === "organization"
             );
-          }
-
-          const organization: Organization | undefined = response.data.included?.find(
-            (item: IncludedItem<Organization>) => item.type === "organization"
-          );
-          if (organization) {
-            const organizationName = organization.attributes.name;
-            setOrganizationName(organizationName);
-            sessionStorage.setItem(ORGANIZATION_NAME, organizationName);
-          }
-          setOrganizationNameLocal(sessionStorage.getItem(ORGANIZATION_NAME)!);
-          setWorkspaceName(response.data.data.attributes.name);
-          setExecutionMode(response.data.data.attributes.executionMode);
-          if (runid && _loadVersions) changeJob(runid); // if runid is provided, show the job details
-          fetchActions();
-          setLoadError(null);
-        })
-        .catch((err) => {
-          setLoadError(getErrorMessage(err));
-        })
-        .finally(() => {
-          setLoading(false);
-        });
-    }).catch((err) => {
-      setLoadError(getErrorMessage(err));
-      setLoading(false);
-    });
+            if (organization) {
+              const organizationName = organization.attributes.name;
+              setOrganizationName(organizationName);
+              sessionStorage.setItem(ORGANIZATION_NAME, organizationName);
+            }
+            setOrganizationNameLocal(sessionStorage.getItem(ORGANIZATION_NAME)!);
+            setWorkspaceName(response.data.data.attributes.name);
+            setExecutionMode(response.data.data.attributes.executionMode);
+            if (runid && _loadVersions) changeJob(runid); // if runid is provided, show the job details
+            fetchActions();
+            setLoadError(null);
+          })
+          .catch((err) => {
+            setLoadError(getErrorMessage(err));
+          })
+          .finally(() => {
+            setLoading(false);
+          });
+      })
+      .catch((err) => {
+        setLoadError(getErrorMessage(err));
+        setLoading(false);
+      });
   };
 
   const handleClickSettings = () => {
@@ -446,13 +454,13 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
       })
       .then((response) => {
         loadWorkspace(true);
-        var newstatus = locked ? "unlocked" : "locked";
+        const newstatus = locked ? "unlocked" : "locked";
         message.success("Workspace " + newstatus + " successfully");
       })
       .catch((error) => {
-        var newstatus = locked ? "unlock" : "lock";
+        const newstatus = locked ? "unlock" : "lock";
         message.error("Workspace " + newstatus + " failed: " + error.response.data.errors[0].detail);
-      })
+      });
   };
 
   return (
@@ -736,7 +744,8 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
                       <Space direction="vertical">
                         <br />
                         <span>
-                          {workspace.attributes.branch !== "remote-content" && isValidUrl(fixSshURL(workspace.attributes.source)) ? (
+                          {workspace.attributes.branch !== "remote-content" &&
+                          isValidUrl(fixSshURL(workspace.attributes.source)) ? (
                             <>
                               {" "}
                               {renderVCSLogo(vcsProvider)}{" "}
@@ -756,8 +765,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
                           )}
                         </span>
                         <span>
-                          <ThunderboltOutlined /> Execution Mode:{" "}
-                          {executionMode}{" "}
+                          <ThunderboltOutlined /> Execution Mode: {executionMode}{" "}
                         </span>
                         <Divider />
                         <h4>Tags</h4>
@@ -768,17 +776,25 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
                 </TabPane>
 
                 <TabPane tab="Runs" key="2">
-                  {jobVisible ? <DetailsJob jobId={jobId!} /> : <RunList jobs={jobs} onRunClick={handleClick} />}
+                  {jobVisible ? (
+                    <Suspense fallback={<LoadingFallback />}>
+                      <DetailsJob jobId={jobId!} />
+                    </Suspense>
+                  ) : (
+                    <RunList jobs={jobs} onRunClick={handleClick} />
+                  )}
                 </TabPane>
                 <TabPane tab="States" key="3" disabled={!manageState}>
-                  <States
-                    history={history}
-                    setStateDetailsVisible={setStateDetailsVisible}
-                    stateDetailsVisible={stateDetailsVisible}
-                    workspace={workspace}
-                    onRollback={loadWorkspace}
-                    manageState={manageState}
-                  />
+                  <Suspense fallback={<LoadingFallback />}>
+                    <States
+                      history={history}
+                      setStateDetailsVisible={setStateDetailsVisible}
+                      stateDetailsVisible={stateDetailsVisible}
+                      workspace={workspace}
+                      onRollback={loadWorkspace}
+                      manageState={manageState}
+                    />
+                  </Suspense>
                 </TabPane>
                 <TabPane tab="Variables" key="4">
                   <Variables
@@ -795,13 +811,15 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
                   {templates ? <Schedules schedules={schedule} manageWorkspace={manageWorkspace} /> : <p>Loading...</p>}
                 </TabPane>
                 <TabPane tab="Settings" key="6">
-                  <WorkspaceSettings
-                    workspace={workspace}
-                    vcsProvider={vcsProvider}
-                    orgTemplates={orgTemplates}
-                    manageWorkspace={manageWorkspace}
-                    onWorkspaceUpdate={() => loadWorkspace(false)}
-                  />
+                  <Suspense fallback={<LoadingFallback />}>
+                    <WorkspaceSettings
+                      workspace={workspace}
+                      vcsProvider={vcsProvider}
+                      orgTemplates={orgTemplates}
+                      manageWorkspace={manageWorkspace}
+                      onWorkspaceUpdate={() => loadWorkspace(false)}
+                    />
+                  </Suspense>
                 </TabPane>
               </Tabs>
             </div>
@@ -811,464 +829,3 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
     </Content>
   );
 };
-
-async function setupWorkspaceIncludes(
-  data: any,
-  setVariables: (val: any[]) => void,
-  setJobs: (val: any[]) => void,
-  setEnvVariables: (val: any[]) => void,
-  setHistory: (val: FlatJobHistory[]) => void,
-  setSchedule: (val: any[]) => void,
-  templates: Template[],
-  setLastRun: (val: string) => void,
-  setVCSProvider: (val: VcsType) => void,
-  setCurrentStateId: (val: string) => void,
-  currentStateId: string,
-  axiosInstance: any,
-  setResources: (val: any[]) => void,
-  setOutputs: (val: any[]) => void,
-  setAgent: (val: any) => void,
-  _loadWebhook: boolean,
-  setContextState: (val: any) => void,
-  setCollectionVariables: (val: any[]) => void,
-  setCollectionEnvVariables: (val: any[]) => void,
-  setGlobalVariables: (val: FlatVariable[]) => void,
-  setGlobalEnvVariables: (val: FlatVariable[]) => void
-): Promise<void> {
-  const variables: FlatVariable[] = [];
-  const jobs: FlatJob[] = [];
-  const webhooks: any = {};
-  const envVariables: FlatVariable[] = [];
-  const history: FlatJobHistory[] = [];
-  const schedule: Schedule[] = [];
-  const collectionVariables: any[] = [];
-  const collectionEnvVariables: any[] = [];
-  const globalVariables: FlatVariable[] = [];
-  const globalEnvVariables: FlatVariable[] = [];
-  const includes = data.included;
-  const asyncPromises: Promise<void>[] = [];
-
-  includes.forEach((element: any) => {
-    switch (element.type) {
-      case include.ORGANIZATION:
-        asyncPromises.push(
-          axiosInstance.get(`/organization/${element.id}/globalvar`).then((response: any) => {
-            const globalVar = response.data.data;
-            if (globalVar != null) {
-              globalVar.forEach((variableItem: any) => {
-                if (variableItem.attributes.category === "ENV") {
-                  globalEnvVariables.push({
-                    id: variableItem.id,
-                    type: variableItem.type,
-                    ...variableItem.attributes,
-                  });
-                } else {
-                  globalVariables.push({
-                    id: variableItem.id,
-                    type: variableItem.type,
-                    ...variableItem.attributes,
-                  });
-                }
-              });
-            }
-          })
-        );
-        break;
-      case include.JOB:
-        let finalColor = "";
-        switch (element.attributes.status) {
-          case "completed":
-            finalColor = "#2eb039";
-            break;
-          case "noChanges":
-            finalColor = "#9f37fa";
-            break;
-          case "rejected":
-            finalColor = "#FB0136";
-            break;
-          case "failed":
-            finalColor = "#FB0136";
-            break;
-          case "running":
-            finalColor = "#108ee9";
-            break;
-          case "waitingApproval":
-            finalColor = "#fa8f37";
-            break;
-          default:
-            finalColor = "";
-            break;
-        }
-        jobs.push({
-          id: element.id,
-          title: "Queue manually using " + getIaCNameById(data?.data?.attributes?.iacType),
-          statusColor: finalColor,
-          commitId: element.attributes.commitId,
-          stepNumber: element.attributes.stepNumber,
-          latestChange: DateTime.fromISO(element.attributes.createdDate).toRelative(),
-          ...element.attributes,
-        });
-        setLastRun(element.attributes.updatedDate);
-        break;
-      case include.HISTORY:
-        console.log(element);
-        history.push({
-          id: element.id,
-          title: "Queue manually using " + getIaCNameById(data?.data?.attributes?.iacType),
-          relativeDate: DateTime.fromISO(element.attributes.createdDate).toRelative(),
-          createdDate: element.attributes.createdDate,
-          ...element.attributes,
-        });
-        break;
-
-      case include.SCHEDULE:
-        schedule.push({
-          id: element.id,
-          name: templates?.find((template: Template) => template.id === element.attributes.templateReference)
-            ?.attributes?.name,
-          ...element.attributes,
-        });
-        break;
-      case include.VCS:
-        setVCSProvider(element.attributes.vcsType);
-        break;
-      case include.AGENT:
-        setAgent(element.id);
-        break;
-      case include.VARIABLE:
-        if (element.attributes.category == "ENV") {
-          envVariables.push({
-            id: element.id,
-            type: element.type,
-            ...element.attributes,
-          });
-        } else {
-          variables.push({
-            id: element.id,
-            type: element.type,
-            ...element.attributes,
-          });
-        }
-        break;
-      case include.WEBHOOK:
-        webhooks[element.attributes.event] = {
-          id: element.id,
-          type: element.type,
-          ...element.attributes,
-        };
-        break;
-      case include.REFERENCE:
-        asyncPromises.push(
-          axiosInstance.get(`/reference/${element.id}/collection?include=item`).then((response: any) => {
-            const collectionInfo = response.data.data;
-            if (response.data.included != null) {
-              const items = response.data.included;
-              items.forEach((item: any) => {
-                item.attributes.priority = collectionInfo.attributes.priority;
-                item.attributes.collectionName = collectionInfo.attributes.name;
-                if (item.attributes.category === "ENV") {
-                  collectionEnvVariables.push({
-                    id: item.id,
-                    type: item.type,
-                    ...item.attributes,
-                  });
-                } else {
-                  collectionVariables.push({
-                    id: item.id,
-                    type: item.type,
-                    ...item.attributes,
-                  });
-                }
-              });
-            }
-          })
-        );
-        break;
-    }
-  });
-
-  await Promise.all(asyncPromises).catch((err) => {
-    console.error("Error loading workspace includes:", err);
-  });
-
-  const byKey = (a: { key?: string }, b: { key?: string }) =>
-    (a.key ?? "").localeCompare(b.key ?? "", undefined, { sensitivity: "base" });
-
-  setVariables([...variables].sort(byKey));
-  setEnvVariables([...envVariables].sort(byKey));
-  setJobs(jobs);
-  setHistory(history);
-  setSchedule(schedule);
-  setCollectionVariables([...collectionVariables].sort(byKey));
-  setCollectionEnvVariables([...collectionEnvVariables].sort(byKey));
-  setGlobalVariables([...globalVariables].sort(byKey));
-  setGlobalEnvVariables([...globalEnvVariables].sort(byKey));
-
-  // set state data
-  const lastState = history
-    .sort((a: FlatJobHistory, b: FlatJobHistory) => parseInt(a.jobReference) - parseInt(b.jobReference))
-    .reverse()[0];
-  // reload state only if there is a new version
-
-  if (currentStateId !== lastState?.id) {
-    const organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
-    const workspaceId = sessionStorage.getItem(WORKSPACE_ARCHIVE);
-    const url = `${
-      new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin
-    }/access-token/v1/teams/permissions/organization/${organizationId}/workspace/${workspaceId}`;
-    axiosInstance.get(url).then((response: any) => {
-      loadState(
-        lastState,
-        axiosInstance,
-        setOutputs,
-        setResources,
-        sessionStorage.getItem(WORKSPACE_ARCHIVE)!,
-        setContextState,
-        response.data.manageState
-      );
-    }).catch((err: any) => {
-      console.error("Failed to load workspace permissions for state:", err);
-    });
-  }
-  setCurrentStateId(lastState?.id);
-}
-
-function loadState(
-  state: any,
-  axiosInstance: AxiosInstance,
-  setOutputs: (val: any) => void,
-  setResources: (val: any) => void,
-  workspaceId: string,
-  setContextState: (val: any) => void,
-  manageState: boolean
-) {
-  if (!state || !manageState) {
-    return;
-  }
-
-  let currentState;
-  const organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
-
-  axiosInstance.get(state.output).then((resp) => {
-    let result = parseState(resp.data);
-    setContextState(resp.data);
-    if (result.outputs.length < 1 && result.resources.length < 1) {
-      axiosInstance
-        .get(
-          `${
-            new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin
-          }/tfstate/v1/organization/${organizationId}/workspace/${workspaceId}/state/terraform.tfstate`
-        )
-        .then((currentStateData) => {
-          currentState = currentStateData.data;
-          setContextState(currentState);
-          result = parseOldState(currentState);
-
-          setResources(result.resources);
-          setOutputs(result.outputs);
-        })
-        .catch(function (error: Error) {
-          console.error(error);
-        });
-    } else {
-      setResources(result.resources);
-      setOutputs(result.outputs);
-    }
-  }).catch((err) => {
-    console.error("Failed to load state data:", err);
-  });
-}
-
-function parseState(state: any) {
-  let resources: any[] = [];
-  const outputs: StateOutputVariableWithName[] = [];
-
-  // parse root outputs
-  if (state?.values?.outputs != null) {
-    for (const [key, value] of Object.entries(state?.values?.outputs) as [any, any][]) {
-      if (typeof value.type === "string") {
-          if (value.sensitive) {
-              outputs.push({
-                  name: key,
-                  type: value.type,
-                  value: "*****",
-              });
-          } else {
-              outputs.push({
-                  name: key,
-                  type: value.type,
-                  value: value.value,
-              });
-          }
-      } else {
-        const jsonObject = JSON.stringify(value.value);
-        if (value.sensitive) {
-            outputs.push({
-                name: key,
-                type: "Other type",
-                value: "*****",
-            });
-        } else {
-            outputs.push({
-                name: key,
-                type: "Other type",
-                value: jsonObject,
-            });
-        }
-
-      }
-    }
-  } else {
-    console.log("State has no outputs");
-  }
-
-  // parse root module resources
-  if (state?.values?.root_module?.resources != null) {
-    for (const [_, value] of Object.entries(state?.values?.root_module?.resources) as [any, any][]) {
-      resources.push({
-        name: value.name,
-        type: value.type,
-        provider: value.provider_name,
-        module: "root_module",
-        values: value.values,
-        depends_on: value.depends_on,
-      });
-    }
-  } else {
-    console.log("State has no resources");
-  }
-
-  // parse child module resources
-  if (state?.values?.root_module?.child_modules?.length > 0) {
-    state?.values?.root_module?.child_modules?.forEach((moduleVal: any, index: any) => {
-      if (moduleVal.resources != null)
-        for (const [_, value] of Object.entries(moduleVal.resources) as [any, any][]) {
-          resources.push({
-            name: value.name,
-            type: value.type,
-            provider: value.provider_name,
-            module: moduleVal.address,
-            values: value.values,
-            depends_on: value.depends_on,
-          });
-        }
-
-      if (moduleVal.child_modules?.length > 0) {
-        resources = parseChildModules(resources, moduleVal.child_modules);
-      }
-    });
-  } else {
-    console.log("State has no child modules resources");
-  }
-
-  return { resources: resources, outputs: outputs };
-}
-
-function parseOldState(state: any) {
-  const resources: any[] = [];
-  const outputs = [];
-  if (state?.outputs != null) {
-    for (const [key, value] of Object.entries(state?.outputs) as [any, any][]) {
-      if (typeof value.type === "string") {
-          if (value.sensitive) {
-              outputs.push({
-              name: key,
-              type: value.type,
-              value: "********",
-              })
-          } else {
-              outputs.push({
-                  name: key,
-                  type: value.type,
-                  value: value.value,
-              });
-          }
-      } else {
-        const jsonObject = JSON.stringify(value.value);
-        if (value.sensitive) {
-            outputs.push({
-              name: key,
-              type: "Other type",
-              value: "********",
-            })
-        } else {
-            outputs.push({
-                name: key,
-                type: "Other type",
-                value: jsonObject,
-            });
-        }
-      }
-    }
-  } else {
-    console.log("State has no outputs");
-  }
-
-  console.log("Parsing resources and modules fallback method");
-  if (state?.resources != null && state?.resources.length > 0) {
-    state?.resources.forEach((value: any) => {
-      if (value.module != null) {
-        resources.push({
-          name: value.name,
-          type: value.type,
-          provider: value.provider.replace("provider[", "").replace("]", ""),
-          module: value.module,
-          values: value.instances[0].attributes,
-          depends_on: value.instances[0].dependencies,
-        });
-      } else {
-        resources.push({
-          name: value.name,
-          type: value.type,
-          provider: value.provider.replace('provider["', "").replace('"]', ""),
-          module: "root_module",
-          values: value.instances[0].attributes,
-          depends_on: value.instances[0].dependencies,
-        });
-      }
-    });
-  } else {
-    console.log("State has no resources/modules");
-  }
-
-  return { resources: resources, outputs: outputs };
-}
-
-function parseChildModules(resources: any, child_modules?: any) {
-  child_modules?.forEach((moduleVal: any, index: number) => {
-    if (moduleVal.resources != null)
-      for (const [_, value] of Object.entries(moduleVal.resources) as [any, any][]) {
-        resources.push({
-          name: value.name,
-          type: value.type,
-          provider: value.provider_name,
-          module: moduleVal.address,
-          values: value.values,
-          depends_on: value.depends_on,
-        });
-      }
-
-    if (moduleVal.child_modules?.length > 0) {
-      resources = parseChildModules(resources);
-    }
-  });
-
-  return resources;
-}
-
-function isValidUrl(source: string): boolean {
-  try {
-    new URL(source);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function fixSshURL(source: string) {
-  if (source.startsWith("git@")) {
-    return source.replace(":", "/").replace("git@", "https://");
-  } else {
-    return source;
-  }
-}

--- a/ui/src/domain/Workspaces/Import.tsx
+++ b/ui/src/domain/Workspaces/Import.tsx
@@ -13,7 +13,8 @@ import {
   Steps,
   Table,
   message,
-  theme, Alert,
+  theme,
+  Alert,
 } from "antd";
 import parse from "html-react-parser";
 import { ValidateErrorEntity } from "rc-field-form/lib/interface";
@@ -224,13 +225,13 @@ export const ImportWorkspace = () => {
             &nbsp;
           </IconContext.Provider>
         );
-        case "AZURE_SP_MI":
-            return (
-                <IconContext.Provider value={{ size: "20px" }}>
-                    <VscAzureDevops />
-                    &nbsp;
-                </IconContext.Provider>
-            );
+      case "AZURE_SP_MI":
+        return (
+          <IconContext.Provider value={{ size: "20px" }}>
+            <VscAzureDevops />
+            &nbsp;
+          </IconContext.Provider>
+        );
       default:
         return <GithubOutlined style={{ fontSize: "20px" }} />;
     }
@@ -407,11 +408,11 @@ export const ImportWorkspace = () => {
           <div className="App-text">
             Easily transfer workspaces from Terraform Cloud and Terraform Enterprise to Terrakube.
             <Alert
-                title="Warning"
-                description="Only approved URLs can be used when using Terraform Enterprise to import workspaces. Please verify with your Terrakube administrator if you encounter any issues."
-                type="warning"
-                showIcon
-                style={{ marginBottom: "20px" }}
+              title="Warning"
+              description="Only approved URLs can be used when using Terraform Enterprise to import workspaces. Please verify with your Terrakube administrator if you encounter any issues."
+              type="warning"
+              showIcon
+              style={{ marginBottom: "20px" }}
             />
           </div>
           <Content hidden={stepsHidden}>

--- a/ui/src/domain/Workspaces/ResourceDrawer.tsx
+++ b/ui/src/domain/Workspaces/ResourceDrawer.tsx
@@ -21,10 +21,9 @@ export const ResourceDrawer = ({ open, resource, setOpen, workspace }: Props) =>
     const fetchActions = async () => {
       try {
         setLoading(true);
-        const response = await axiosInstance.get('action', {
+        const response = await axiosInstance.get("action", {
           params: {
-            'filter[action]':
-              "active==true;type=in=('Workspace/ResourceDrawer/Action','Workspace/ResourceDrawer/Tab')",
+            "filter[action]": "active==true;type=in=('Workspace/ResourceDrawer/Action','Workspace/ResourceDrawer/Tab')",
           },
         });
         const fetchedActions = response.data.data || [];

--- a/ui/src/domain/Workspaces/Settings/Advanced.tsx
+++ b/ui/src/domain/Workspaces/Settings/Advanced.tsx
@@ -72,24 +72,24 @@ export const WorkspaceAdvanced = ({ workspace, manageWorkspace }: Props) => {
     <div className="generalSettings">
       <h1>Destruction and Deletion</h1>
       <Text type="secondary">
-        There are two independent steps for destroying this workspace and any infrastructure associated with it.
-        First, any Terraform infrastructure managed by this workspace can be destroyed. Then, the workspace in
-        Terrakube, including any variables, settings, and alert history can be deleted.
+        There are two independent steps for destroying this workspace and any infrastructure associated with it. First,
+        any Terraform infrastructure managed by this workspace can be destroyed. Then, the workspace in Terrakube,
+        including any variables, settings, and alert history can be deleted.
       </Text>
 
-      <h2>Delete Workspace</h2>
-      <p>
-        <Text type="secondary">
-          <Text strong>Warning!</Text> Deleting this workspace permanently removes all of its variables, settings,
-          alert history, run history, and Terraform state.
-        </Text>
-      </p>
-      <p>
-        <Text type="secondary">
+      <h3 style={{ marginBottom: "16px" }}>Delete this Workspace</h3>
+      <div style={{ textAlign: "left", marginBottom: "16px" }}>
+        <Typography.Text type="secondary">
+          <Text strong>Warning!</Text> Deleting this workspace permanently removes all of its variables, settings, alert
+          history, run history, and Terraform state.
+        </Typography.Text>
+      </div>
+      <div style={{ textAlign: "left", marginBottom: "16px" }}>
+        <Typography.Text type="secondary">
           This workspace is {isLocked ? "locked" : "unlocked"} and is
           {resourceCount > 0 ? ` managing ${resourceCount} resources` : " not managing any resources"}.
-        </Text>
-      </p>
+        </Typography.Text>
+      </div>
       <Popconfirm
         onConfirm={() => {
           onDelete(workspace);
@@ -105,7 +105,12 @@ export const WorkspaceAdvanced = ({ workspace, manageWorkspace }: Props) => {
         cancelText="No"
         placement="bottom"
       >
-        <Button type="default" danger disabled={!manageWorkspace}>
+        <Button
+          type="primary"
+          danger
+          style={{ width: "fit-content", padding: "8px 24px", height: "auto" }}
+          disabled={!manageWorkspace}
+        >
           <Space>
             <DeleteOutlined />
             Delete from Terrakube

--- a/ui/src/domain/Workspaces/Settings/General.tsx
+++ b/ui/src/domain/Workspaces/Settings/General.tsx
@@ -49,18 +49,31 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace 
       setTerraformVersions(tfVersions.sort(compareVersions).reverse());
     });
   };
-  const loadAgentlist = () => {
-    axiosInstance.get(`organization/${organizationId}/agent`).then((response) => {
-      setAgentList(response.data.data);
-    });
-  };
 
   useEffect(() => {
     setWaiting(true);
-    loadVersions(workspaceData.attributes?.iacType);
-    loadAgentlist();
-    setWaiting(false);
-  }, []);
+    const iacType = workspaceData.attributes?.iacType;
+    const versionsApi = `${new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin}/${iacType}/index.json`;
+
+    // Parallel load: versions and agent list
+    Promise.all([axiosInstance.get(versionsApi), axiosInstance.get(`organization/${organizationId}/agent`)]).then(
+      ([versionsRes, agentsRes]) => {
+        const tfVersions: string[] = [];
+        if (iacType === "tofu") {
+          versionsRes.data.forEach((release: TofuRelease) => {
+            if (!release.tag_name.includes("-")) tfVersions.push(release.tag_name.replace("v", ""));
+          });
+        } else {
+          for (const version in versionsRes.data.versions) {
+            if (!version.includes("-")) tfVersions.push(version);
+          }
+        }
+        setTerraformVersions(tfVersions.sort(compareVersions).reverse());
+        setAgentList(agentsRes.data.data);
+        setWaiting(false);
+      }
+    );
+  }, [organizationId, workspaceData.attributes?.iacType]);
 
   const handleIacChange = (iac: string) => {
     setSelectedIac(iac);
@@ -136,8 +149,8 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace 
     <div style={{ width: "100%" }} className="generalSettings">
       <h1>General Settings</h1>
       <p>
-        Adjust the settings for this workspace. These settings control how the workspace behaves,
-        including execution mode, IaC configuration, and security options.
+        Adjust the settings for this workspace. These settings control how the workspace behaves, including execution
+        mode, IaC configuration, and security options.
       </p>
       <Spin spinning={waiting}>
         <Form
@@ -181,24 +194,23 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace 
           {/* Section 2: Execution Mode */}
           <h2>Execution Mode</h2>
           <Text type="secondary">
-            Select the execution mode for this workspace. Remote indicates Terrakube will run plans
-            and applies. Local indicates users should run locally with remote state.
+            Select the execution mode for this workspace. Remote indicates Terrakube will run plans and applies. Local
+            indicates users should run locally with remote state.
           </Text>
 
           <Form.Item
             name="executionMode"
             label="Execution Mode"
             extra={
-              "Local indicates users should run " + getIaCNameById(selectedIac || workspaceData.attributes?.iacType) + " " +
+              "Local indicates users should run " +
+              getIaCNameById(selectedIac || workspaceData.attributes?.iacType) +
+              " " +
               "locally with remote state/cloud block and just upload the state to Terrakube. Remote " +
               "indicates Terrakube will run plans and apply. Informational only."
             }
             style={{ marginTop: 16 }}
           >
-            <Select
-              defaultValue={workspaceData.attributes.executionMode}
-              disabled={!manageWorkspace}
-            >
+            <Select defaultValue={workspaceData.attributes.executionMode} disabled={!manageWorkspace}>
               <Option key="remote">remote</Option>
               <Option key="local">local</Option>
             </Select>
@@ -224,9 +236,7 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace 
 
           {/* Section 3: IaC Configuration */}
           <h2>IaC Configuration</h2>
-          <Text type="secondary">
-            Configure the Infrastructure as Code tool and version used for this workspace.
-          </Text>
+          <Text type="secondary">Configure the Infrastructure as Code tool and version used for this workspace.</Text>
 
           <Form.Item
             name="iacType"
@@ -257,10 +267,7 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace 
               " to use for this workspace. Upon creating this workspace, the latest version was selected and will be used until it is changed manually. It will not upgrade automatically."
             }
           >
-            <Select
-              defaultValue={workspaceData.attributes?.terraformVersion}
-              disabled={!manageWorkspace}
-            >
+            <Select defaultValue={workspaceData.attributes?.terraformVersion} disabled={!manageWorkspace}>
               {terraformVersions.map(function (name) {
                 return <Option key={name}>{name}</Option>;
               })}
@@ -290,9 +297,7 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace 
 
           {/* Section 4: Default Template */}
           <h2>Default Template</h2>
-          <Text type="secondary">
-            Configure the default template used when a git push event triggers a run.
-          </Text>
+          <Text type="secondary">Configure the default template used when a git push event triggers a run.</Text>
 
           <Form.Item
             name="defaultTemplate"

--- a/ui/src/domain/Workspaces/Settings/Locking.tsx
+++ b/ui/src/domain/Workspaces/Settings/Locking.tsx
@@ -109,7 +109,9 @@ export const WorkspaceLocking = ({ workspace, manageWorkspace, onWorkspaceUpdate
             message={
               <span>
                 This workspace is <Text strong>currently locked</Text>.
-                {lockDescription ? ` Reason: ${lockDescription}` : " No reason was provided for locking this workspace."}
+                {lockDescription
+                  ? ` Reason: ${lockDescription}`
+                  : " No reason was provided for locking this workspace."}
               </span>
             }
             type="info"
@@ -131,8 +133,8 @@ export const WorkspaceLocking = ({ workspace, manageWorkspace, onWorkspaceUpdate
         <>
           <p>
             <Text type="secondary">
-              This workspace is not currently locked. All operations can proceed normally. You can lock this workspace to
-              prevent Terraform runs.
+              This workspace is not currently locked. All operations can proceed normally. You can lock this workspace
+              to prevent Terraform runs.
             </Text>
           </p>
 

--- a/ui/src/domain/Workspaces/Settings/SSHKey.tsx
+++ b/ui/src/domain/Workspaces/Settings/SSHKey.tsx
@@ -67,13 +67,11 @@ export const WorkspaceSSHKey = ({ workspace, manageWorkspace }: Props) => {
     <div className="generalSettings">
       <h1>SSH Key</h1>
       <Text type="secondary">
-        Optionally choose a private SSH key for downloading Terraform modules from Git-based module sources. This key
-        is not used for cloning the workspace VCS repository or for provisioner connections.
+        Optionally choose a private SSH key for downloading Terraform modules from Git-based module sources. This key is
+        not used for cloning the workspace VCS repository or for provisioner connections.
       </Text>
       <p style={{ marginTop: 4 }}>
-        <Link to={`/organizations/${organizationId}/settings`}>
-          Manage SSH keys for this organization.
-        </Link>
+        <Link to={`/organizations/${organizationId}/settings`}>Manage SSH keys for this organization.</Link>
       </p>
 
       <Spin spinning={waiting}>

--- a/ui/src/domain/Workspaces/Settings/Webhook.tsx
+++ b/ui/src/domain/Workspaces/Settings/Webhook.tsx
@@ -1,5 +1,20 @@
 import { InfoCircleOutlined } from "@ant-design/icons";
-import { Button, Col, Flex, Form, Input, Popconfirm, Row, Select, Space, Spin, Switch, Table, Typography, message } from "antd";
+import {
+  Button,
+  Col,
+  Flex,
+  Form,
+  Input,
+  Popconfirm,
+  Row,
+  Select,
+  Space,
+  Spin,
+  Switch,
+  Table,
+  Typography,
+  message,
+} from "antd";
 import { useEffect, useState } from "react";
 import { v7 as uuid } from "uuid";
 import axiosInstance from "../../../config/axiosConfig";
@@ -39,41 +54,41 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
       return;
     }
     setWebhookEnabled(true);
-    try {
-      axiosInstance
-        .get(`organization/${organizationId}/workspace/${workspaceId}/webhook/${webhookId}`)
-        .then((response) => {
-          setRemoteHookId(response.data.data.attributes.remoteHookId);
-        });
-      axiosInstance
-        .get(`organization/${organizationId}/workspace/${workspaceId}/webhook/${webhookId}/events`)
-        .then((response) => {
-          let i = 1;
-          const events = response.data.data
-            .sort((a: WebhookEvent, b: WebhookEvent) => b.attributes.priority - a.attributes.priority)
-            .map((event: WebhookEvent) => {
-              return {
-                key: i++,
-                id: event.id,
-                priority: event.attributes.priority,
-                event: event.attributes.event,
-                branch: event.attributes.branch,
-                file: event.attributes.path,
-                template: event.attributes.templateId,
-                created: true,
-              };
-            });
-          setRecordIndex(events.length + 1);
-          setWebhookEvents(
-            events.concat({
-              key: i,
-              id: uuid(),
-            })
-          );
-        });
-    } catch (error) {
-      message.error("Failed to load webhook");
-    }
+
+    // Parallel load: webhook details and webhook events
+    Promise.all([
+      axiosInstance.get(`organization/${organizationId}/workspace/${workspaceId}/webhook/${webhookId}`),
+      axiosInstance.get(`organization/${organizationId}/workspace/${workspaceId}/webhook/${webhookId}/events`),
+    ])
+      .then(([webhookRes, eventsRes]) => {
+        setRemoteHookId(webhookRes.data.data.attributes.remoteHookId);
+
+        let i = 1;
+        const events = eventsRes.data.data
+          .sort((a: WebhookEvent, b: WebhookEvent) => b.attributes.priority - a.attributes.priority)
+          .map((event: WebhookEvent) => {
+            return {
+              key: i++,
+              id: event.id,
+              priority: event.attributes.priority,
+              event: event.attributes.event,
+              branch: event.attributes.branch,
+              file: event.attributes.path,
+              template: event.attributes.templateId,
+              created: true,
+            };
+          });
+        setRecordIndex(events.length + 1);
+        setWebhookEvents(
+          events.concat({
+            key: i,
+            id: uuid(),
+          })
+        );
+      })
+      .catch(() => {
+        message.error("Failed to load webhook");
+      });
   };
   const handleEventChange = (index: number, _: any, name: string, value: string) => {
     webhookEvents[index][name] = value;

--- a/ui/src/domain/Workspaces/Settings/WorkspaceSettings.tsx
+++ b/ui/src/domain/Workspaces/Settings/WorkspaceSettings.tsx
@@ -19,7 +19,13 @@ type Props = {
   onWorkspaceUpdate?: () => void;
 };
 
-export const WorkspaceSettings = ({ workspace, orgTemplates, manageWorkspace, vcsProvider, onWorkspaceUpdate }: Props) => {
+export const WorkspaceSettings = ({
+  workspace,
+  orgTemplates,
+  manageWorkspace,
+  vcsProvider,
+  onWorkspaceUpdate,
+}: Props) => {
   const [activeKey, setActiveKey] = useState("general");
   const { token } = theme.useToken();
 

--- a/ui/src/domain/Workspaces/Tags.tsx
+++ b/ui/src/domain/Workspaces/Tags.tsx
@@ -43,26 +43,26 @@ export const Tags = ({ organizationId, workspaceId, manageWorkspace }: Props) =>
     let existingTagId;
     axiosInstance
       .get(`organization/${organizationId}/tag`, {
-        params: { 'filter[tag]': `name==${tagName}` },
+        params: { "filter[tag]": `name==${tagName}` },
       })
       .then((oldTag) => {
-      existingTagId = oldTag.data?.data[0]?.id;
+        existingTagId = oldTag.data?.data[0]?.id;
 
-      if (existingTagId === undefined) {
-        axiosInstance
-          .post(`organization/${organizationId}/tag`, body, {
-            headers: {
-              "Content-Type": "application/vnd.api+json",
-            },
-          })
-          .then((response) => {
-            setTags((prev) => [...prev, response.data?.data]);
-            addTagToWorkspace(response.data?.data?.id);
-          });
-      } else {
-        addTagToWorkspace(existingTagId);
-      }
-    });
+        if (existingTagId === undefined) {
+          axiosInstance
+            .post(`organization/${organizationId}/tag`, body, {
+              headers: {
+                "Content-Type": "application/vnd.api+json",
+              },
+            })
+            .then((response) => {
+              setTags((prev) => [...prev, response.data?.data]);
+              addTagToWorkspace(response.data?.data?.id);
+            });
+        } else {
+          addTagToWorkspace(existingTagId);
+        }
+      });
   };
   const addTagToWorkspace = (tagId: string) => {
     const body = {

--- a/ui/src/domain/Workspaces/Workspaces.css
+++ b/ui/src/domain/Workspaces/Workspaces.css
@@ -124,7 +124,6 @@
   margin-right: 40px;
 }
 
-
 .ant-collapse-content > .ant-collapse-content-box {
   padding: 0px;
 }
@@ -165,4 +164,44 @@
 
 .react-flow__attribution {
   display: none;
+}
+
+/* Dark theme support */
+[data-theme="dark"] .generalSettings > p {
+  color: var(--ant-color-text-secondary);
+}
+
+[data-theme="dark"] .generalSettings .ant-form-item-extra {
+  color: var(--ant-color-text-tertiary);
+}
+
+[data-theme="dark"] .generalSettings .ant-input,
+[data-theme="dark"] .generalSettings .ant-input-affix-wrapper,
+[data-theme="dark"] .generalSettings .ant-select-selector {
+  background-color: var(--ant-color-bg-container) !important;
+  border-color: var(--ant-color-border) !important;
+}
+
+[data-theme="dark"] .generalSettings .ant-input:hover,
+[data-theme="dark"] .generalSettings .ant-input-affix-wrapper:hover,
+[data-theme="dark"] .generalSettings .ant-select-selector:hover {
+  border-color: var(--ant-color-border-secondary) !important;
+}
+
+[data-theme="dark"] .metadata {
+  color: var(--ant-color-text-secondary) !important;
+}
+
+[data-theme="dark"] .states,
+[data-theme="dark"] .stateDetails {
+  color: var(--ant-color-text-secondary);
+}
+
+[data-theme="dark"] .code {
+  background-color: #21262d;
+  color: #e6edf3;
+}
+
+[data-theme="dark"] .workspace-details {
+  color: var(--ant-color-text-secondary);
 }

--- a/ui/src/domain/Workspaces/workspaceDataUtils.ts
+++ b/ui/src/domain/Workspaces/workspaceDataUtils.ts
@@ -1,0 +1,485 @@
+import { AxiosInstance } from "axios";
+import { DateTime } from "luxon";
+import { ORGANIZATION_ARCHIVE, WORKSPACE_ARCHIVE } from "../../config/actionTypes";
+import { FlatJob, FlatJobHistory, FlatVariable, Schedule, Template, VcsType, StateOutputValue } from "../types";
+import { getIaCNameById } from "./Workspaces";
+
+export type StateOutputVariableWithName = { name: string } & StateOutputValue;
+
+export const include = {
+  VARIABLE: "variable",
+  JOB: "job",
+  HISTORY: "history",
+  SCHEDULE: "schedule",
+  VCS: "vcs",
+  AGENT: "agent",
+  WEBHOOK: "webhook",
+  REFERENCE: "reference",
+  ORGANIZATION: "organization",
+};
+
+export async function setupWorkspaceIncludes(
+  data: any,
+  setVariables: (val: any[]) => void,
+  setJobs: (val: any[]) => void,
+  setEnvVariables: (val: any[]) => void,
+  setHistory: (val: FlatJobHistory[]) => void,
+  setSchedule: (val: any[]) => void,
+  templates: Template[],
+  setLastRun: (val: string) => void,
+  setVCSProvider: (val: VcsType) => void,
+  setCurrentStateId: (val: string) => void,
+  currentStateId: string,
+  axiosInstance: any,
+  setResources: (val: any[]) => void,
+  setOutputs: (val: any[]) => void,
+  setAgent: (val: any) => void,
+  _loadWebhook: boolean,
+  setContextState: (val: any) => void,
+  setCollectionVariables: (val: any[]) => void,
+  setCollectionEnvVariables: (val: any[]) => void,
+  setGlobalVariables: (val: FlatVariable[]) => void,
+  setGlobalEnvVariables: (val: FlatVariable[]) => void
+): Promise<void> {
+  const variables: FlatVariable[] = [];
+  const jobs: FlatJob[] = [];
+  const webhooks: any = {};
+  const envVariables: FlatVariable[] = [];
+  const history: FlatJobHistory[] = [];
+  const schedule: Schedule[] = [];
+  const collectionVariables: any[] = [];
+  const collectionEnvVariables: any[] = [];
+  const globalVariables: FlatVariable[] = [];
+  const globalEnvVariables: FlatVariable[] = [];
+  const includes = data.included;
+  const asyncPromises: Promise<void>[] = [];
+
+  includes.forEach((element: any) => {
+    switch (element.type) {
+      case include.ORGANIZATION:
+        asyncPromises.push(
+          axiosInstance.get(`/organization/${element.id}/globalvar`).then((response: any) => {
+            const globalVar = response.data.data;
+            if (globalVar != null) {
+              globalVar.forEach((variableItem: any) => {
+                if (variableItem.attributes.category === "ENV") {
+                  globalEnvVariables.push({
+                    id: variableItem.id,
+                    type: variableItem.type,
+                    ...variableItem.attributes,
+                  });
+                } else {
+                  globalVariables.push({
+                    id: variableItem.id,
+                    type: variableItem.type,
+                    ...variableItem.attributes,
+                  });
+                }
+              });
+            }
+          })
+        );
+        break;
+      case include.JOB:
+        let finalColor = "";
+        switch (element.attributes.status) {
+          case "completed":
+            finalColor = "#2eb039";
+            break;
+          case "noChanges":
+            finalColor = "#9f37fa";
+            break;
+          case "rejected":
+            finalColor = "#FB0136";
+            break;
+          case "failed":
+            finalColor = "#FB0136";
+            break;
+          case "running":
+            finalColor = "#108ee9";
+            break;
+          case "waitingApproval":
+            finalColor = "#fa8f37";
+            break;
+          default:
+            finalColor = "";
+            break;
+        }
+        jobs.push({
+          id: element.id,
+          title: "Queue manually using " + getIaCNameById(data?.data?.attributes?.iacType),
+          statusColor: finalColor,
+          commitId: element.attributes.commitId,
+          stepNumber: element.attributes.stepNumber,
+          latestChange: DateTime.fromISO(element.attributes.createdDate).toRelative(),
+          ...element.attributes,
+        });
+        setLastRun(element.attributes.updatedDate);
+        break;
+      case include.HISTORY:
+        console.log(element);
+        history.push({
+          id: element.id,
+          title: "Queue manually using " + getIaCNameById(data?.data?.attributes?.iacType),
+          relativeDate: DateTime.fromISO(element.attributes.createdDate).toRelative(),
+          createdDate: element.attributes.createdDate,
+          ...element.attributes,
+        });
+        break;
+
+      case include.SCHEDULE:
+        schedule.push({
+          id: element.id,
+          name: templates?.find((template: Template) => template.id === element.attributes.templateReference)
+            ?.attributes?.name,
+          ...element.attributes,
+        });
+        break;
+      case include.VCS:
+        setVCSProvider(element.attributes.vcsType);
+        break;
+      case include.AGENT:
+        setAgent(element.id);
+        break;
+      case include.VARIABLE:
+        if (element.attributes.category == "ENV") {
+          envVariables.push({
+            id: element.id,
+            type: element.type,
+            ...element.attributes,
+          });
+        } else {
+          variables.push({
+            id: element.id,
+            type: element.type,
+            ...element.attributes,
+          });
+        }
+        break;
+      case include.WEBHOOK:
+        webhooks[element.attributes.event] = {
+          id: element.id,
+          type: element.type,
+          ...element.attributes,
+        };
+        break;
+      case include.REFERENCE:
+        asyncPromises.push(
+          axiosInstance.get(`/reference/${element.id}/collection?include=item`).then((response: any) => {
+            const collectionInfo = response.data.data;
+            if (response.data.included != null) {
+              const items = response.data.included;
+              items.forEach((item: any) => {
+                item.attributes.priority = collectionInfo.attributes.priority;
+                item.attributes.collectionName = collectionInfo.attributes.name;
+                if (item.attributes.category === "ENV") {
+                  collectionEnvVariables.push({
+                    id: item.id,
+                    type: item.type,
+                    ...item.attributes,
+                  });
+                } else {
+                  collectionVariables.push({
+                    id: item.id,
+                    type: item.type,
+                    ...item.attributes,
+                  });
+                }
+              });
+            }
+          })
+        );
+        break;
+    }
+  });
+
+  await Promise.all(asyncPromises).catch((err) => {
+    console.error("Error loading workspace includes:", err);
+  });
+
+  const byKey = (a: { key?: string }, b: { key?: string }) =>
+    (a.key ?? "").localeCompare(b.key ?? "", undefined, { sensitivity: "base" });
+
+  setVariables([...variables].sort(byKey));
+  setEnvVariables([...envVariables].sort(byKey));
+  setJobs(jobs);
+  setHistory(history);
+  setSchedule(schedule);
+  setCollectionVariables([...collectionVariables].sort(byKey));
+  setCollectionEnvVariables([...collectionEnvVariables].sort(byKey));
+  setGlobalVariables([...globalVariables].sort(byKey));
+  setGlobalEnvVariables([...globalEnvVariables].sort(byKey));
+
+  // set state data
+  const lastState = history
+    .sort((a: FlatJobHistory, b: FlatJobHistory) => parseInt(a.jobReference) - parseInt(b.jobReference))
+    .reverse()[0];
+  // reload state only if there is a new version
+
+  if (currentStateId !== lastState?.id) {
+    const organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
+    const workspaceId = sessionStorage.getItem(WORKSPACE_ARCHIVE);
+    const url = `${
+      new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin
+    }/access-token/v1/teams/permissions/organization/${organizationId}/workspace/${workspaceId}`;
+    axiosInstance
+      .get(url)
+      .then((response: any) => {
+        loadState(
+          lastState,
+          axiosInstance,
+          setOutputs,
+          setResources,
+          sessionStorage.getItem(WORKSPACE_ARCHIVE)!,
+          setContextState,
+          response.data.manageState
+        );
+      })
+      .catch((err: any) => {
+        console.error("Failed to load workspace permissions for state:", err);
+      });
+  }
+  setCurrentStateId(lastState?.id);
+}
+
+export function loadState(
+  state: any,
+  axiosInstance: AxiosInstance,
+  setOutputs: (val: any) => void,
+  setResources: (val: any) => void,
+  workspaceId: string,
+  setContextState: (val: any) => void,
+  manageState: boolean
+) {
+  if (!state || !manageState) {
+    return;
+  }
+
+  let currentState;
+  const organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
+
+  axiosInstance
+    .get(state.output)
+    .then((resp) => {
+      let result = parseState(resp.data);
+      setContextState(resp.data);
+      if (result.outputs.length < 1 && result.resources.length < 1) {
+        axiosInstance
+          .get(
+            `${
+              new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin
+            }/tfstate/v1/organization/${organizationId}/workspace/${workspaceId}/state/terraform.tfstate`
+          )
+          .then((currentStateData) => {
+            currentState = currentStateData.data;
+            setContextState(currentState);
+            result = parseOldState(currentState);
+
+            setResources(result.resources);
+            setOutputs(result.outputs);
+          })
+          .catch(function (error: Error) {
+            console.error(error);
+          });
+      } else {
+        setResources(result.resources);
+        setOutputs(result.outputs);
+      }
+    })
+    .catch((err) => {
+      console.error("Failed to load state data:", err);
+    });
+}
+
+export function parseState(state: any) {
+  let resources: any[] = [];
+  const outputs: StateOutputVariableWithName[] = [];
+
+  // parse root outputs
+  if (state?.values?.outputs != null) {
+    for (const [key, value] of Object.entries(state?.values?.outputs) as [any, any][]) {
+      if (typeof value.type === "string") {
+        if (value.sensitive) {
+          outputs.push({
+            name: key,
+            type: value.type,
+            value: "*****",
+          });
+        } else {
+          outputs.push({
+            name: key,
+            type: value.type,
+            value: value.value,
+          });
+        }
+      } else {
+        const jsonObject = JSON.stringify(value.value);
+        if (value.sensitive) {
+          outputs.push({
+            name: key,
+            type: "Other type",
+            value: "*****",
+          });
+        } else {
+          outputs.push({
+            name: key,
+            type: "Other type",
+            value: jsonObject,
+          });
+        }
+      }
+    }
+  } else {
+    console.log("State has no outputs");
+  }
+
+  // parse root module resources
+  if (state?.values?.root_module?.resources != null) {
+    for (const [_, value] of Object.entries(state?.values?.root_module?.resources) as [any, any][]) {
+      resources.push({
+        name: value.name,
+        type: value.type,
+        provider: value.provider_name,
+        module: "root_module",
+        values: value.values,
+        depends_on: value.depends_on,
+      });
+    }
+  } else {
+    console.log("State has no resources");
+  }
+
+  // parse child module resources
+  if (state?.values?.root_module?.child_modules?.length > 0) {
+    state?.values?.root_module?.child_modules?.forEach((moduleVal: any, index: any) => {
+      if (moduleVal.resources != null)
+        for (const [_, value] of Object.entries(moduleVal.resources) as [any, any][]) {
+          resources.push({
+            name: value.name,
+            type: value.type,
+            provider: value.provider_name,
+            module: moduleVal.address,
+            values: value.values,
+            depends_on: value.depends_on,
+          });
+        }
+
+      if (moduleVal.child_modules?.length > 0) {
+        resources = parseChildModules(resources, moduleVal.child_modules);
+      }
+    });
+  } else {
+    console.log("State has no child modules resources");
+  }
+
+  return { resources: resources, outputs: outputs };
+}
+
+export function parseOldState(state: any) {
+  const resources: any[] = [];
+  const outputs = [];
+  if (state?.outputs != null) {
+    for (const [key, value] of Object.entries(state?.outputs) as [any, any][]) {
+      if (typeof value.type === "string") {
+        if (value.sensitive) {
+          outputs.push({
+            name: key,
+            type: value.type,
+            value: "********",
+          });
+        } else {
+          outputs.push({
+            name: key,
+            type: value.type,
+            value: value.value,
+          });
+        }
+      } else {
+        const jsonObject = JSON.stringify(value.value);
+        if (value.sensitive) {
+          outputs.push({
+            name: key,
+            type: "Other type",
+            value: "********",
+          });
+        } else {
+          outputs.push({
+            name: key,
+            type: "Other type",
+            value: jsonObject,
+          });
+        }
+      }
+    }
+  } else {
+    console.log("State has no outputs");
+  }
+
+  console.log("Parsing resources and modules fallback method");
+  if (state?.resources != null && state?.resources.length > 0) {
+    state?.resources.forEach((value: any) => {
+      if (value.module != null) {
+        resources.push({
+          name: value.name,
+          type: value.type,
+          provider: value.provider.replace("provider[", "").replace("]", ""),
+          module: value.module,
+          values: value.instances[0].attributes,
+          depends_on: value.instances[0].dependencies,
+        });
+      } else {
+        resources.push({
+          name: value.name,
+          type: value.type,
+          provider: value.provider.replace('provider["', "").replace('"]', ""),
+          module: "root_module",
+          values: value.instances[0].attributes,
+          depends_on: value.instances[0].dependencies,
+        });
+      }
+    });
+  } else {
+    console.log("State has no resources/modules");
+  }
+
+  return { resources: resources, outputs: outputs };
+}
+
+export function parseChildModules(resources: any, child_modules?: any) {
+  child_modules?.forEach((moduleVal: any, index: number) => {
+    if (moduleVal.resources != null)
+      for (const [_, value] of Object.entries(moduleVal.resources) as [any, any][]) {
+        resources.push({
+          name: value.name,
+          type: value.type,
+          provider: value.provider_name,
+          module: moduleVal.address,
+          values: value.values,
+          depends_on: value.depends_on,
+        });
+      }
+
+    if (moduleVal.child_modules?.length > 0) {
+      resources = parseChildModules(resources);
+    }
+  });
+
+  return resources;
+}
+
+export function isValidUrl(source: string): boolean {
+  try {
+    new URL(source);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function fixSshURL(source: string) {
+  if (source.startsWith("git@")) {
+    return source.replace(":", "/").replace("git@", "https://");
+  } else {
+    return source;
+  }
+}

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { usePolling } from "./usePolling";
+export { useAbortableFetch, useAbortController } from "./useAbortableFetch";

--- a/ui/src/hooks/useAbortableFetch.ts
+++ b/ui/src/hooks/useAbortableFetch.ts
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useCallback } from "react";
+import { AxiosRequestConfig, AxiosResponse } from "axios";
+import axiosInstance from "../config/axiosConfig";
+
+interface UseAbortableFetchReturn<T> {
+  execute: (config?: AxiosRequestConfig) => Promise<AxiosResponse<T>>;
+  abort: () => void;
+  isAborted: boolean;
+}
+
+export function useAbortableFetch<T = unknown>(url: string, config?: AxiosRequestConfig): UseAbortableFetchReturn<T> {
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const isAbortedRef = useRef(false);
+
+  const abort = useCallback(() => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      isAbortedRef.current = true;
+    }
+  }, []);
+
+  const execute = useCallback(
+    async (overrideConfig?: AxiosRequestConfig): Promise<AxiosResponse<T>> => {
+      abort();
+
+      abortControllerRef.current = new AbortController();
+      isAbortedRef.current = false;
+
+      try {
+        const response = await axiosInstance.request<T>({
+          url,
+          ...config,
+          ...overrideConfig,
+          signal: abortControllerRef.current.signal,
+        });
+        return response;
+      } catch (error: unknown) {
+        if (error instanceof Error && (error.name === "AbortError" || error.name === "CanceledError")) {
+          isAbortedRef.current = true;
+        }
+        throw error;
+      }
+    },
+    [url, config, abort]
+  );
+
+  useEffect(() => {
+    return () => {
+      abort();
+    };
+  }, [abort]);
+
+  return {
+    execute,
+    abort,
+    get isAborted() {
+      return isAbortedRef.current;
+    },
+  };
+}
+
+export function useAbortController() {
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const getSignal = useCallback(() => {
+    if (controllerRef.current) {
+      controllerRef.current.abort();
+    }
+    controllerRef.current = new AbortController();
+    return controllerRef.current.signal;
+  }, []);
+
+  const abort = useCallback(() => {
+    if (controllerRef.current) {
+      controllerRef.current.abort();
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (controllerRef.current) {
+        controllerRef.current.abort();
+      }
+    };
+  }, []);
+
+  return { getSignal, abort };
+}

--- a/ui/src/hooks/usePolling.ts
+++ b/ui/src/hooks/usePolling.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useCallback } from "react";
+
+interface UsePollingOptions {
+  interval: number;
+  enabled?: boolean;
+  immediate?: boolean;
+}
+
+export function usePolling(callback: () => void | Promise<void>, options: UsePollingOptions) {
+  const { interval, enabled = true, immediate = false } = options;
+  const savedCallback = useRef(callback);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  const clearPolling = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      clearPolling();
+      return;
+    }
+
+    if (immediate) {
+      savedCallback.current();
+    }
+
+    intervalRef.current = setInterval(() => {
+      savedCallback.current();
+    }, interval);
+
+    return () => {
+      clearPolling();
+    };
+  }, [interval, enabled, immediate, clearPolling]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        clearPolling();
+      } else {
+        if (immediate) {
+          savedCallback.current();
+        }
+        intervalRef.current = setInterval(() => {
+          savedCallback.current();
+        }, interval);
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [interval, enabled, immediate, clearPolling]);
+
+  return { clear: clearPolling };
+}

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -1,4 +1,6 @@
 import "github-markdown-css/github-markdown-light.css";
+import "./styles/variables.css";
+import "./styles/global.css";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { AuthProvider } from "react-oidc-context";

--- a/ui/src/modules/organizations/OrganizationsPickerPage.tsx
+++ b/ui/src/modules/organizations/OrganizationsPickerPage.tsx
@@ -1,4 +1,5 @@
 import { Button, Empty, Flex } from "antd";
+import { PlusOutlined } from "@ant-design/icons";
 import "antd/dist/reset.css";
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
@@ -24,6 +25,12 @@ export default function OrganizationsPickerPage() {
   });
 
   async function initPage() {
+    // Skip redirect if explicitly navigating to /organizations
+    if (window.location.pathname === "/organizations") {
+      await execute();
+      return;
+    }
+
     if (orgId === "" || orgId === null) {
       await execute();
     } else {
@@ -51,12 +58,20 @@ export default function OrganizationsPickerPage() {
 
   return (
     <PageWrapper
-      title="Choose an Organization"
-      subTitle="You have access to the following organizations"
+      title="Organizations"
+      subTitle="Manage your organizations"
       error={error}
       loading={loading}
       loadingText="Loading organizations..."
       breadcrumbs={[{ label: "Organizations", path: "/" }]}
+      actions={
+        !loading &&
+        organizations.length > 0 && (
+          <Button type="primary" onClick={() => navigate("/organizations/create")}>
+            <PlusOutlined /> Create organization
+          </Button>
+        )
+      }
     >
       {!loading && organizations.length === 0 && (
         <Flex justify="center">

--- a/ui/src/modules/organizations/components/OrganizationGrid/OrganizationGrid.css
+++ b/ui/src/modules/organizations/components/OrganizationGrid/OrganizationGrid.css
@@ -10,3 +10,8 @@
 .org-card-title {
   font-size: 20px;
 }
+
+/* Dark mode for organization card */
+[data-theme="dark"] .org-card-title {
+  color: #58a6ff;
+}

--- a/ui/src/modules/organizations/components/OrganizationGrid/OrganizationGridItem.tsx
+++ b/ui/src/modules/organizations/components/OrganizationGrid/OrganizationGridItem.tsx
@@ -1,7 +1,7 @@
 import { Flex, Typography, Card } from "antd";
 import stringToDeterministicColor from "@/modules/utils/stringToDeterministicColor";
 import { OrganizationModel } from "../../types";
-import * as FaIcons from "react-icons/fa6";
+import { getFaIcon, FaBuilding } from "@/config/iconList";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "../../../../config/actionTypes";
 const DEFAULT_ICON = "FaBuilding";
 const DEFAULT_COLOR = "#000000";
@@ -22,7 +22,7 @@ function parseIconField(iconField: string | undefined, orgId: string): { iconNam
 
 // Helper to get the icon component
 function getOrgIcon(iconName: string, color: string) {
-  const IconComponent = FaIcons[(iconName as keyof typeof FaIcons) || DEFAULT_ICON] || FaIcons[DEFAULT_ICON];
+  const IconComponent = getFaIcon(iconName) || FaBuilding;
   return <IconComponent style={{ color, fontSize: 40 }} />;
 }
 

--- a/ui/src/modules/token/TokenGrid.tsx
+++ b/ui/src/modules/token/TokenGrid.tsx
@@ -1,4 +1,4 @@
-import { Row, Col, Alert } from "antd";
+import { Alert, Flex, Typography } from "antd";
 import { UserToken } from "@/modules/user/types";
 import TokenGridItem from "./TokenGridItem";
 import "./TokenList.css";
@@ -20,14 +20,15 @@ export default function TokenGrid({ tokens, action, onDeleted }: Props) {
 
   return (
     <div className="token-list">
+      <Typography.Title level={4} className="list-header">
+        Tokens ({tokens.length})
+      </Typography.Title>
       {error && <Alert message="Failed to delete token" type="error" showIcon banner />}
-      <Row wrap={true} gutter={[16, 16]} style={{ marginTop: error !== undefined ? "10px" : undefined }}>
+      <Flex vertical gap="middle" style={{ marginTop: error !== undefined ? "10px" : undefined }}>
         {tokens.map((tkn) => (
-          <Col xxl={8} xl={12} md={24} key={tkn.id}>
-            <TokenGridItem token={tkn} onDelete={(id: string) => execute(id)} loading={loading} />
-          </Col>
+          <TokenGridItem key={tkn.id} token={tkn} onDelete={(id: string) => execute(id)} loading={loading} />
         ))}
-      </Row>
+      </Flex>
     </div>
   );
 }

--- a/ui/src/modules/token/TokenGridItem.tsx
+++ b/ui/src/modules/token/TokenGridItem.tsx
@@ -1,11 +1,12 @@
 import {
   DeleteOutlined,
-  ExclamationCircleOutlined,
-  QuestionCircleOutlined,
-  CalendarOutlined,
+  ClockCircleOutlined,
   UserOutlined,
+  SafetyCertificateOutlined,
+  SyncOutlined,
+  HourglassOutlined,
 } from "@ant-design/icons";
-import { Card, Popconfirm, Button, Flex, Typography } from "antd";
+import { Button, Flex, Typography, Popconfirm, Tag, theme } from "antd";
 import { DateTime } from "luxon";
 import { UserToken } from "@/modules/user/types";
 
@@ -16,79 +17,105 @@ type Props = {
 };
 
 export default function TokenGridItem({ token, onDelete, loading }: Props) {
+  const { token: themeToken } = theme.useToken();
+
+  const expiryDate =
+    token.createdDate && (token.days > 0 || token.hours > 0 || token.minutes > 0)
+      ? DateTime.fromISO(token.createdDate).plus({ days: token.days, hours: token.hours, minutes: token.minutes })
+      : null;
+
   return (
-    <Card
-      type="inner"
-      className="card"
-      title={
-        <Flex justify="space-between" align="center" gap="middle">
-          <Typography.Text className="title" ellipsis>
-            {token.description}
-          </Typography.Text>
+    <div
+      className="token-item"
+      style={{
+        border: `1px solid ${themeToken.colorBorderSecondary}`,
+        borderRadius: themeToken.borderRadiusLG,
+        padding: "16px",
+        backgroundColor: themeToken.colorBgContainer,
+      }}
+    >
+      <Flex justify="space-between" align="start">
+        <Flex gap="middle" align="center" style={{ width: "100%" }}>
+          <div
+            style={{
+              backgroundColor: themeToken.colorFillTertiary,
+              padding: "8px",
+              borderRadius: "50%",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <SafetyCertificateOutlined style={{ fontSize: "20px", color: themeToken.colorTextSecondary }} />
+          </div>
+
+          <Flex vertical gap={4} style={{ flex: 1 }}>
+            <Flex gap="small" align="center">
+              <Typography.Text strong style={{ fontSize: "16px" }}>
+                {token.description}
+              </Typography.Text>
+
+              {expiryDate ? (
+                <Tag
+                  icon={<HourglassOutlined />}
+                  style={{
+                    backgroundColor: "#fff7e6",
+                    borderColor: "#ffd591",
+                    color: "#d46b08",
+                    margin: 0,
+                  }}
+                >
+                  Expires {expiryDate.toFormat("MMMM d, yyyy")}
+                </Tag>
+              ) : (
+                <Tag color="blue">Never expires</Tag>
+              )}
+            </Flex>
+          </Flex>
+
           <Popconfirm
-            onConfirm={() => {
-              onDelete(token.id);
-            }}
-            style={{ width: "20px" }}
-            styles={{
-              body: {
-                width: "250px",
-              },
-            }}
-            okButtonProps={{ color: "red", variant: "solid" }}
-            okText="Yes"
-            cancelText="No"
             title="Delete token?"
             description="This operation is irreversible. Are you sure you want to proceed?"
-            icon={<QuestionCircleOutlined style={{ color: "red" }} />}
+            onConfirm={() => onDelete(token.id)}
+            okText="Yes"
+            cancelText="No"
+            okButtonProps={{ danger: true }}
           >
-            <Button variant="outlined" color="red" icon={<DeleteOutlined />} loading={loading} />
+            <Button type="text" icon={<DeleteOutlined />} danger loading={loading} />
           </Popconfirm>
         </Flex>
-      }
-      variant="borderless"
-    >
-      <Flex vertical gap="small">
-        <Flex gap="small">
-          <UserOutlined />
-          <Typography.Text strong type="secondary">
-            Created By:
-          </Typography.Text>
-          {token.createdBy}
+      </Flex>
+
+      <div
+        style={{
+          marginTop: "16px",
+          paddingTop: "16px",
+          borderTop: `1px solid ${themeToken.colorBorderSecondary}`,
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          color: themeToken.colorTextSecondary,
+          fontSize: "13px",
+        }}
+      >
+        <Flex gap="middle" align="center">
+          <Flex gap="small" align="center">
+            <ClockCircleOutlined />
+            <span>
+              Created {token.createdDate ? DateTime.fromISO(token.createdDate).toRelative() : "Unknown"} by user
+            </span>
+          </Flex>
+          <Flex gap="small" align="center">
+            <UserOutlined />
+            <Typography.Text type="secondary">{token.createdBy}</Typography.Text>
+          </Flex>
         </Flex>
 
-        <Flex gap="small">
-          <CalendarOutlined />
-          <Typography.Text strong type="secondary">
-            Created:
-          </Typography.Text>
-          {token.createdDate ? (
-            <Typography.Text>
-              {DateTime.fromISO(token.createdDate).toRelative()} (
-              {DateTime.fromISO(token.createdDate).toFormat("yyyy-MM-dd")})
-            </Typography.Text>
-          ) : (
-            <Typography.Text type="danger">Unknown</Typography.Text>
-          )}
+        <Flex gap="small" align="center">
+          <SyncOutlined />
+          <span>Token has not been used</span>
         </Flex>
-        <Flex gap="small">
-          <ExclamationCircleOutlined />
-          <Typography.Text strong type="secondary">
-            Expires:
-          </Typography.Text>
-          {token.createdDate ? (
-            <Typography.Text type="warning">
-              {(token.days > 0 || token.hours > 0 || token.minutes > 0) && token.createdDate
-                ? DateTime.fromISO(token.createdDate)
-                    .plus({ days: token.days, hours: token.hours, minutes: token.minutes })
-                    .toLocaleString(DateTime.DATETIME_MED)
-                : "Token without expiration date"}
-            </Typography.Text>
-          ) : (
-            <Typography.Text type="danger">Unknown</Typography.Text>
-          )}
-        </Flex>
-      </Flex>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/ui/src/modules/token/TokenList.css
+++ b/ui/src/modules/token/TokenList.css
@@ -1,10 +1,9 @@
 .token-list {
-  padding: 10px;
   margin-top: 20px;
-  .title {
-    max-width: 85%;
-  }
-  .card {
-    border: 1px solid rgb(240, 242, 245);
+
+  .list-header {
+    margin-bottom: 20px !important;
+    font-size: 16px;
+    font-weight: 600;
   }
 }

--- a/ui/src/modules/token/modals/CreatePatModal.css
+++ b/ui/src/modules/token/modals/CreatePatModal.css
@@ -1,11 +1,81 @@
 .create-pat-modal {
-  width: "600px";
-  .content {
-    width: 100%;
+  .ant-modal-content {
+    border-radius: 8px;
   }
 
-  .created-token {
-    padding: 10px 15px;
-    border-radius: 15px;
+  .ant-modal-header {
+    margin-bottom: 20px;
   }
+
+  .required-badge {
+    margin-left: 8px;
+    background: #f5f5f5;
+    border: 1px solid #d9d9d9;
+    color: #666;
+    font-size: 12px;
+    border-radius: 4px;
+  }
+
+  .expiry-text {
+    display: block;
+    margin-top: -10px;
+    margin-bottom: 20px;
+    font-size: 13px;
+  }
+
+  .token-display {
+    background: #f5f5f5;
+    padding: 15px;
+    border-radius: 4px;
+    margin-bottom: 15px;
+
+    .created-token {
+      margin-bottom: 0;
+      font-family: monospace;
+      font-size: 14px;
+    }
+  }
+
+  .warning-banner {
+    background-color: #fff0f6; /* Light pink/purple */
+    border: 1px solid #ffadd2;
+    margin-bottom: 20px;
+
+    .ant-alert-message {
+      color: #c41d7f;
+    }
+
+    .anticon {
+      color: #c41d7f;
+    }
+  }
+}
+
+/* Dark mode styles */
+[data-theme="dark"] .create-pat-modal .token-display {
+  background: #21262d;
+  border: 1px solid #30363d;
+}
+
+[data-theme="dark"] .create-pat-modal .token-display .created-token {
+  color: #58a6ff;
+}
+
+[data-theme="dark"] .create-pat-modal .warning-banner {
+  background-color: #2d1f1f;
+  border-color: #5c3d3d;
+}
+
+[data-theme="dark"] .create-pat-modal .warning-banner .ant-alert-message {
+  color: #f8a8a8;
+}
+
+[data-theme="dark"] .create-pat-modal .warning-banner .anticon {
+  color: #f8a8a8;
+}
+
+[data-theme="dark"] .create-pat-modal .required-badge {
+  background: #21262d;
+  border-color: #30363d;
+  color: #8b949e;
 }

--- a/ui/src/modules/token/modals/CreatePatModal.tsx
+++ b/ui/src/modules/token/modals/CreatePatModal.tsx
@@ -1,20 +1,22 @@
-import { InfoCircleOutlined } from "@ant-design/icons";
-import { Modal, Space, Form, Input, InputNumber, Typography, Alert, ModalProps, Button, Flex } from "antd";
-import { useState } from "react";
+import { Modal, Space, Form, Input, Typography, Alert, Button, Flex, Select, Tag } from "antd";
+import { useState, useEffect } from "react";
+import { DateTime } from "luxon";
 import useApiRequest from "@/modules/api/useApiRequest";
-import { CreateTokenForm } from "@/modules/token/types";
+import { CreateTokenForm, CreatedToken } from "@/modules/token/types";
+import "./CreatePatModal.css";
 
 type Props = {
   visible: boolean;
-  shortlivedTokens: boolean;
   onCancel: () => void;
   onCreated: () => void;
   action: (data?: CreateTokenForm) => Promise<ApiResponse<CreatedToken>>;
 };
 
-export default function CreatePatModal({ onCancel, action, onCreated, visible, shortlivedTokens }: Props) {
+export default function CreatePatModal({ onCancel, action, onCreated, visible }: Props) {
   const [form] = Form.useForm<CreateTokenForm>();
   const [tokenValue, setTokenValue] = useState<string>();
+  const [expiryDate, setExpiryDate] = useState<string>("");
+  const [selectedDays, setSelectedDays] = useState<number>(30);
 
   const { loading, execute, error } = useApiRequest({
     showErrorAsNotification: false,
@@ -29,92 +31,86 @@ export default function CreatePatModal({ onCancel, action, onCreated, visible, s
     },
   });
 
+  useEffect(() => {
+    if (selectedDays === 0) {
+      setExpiryDate("Never expires");
+    } else {
+      const date = DateTime.now().plus({ days: selectedDays });
+      setExpiryDate(`This token will expire on ${date.toFormat("MMMM d, yyyy")}`);
+    }
+  }, [selectedDays]);
+
   async function submitForm() {
     setTokenValue(undefined);
     const formValues = await form.validateFields();
-    await execute(formValues);
+    // Map the selected days to the form values expected by the API
+    // The API expects days, hours, minutes. We'll just set days.
+    const apiValues: CreateTokenForm = {
+      description: formValues.description,
+      days: selectedDays,
+      hours: 0,
+      minutes: 0,
+    };
+    await execute(apiValues);
   }
 
-  const buttonProps: Partial<ModalProps> =
-    tokenValue === undefined
-      ? {
-          okText: "Create",
-          okButtonProps: { loading, type: "primary" },
-          onOk: () => submitForm(),
-          onCancel: onCancel,
-          cancelText: "Cancel",
-          cancelButtonProps: { type: "text", danger: true },
-        }
-      : {
-          footer: null,
-        };
+  const handleDaysChange = (value: number) => {
+    setSelectedDays(value);
+  };
 
   return (
-    <Modal className="create-pat-modal" open={visible} title="Create Access Token" destroyOnClose {...buttonProps}>
+    <Modal
+      className="create-pat-modal"
+      open={visible}
+      title="Creating a user token"
+      destroyOnClose
+      onCancel={onCancel}
+      footer={
+        tokenValue === undefined ? (
+          <Flex justify="end" gap="small">
+            <Button onClick={onCancel}>Cancel</Button>
+            <Button type="primary" loading={loading} onClick={submitForm}>
+              Generate token
+            </Button>
+          </Flex>
+        ) : null
+      }
+    >
       {tokenValue === undefined && (
         <Space className="content" direction="vertical">
           {error && <Alert type="error" banner message={error?.message} />}
-          <Form
-            name="tokens"
-            form={form}
-            layout="vertical"
-            disabled={loading}
-            initialValues={{ minutes: 0, hours: 0, days: 0 }}
-            validateMessages={{
-              required: "${label} is required",
-            }}
-          >
+          <Form name="tokens" form={form} layout="vertical" disabled={loading} initialValues={{ description: "" }}>
             <Form.Item
               name="description"
-              tooltip={{
-                title: "Choose a description to help you identify this token later",
-                icon: <InfoCircleOutlined />,
-              }}
-              label="Description"
-              rules={[{ required: true }]}
+              label={
+                <span>
+                  Description <Tag className="required-badge">Required</Tag>
+                </span>
+              }
+              help="To help you identify this token later."
+              rules={[{ required: true, message: "Description is required" }]}
             >
-              <Input placeholder="Please input a description" />
+              <Input placeholder="e.g. API testing" />
             </Form.Item>
-            <Form.Item
-              name="days"
-              tooltip={{
-                title: "Number of days for the token to be valid",
-                icon: <InfoCircleOutlined />,
-              }}
-              label="Days"
-              rules={[{ required: true }]}
-            >
-              <InputNumber min={0} placeholder="10" />
+
+            <Form.Item label="Expiration" name="expiration" initialValue={30}>
+              <Select onChange={handleDaysChange} value={selectedDays}>
+                <Select.Option value={30}>30 days</Select.Option>
+                <Select.Option value={60}>60 days</Select.Option>
+                <Select.Option value={90}>90 days</Select.Option>
+                <Select.Option value={120}>120 days</Select.Option>
+                <Select.Option value={365}>1 year</Select.Option>
+                <Select.Option value={0}>Never</Select.Option>
+              </Select>
             </Form.Item>
-            {shortlivedTokens ? (
-              <>
-                <Form.Item
-                  name="hours"
-                  tooltip={{
-                    title: "Number of hours for the token to be valid",
-                    icon: <InfoCircleOutlined />,
-                  }}
-                  label="Hours"
-                  rules={[{ required: true }]}
-                >
-                  <InputNumber min={0} />
-                </Form.Item>
-                <Form.Item
-                  name="minutes"
-                  tooltip={{
-                    title: "Number of minutes for the token to be valid",
-                    icon: <InfoCircleOutlined />,
-                  }}
-                  label="Minutes"
-                  rules={[{ required: true }]}
-                >
-                  <InputNumber min={0} />
-                </Form.Item>
-              </>
-            ) : undefined}
+
+            <Typography.Text type="secondary" className="expiry-text">
+              {expiryDate}
+            </Typography.Text>
           </Form>
         </Space>
       )}
+
       {tokenValue !== undefined && (
         <Space className="content" direction="vertical" size="middle">
           <Typography.Text>
@@ -122,23 +118,22 @@ export default function CreatePatModal({ onCancel, action, onCreated, visible, s
             account without a username, password, or two-factor authentication.
           </Typography.Text>
 
-          <Typography.Paragraph className="created-token" copyable>
-            {tokenValue}
-          </Typography.Paragraph>
+          <div className="token-display">
+            <Typography.Paragraph className="created-token" copyable>
+              {tokenValue}
+            </Typography.Paragraph>
+          </div>
+
           <Alert
-            banner
-            description={
-              <span>
-                This token <b>will not be displayed again</b>, so make sure to save it to a safe place.
-              </span>
-            }
+            message="Terrakube will not display this token again, so store it securely."
             type="warning"
             showIcon
+            className="warning-banner"
           />
+
           <Flex justify="end">
             <Button
               type="primary"
-              danger
               onClick={() => {
                 setTokenValue(undefined);
                 onCreated();

--- a/ui/src/modules/user/components/PatSection/PatSection.css
+++ b/ui/src/modules/user/components/PatSection/PatSection.css
@@ -2,20 +2,44 @@
   margin-left: 40px;
   margin-right: 100px;
   padding-bottom: 100px;
-  .title {
-    margin-bottom: 5px;
+
+  .breadcrumb {
+    margin-bottom: 20px;
+    font-size: 14px;
+    color: #666;
   }
+
+  .header-section {
+    margin-bottom: 30px;
+  }
+
+  .title {
+    margin-bottom: 10px !important;
+    font-weight: 600;
+  }
+
+  .description {
+    margin-bottom: 10px;
+    display: block;
+    max-width: 800px;
+  }
+
+  .warning-text {
+    display: block;
+    max-width: 800px;
+    margin-top: 10px;
+  }
+
   .alert {
     margin-top: 10px;
   }
+
   .loader {
     margin-top: 50px;
   }
+
   .no-content {
     margin-top: 50px;
     max-width: 350px;
-  }
-  .delete-button {
-    margin-left: 20px;
   }
 }

--- a/ui/src/modules/user/components/PatSection/PatSection.tsx
+++ b/ui/src/modules/user/components/PatSection/PatSection.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Empty, Flex, Spin, Typography } from "antd";
+import { Alert, Button, Flex, Spin, Typography, Breadcrumb } from "antd";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { UserToken } from "@/modules/user/types";
@@ -34,16 +34,37 @@ export const Tokens = () => {
 
   return (
     <div className="pat-section">
-      <Flex gap="middle" justify="space-between" align="center">
+      <Breadcrumb
+        className="breadcrumb"
+        items={[
+          {
+            title: "Settings",
+          },
+          {
+            title: "Tokens",
+          },
+        ]}
+      />
+      <Flex gap="middle" justify="space-between" align="center" className="header-section">
         <Flex vertical>
-          <Typography.Title className="title">Personal Access Tokens</Typography.Title>
-          <Typography.Text type="secondary">
-            Personal Access Tokens (PAT), also known as API tokens can be used to access the Terrakube API and perform
-            all the actions your user account is entitled to. For more information, see the Terrakube documentation.
+          <Typography.Title level={2} className="title">
+            Tokens
+          </Typography.Title>
+          <Typography.Text type="secondary" className="description">
+            Your API tokens can be used to access the Terrakube API and perform all the actions your user account is
+            entitled to. For more information, see the{" "}
+            <a href="https://docs.terrakube.io/" target="_blank" rel="noreferrer">
+              user API tokens documentation
+            </a>
+            .
+          </Typography.Text>
+          <Typography.Text type="secondary" className="warning-text">
+            Treat these tokens like passwords, as they can be used to access your account without a username, password,
+            or two-factor authentication.
           </Typography.Text>
         </Flex>
         <Button type="primary" onClick={() => setVisible(true)}>
-          New token
+          Create an API token
         </Button>
       </Flex>
 
@@ -58,20 +79,7 @@ export const Tokens = () => {
         </Flex>
       )}
 
-      {!loading && tokens.length === 0 && (
-        <Flex justify="center">
-          <Empty
-            className="no-content"
-            style={{ textAlign: "center" }}
-            description="You have not created any Personal Access Tokens. Create one now to start integrating with the Terrakube API"
-          >
-            <Button type="primary" onClick={() => setVisible(true)}>
-              Create a new token
-            </Button>
-          </Empty>
-        </Flex>
-      )}
-      {!loading && tokens.length > 0 && (
+      {!loading && (
         <TokenGrid
           tokens={tokens}
           action={(id) => userService.deletePersonalAccessToken(id!)}

--- a/ui/src/modules/user/components/ThemeSection/ThemeSection.tsx
+++ b/ui/src/modules/user/components/ThemeSection/ThemeSection.tsx
@@ -1,6 +1,6 @@
 import { Card, Flex, Select, Space, Typography } from "antd";
-import { useEffect, useState } from "react";
-import { ColorSchemeOption, ThemeMode, defaultColorScheme, defaultThemeMode } from "../../../../config/themeConfig";
+import { ColorSchemeOption, ThemeMode } from "../../../../config/themeConfig";
+import { useTheme } from "../../../../context/ThemeContext";
 import "./ThemeSection.css";
 
 const ColorBox = ({ color }: { color: string }) => (
@@ -15,33 +15,14 @@ const ColorOption = ({ color, label }: { color: string; label: string }) => (
 );
 
 export const ThemeSection = () => {
-  const [colorScheme, setColorScheme] = useState<ColorSchemeOption>(defaultColorScheme);
-  const [themeMode, setThemeMode] = useState<ThemeMode>(defaultThemeMode);
-
-  useEffect(() => {
-    // Load color scheme and theme mode preferences from localStorage
-    const savedScheme = localStorage.getItem("terrakube-color-scheme") as ColorSchemeOption;
-    const savedThemeMode = localStorage.getItem("terrakube-theme-mode") as ThemeMode;
-    if (savedScheme) {
-      setColorScheme(savedScheme);
-    }
-    if (savedThemeMode) {
-      setThemeMode(savedThemeMode);
-    }
-  }, []);
+  const { colorScheme, themeMode, setColorScheme, setThemeMode } = useTheme();
 
   const handleColorSchemeChange = (value: ColorSchemeOption) => {
     setColorScheme(value);
-    localStorage.setItem("terrakube-color-scheme", value);
-    // Automatically reload the page
-    window.location.reload();
   };
 
   const handleThemeModeChange = (value: ThemeMode) => {
     setThemeMode(value);
-    localStorage.setItem("terrakube-theme-mode", value);
-    // Automatically reload the page
-    window.location.reload();
   };
 
   const colorOptions = [

--- a/ui/src/modules/workspaces/components/WorkspaceFilter.css
+++ b/ui/src/modules/workspaces/components/WorkspaceFilter.css
@@ -1,0 +1,169 @@
+/* WorkspaceFilter.css */
+
+/* Main Container */
+.workspace-filter-container {
+  margin-top: 16px;
+}
+
+/* Top row: Search */
+.workspace-filter-search-row {
+  margin-bottom: 12px;
+}
+
+.workspace-search-input {
+  width: 100%;
+}
+
+.workspace-sort-select {
+  min-width: 180px;
+}
+
+/* Bottom row: Status + Tags */
+.workspace-filter-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--tk-bg-container);
+  border: 1px solid var(--tk-border-primary);
+  border-radius: 8px;
+  flex-wrap: wrap;
+}
+
+.workspace-filter-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.workspace-filter-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* Filter Buttons (Tags) */
+.filter-button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 32px;
+  padding: 0 12px;
+  border-radius: 6px;
+  border: 1px solid var(--tk-border-primary);
+  background: var(--tk-bg-container);
+  color: var(--tk-text-primary);
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.filter-button:hover {
+  background: var(--tk-fill-secondary);
+  border-color: var(--tk-border-secondary);
+}
+
+.filter-button .anticon {
+  font-size: 12px;
+  color: var(--tk-text-secondary);
+}
+
+/* Active state for filter buttons */
+.filter-button.active {
+  background: var(--tk-fill-secondary);
+  border-color: var(--tk-border-primary);
+}
+
+/* Popover Content */
+.filter-popover-content {
+  width: 500px;
+  padding: 16px;
+}
+
+.filter-popover-header {
+  margin-bottom: 16px;
+  font-weight: 600;
+  color: var(--tk-text-primary);
+}
+
+.filter-row {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 12px;
+  align-items: center;
+}
+
+.filter-row .ant-select {
+  flex: 1;
+}
+
+.filter-row-remove {
+  color: var(--tk-text-secondary);
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.filter-row-remove:hover {
+  color: var(--tk-text-primary);
+}
+
+.add-filter-btn {
+  color: #0969da;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 16px;
+  font-size: 14px;
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+.add-filter-btn:hover {
+  text-decoration: underline;
+}
+
+[data-theme="dark"] .add-filter-btn {
+  color: #58a6ff;
+}
+
+.filter-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--tk-border-secondary);
+}
+
+/* Dark Mode Overrides */
+[data-theme="dark"] .workspace-filter-bar {
+  background: var(--tk-bg-container);
+  border-color: var(--tk-border-primary);
+}
+
+[data-theme="dark"] .filter-button {
+  background: var(--tk-bg-elevated);
+  border-color: var(--tk-border-primary);
+  color: var(--tk-text-primary);
+}
+
+[data-theme="dark"] .filter-button:hover {
+  background: var(--tk-fill-secondary);
+}
+
+[data-theme="dark"] .filter-popover-content {
+  background: var(--tk-bg-elevated);
+}
+
+[data-theme="dark"] .filter-footer {
+  border-top-color: var(--tk-border-primary);
+}
+
+/* Segmented control styling */
+.workspace-filter-left .ant-segmented {
+  background: transparent;
+}

--- a/ui/src/modules/workspaces/components/WorkspaceFilter.tsx
+++ b/ui/src/modules/workspaces/components/WorkspaceFilter.tsx
@@ -4,10 +4,12 @@ import {
   StopOutlined,
   SyncOutlined,
   CheckCircleOutlined,
-  CloseCircleOutlined,
   InfoCircleOutlined,
+  PlusOutlined,
+  DeleteOutlined,
+  DownOutlined,
 } from "@ant-design/icons";
-import { Card, Row, Col, Segmented, Flex, Select, Input, theme } from "antd";
+import { Row, Col, Select, Input, Button, Popover, Badge, Segmented } from "antd";
 import { JobStatus } from "../../../domain/types";
 import { useEffect, useMemo, useState } from "react";
 import { WorkspaceListItem } from "@/modules/workspaces/types";
@@ -16,6 +18,7 @@ import useApiRequest from "@/modules/api/useApiRequest";
 import { mapTag } from "@/modules/organizations/organizationMapper";
 import { TagModel } from "@/modules/organizations/types";
 import { WorkspaceSortOption, WORKSPACE_SORT_OPTIONS } from "../utils/workspaceSort";
+import "./WorkspaceFilter.css";
 
 type Props = {
   organizationId: string;
@@ -39,16 +42,12 @@ export default function WorkspaceFilter({
   sortOption,
   onSortChange,
 }: Props) {
-  const {
-    token: { colorBgContainer },
-  } = theme.useToken();
-
   const [statusFilter, setStatusFilter] = useState<string>(sessionStorage.getItem("filterValue") || "All");
   const [searchFilter, setSearchFilter] = useState(sessionStorage.getItem("searchValue") || "");
   const [tagsFilter, setTagsFilter] = useState<string[]>((sessionStorage.getItem("selectedTags") as any) || []);
   const [tags, setTags] = useState<TagModel[]>([]);
 
-  const { loading, execute } = useApiRequest({
+  const { execute } = useApiRequest({
     action: () => organizationService.listOrganizationTags(organizationId),
     onReturn: (data) => {
       const mapped = data.map(mapTag);
@@ -66,7 +65,11 @@ export default function WorkspaceFilter({
     if (isClear) internalSearchFilter = "";
 
     let filteredWorkspaces =
-      statusFilter === Additional.All ? workspaces : workspaces.filter((x) => x.lastStatus === statusFilter);
+      statusFilter === Additional.All
+        ? workspaces
+        : statusFilter === Additional.NeverExecuted
+          ? workspaces.filter((x) => !x.lastStatus)
+          : workspaces.filter((x) => x.lastStatus === statusFilter);
 
     filteredWorkspaces = filteredWorkspaces.filter((workspace) => {
       if (workspace.description) {
@@ -94,105 +97,169 @@ export default function WorkspaceFilter({
     execute();
   }, []);
 
-  return (
-    <Card
-      style={{ marginTop: "10px", background: colorBgContainer }}
-      styles={{
-        body: {
-          padding: "5px 10px",
-        },
-      }}
-    >
-      <Row justify="end" gutter={[0, 5]}>
-        <Col span={24} xxl={16}>
-          <div className="workspaceFilterSegmentedWrapper">
-            <Segmented
-              onChange={setStatusFilter}
-              value={statusFilter}
-              options={[
-                {
-                  label: "All",
-                  value: Additional.All,
-                  icon: <BarsOutlined />,
-                },
-                {
-                  label: "Awaiting approval",
-                  value: JobStatus.WaitingApproval,
-                  icon: <ExclamationCircleOutlined style={{ color: "#fa8f37" }} />,
-                },
-                {
-                  label: "Failed",
-                  value: JobStatus.Failed,
-                  icon: <StopOutlined style={{ color: "#FB0136" }} />,
-                },
-                {
-                  label: "Rejected",
-                  value: JobStatus.Rejected,
-                  icon: <CloseCircleOutlined style={{ color: "#FB0136" }} />,
-                },
-                {
-                  label: "Running",
-                  value: JobStatus.Running,
-                  icon: <SyncOutlined style={{ color: "#108ee9" }} />,
-                },
-                {
-                  label: "Completed",
-                  value: JobStatus.Completed,
-                  icon: <CheckCircleOutlined style={{ color: "#2eb039" }} />,
-                },
-                {
-                  label: "Never Executed",
-                  value: Additional.NeverExecuted,
-                  icon: <InfoCircleOutlined />,
-                },
-              ]}
-            />
-          </div>
-        </Col>
+  const [isTagsPopoverOpen, setIsTagsPopoverOpen] = useState(false);
+  const [tempTagRows, setTempTagRows] = useState<{ key: string; value: string }[]>([{ key: "", value: "" }]);
 
-        <Col span={24} xxl={8}>
-          <Flex gap="middle">
-            <Select
-              mode="multiple"
-              showSearch
-              optionFilterProp="children"
-              allowClear
-              style={{ width: "100%" }}
-              placeholder="Search by tag"
-              options={options}
-              maxTagCount="responsive"
-              loading={loading}
-              onChange={setTagsFilter}
-              filterOption={(input, option) => (option?.label ?? "").toLowerCase().includes(input.toLowerCase())}
-              filterSort={(optionA, optionB) =>
-                (optionA?.label ?? "").toLowerCase().localeCompare((optionB?.label ?? "").toLowerCase())
-              }
-            />
-            <Input.Search
-              placeholder="Search by name, description"
-              value={searchFilter}
-              onChange={(e) => setSearchFilter(e.target.value)}
-              onSearch={() => filterItems()}
-              onClear={() => {
-                filterItems(true);
-              }}
-              allowClear
-            />
-          </Flex>
-        </Col>
-      </Row>
-      <Row style={{ marginTop: "5px" }}>
-        <Col span={24} xl={8}>
+  const handleOpenChange = (newOpen: boolean) => {
+    if (newOpen) {
+      if (tagsFilter.length > 0) {
+        setTempTagRows(tagsFilter.map((tagId) => ({ key: tagId, value: "" })));
+      } else {
+        setTempTagRows([{ key: "", value: "" }]);
+      }
+    }
+    setIsTagsPopoverOpen(newOpen);
+  };
+
+  const handleApplyTags = () => {
+    const validTags = tempTagRows.map((r) => r.key).filter((k) => k);
+    setTagsFilter(validTags);
+    setIsTagsPopoverOpen(false);
+  };
+
+  const handleCancelTags = () => {
+    setIsTagsPopoverOpen(false);
+  };
+
+  const addFilterRow = () => {
+    setTempTagRows([...tempTagRows, { key: "", value: "" }]);
+  };
+
+  const removeFilterRow = (index: number) => {
+    const newRows = [...tempTagRows];
+    newRows.splice(index, 1);
+    setTempTagRows(newRows);
+  };
+
+  const updateFilterRow = (index: number, field: "key" | "value", val: string) => {
+    const newRows = [...tempTagRows];
+    newRows[index] = { ...newRows[index], [field]: val };
+    setTempTagRows(newRows);
+  };
+
+  const tagsContent = (
+    <div className="filter-popover-content">
+      <div className="filter-popover-header">
+        <Row gutter={12}>
+          <Col span={11}>Tag key</Col>
+          <Col span={11}>Tag value (Optional)</Col>
+          <Col span={2}></Col>
+        </Row>
+      </div>
+      {tempTagRows.map((row, index) => (
+        <div key={index} className="filter-row">
           <Select
-            prefix={<span style={{ marginRight: "5px" }}>Sort by:</span>}
-            options={WORKSPACE_SORT_OPTIONS}
+            showSearch
+            placeholder="Select tag"
+            optionFilterProp="children"
+            options={options}
+            value={row.key || undefined}
+            onChange={(val) => updateFilterRow(index, "key", val)}
+            filterOption={(input, option) => (option?.label ?? "").toLowerCase().includes(input.toLowerCase())}
+            style={{ width: "45%" }}
+          />
+          <Input
+            placeholder="Value"
+            value={row.value}
+            onChange={(e) => updateFilterRow(index, "value", e.target.value)}
+            style={{ width: "45%" }}
+          />
+          {tempTagRows.length > 1 && (
+            <DeleteOutlined className="filter-row-remove" onClick={() => removeFilterRow(index)} />
+          )}
+        </div>
+      ))}
+      <button type="button" className="add-filter-btn" onClick={addFilterRow}>
+        <PlusOutlined /> Filter by another tag
+      </button>
+      <div className="filter-footer">
+        <Button onClick={handleCancelTags}>Cancel</Button>
+        <Button type="primary" onClick={handleApplyTags}>
+          Apply Filter
+        </Button>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="workspace-filter-container">
+      {/* Top row: Search */}
+      <div className="workspace-filter-search-row">
+        <Input.Search
+          placeholder="Search by name..."
+          value={searchFilter}
+          onChange={(e) => setSearchFilter(e.target.value)}
+          onSearch={() => filterItems()}
+          allowClear
+          className="workspace-search-input"
+        />
+      </div>
+
+      {/* Bottom row: Status (left) | Tags + Sort (right) */}
+      <div className="workspace-filter-bar">
+        <div className="workspace-filter-left">
+          <Segmented
+            onChange={setStatusFilter}
+            value={statusFilter}
+            options={[
+              {
+                label: "All",
+                value: Additional.All,
+                icon: <BarsOutlined />,
+              },
+              {
+                label: "Awaiting approval",
+                value: JobStatus.WaitingApproval,
+                icon: <ExclamationCircleOutlined style={{ color: "#fa8f37" }} />,
+              },
+              {
+                label: "Failed",
+                value: JobStatus.Failed,
+                icon: <StopOutlined style={{ color: "#FB0136" }} />,
+              },
+              {
+                label: "Running",
+                value: JobStatus.Running,
+                icon: <SyncOutlined style={{ color: "#108ee9" }} />,
+              },
+              {
+                label: "Completed",
+                value: JobStatus.Completed,
+                icon: <CheckCircleOutlined style={{ color: "#2eb039" }} />,
+              },
+              {
+                label: "Never Executed",
+                value: Additional.NeverExecuted,
+                icon: <InfoCircleOutlined />,
+              },
+            ]}
+          />
+        </div>
+
+        <div className="workspace-filter-right">
+          <Popover
+            content={tagsContent}
+            trigger="click"
+            open={isTagsPopoverOpen}
+            onOpenChange={handleOpenChange}
+            placement="bottomRight"
+            overlayClassName="workspace-filter-popover"
+          >
+            <Button className={`filter-button ${tagsFilter.length > 0 ? "active" : ""}`}>
+              Tags
+              {tagsFilter.length > 0 && <Badge count={tagsFilter.length} style={{ backgroundColor: "#52c41a" }} />}
+              <DownOutlined />
+            </Button>
+          </Popover>
+          <Select
             value={sortOption}
             onChange={onSortChange}
-            style={{ minWidth: 220 }}
+            options={WORKSPACE_SORT_OPTIONS}
+            className="workspace-sort-select"
             placeholder="Sort by"
           />
-        </Col>
-      </Row>
-    </Card>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/ui/src/styles/global.css
+++ b/ui/src/styles/global.css
@@ -1,0 +1,476 @@
+/* Premium Dark Theme Implementation */
+/* Requires variables.css to be imported first */
+
+/* ==========================================================================
+   Base Styles & Typography
+   ========================================================================== */
+
+[data-theme="dark"] body {
+  background-color: var(--tk-bg-base);
+  color: var(--tk-text-primary);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+[data-theme="dark"] a {
+  color: #58a6ff;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+[data-theme="dark"] a:hover {
+  color: #79c0ff;
+  text-decoration: underline;
+}
+
+[data-theme="dark"] code,
+[data-theme="dark"] pre {
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    SF Mono,
+    Menlo,
+    Consolas,
+    Liberation Mono,
+    monospace;
+  background-color: rgba(110, 118, 129, 0.4);
+  border-radius: 6px;
+  padding: 0.2em 0.4em;
+  font-size: 85%;
+}
+
+[data-theme="dark"] pre {
+  padding: 16px;
+  overflow: auto;
+  background-color: var(--tk-bg-container);
+  border: 1px solid var(--tk-border-primary);
+}
+
+[data-theme="dark"] pre code {
+  background-color: transparent;
+  padding: 0;
+  font-size: 100%;
+  color: var(--tk-text-primary);
+}
+
+/* ==========================================================================
+   Scrollbars (Premium Look)
+   ========================================================================== */
+
+[data-theme="dark"] ::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-track {
+  background: var(--tk-scrollbar-track);
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-thumb {
+  background: var(--tk-scrollbar-thumb);
+  border-radius: 4px;
+  border: 2px solid var(--tk-scrollbar-track); /* Creates padding effect */
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
+  background: var(--tk-scrollbar-thumb-hover);
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-corner {
+  background: var(--tk-scrollbar-track);
+}
+
+/* ==========================================================================
+   Ant Design Component Overrides
+   ========================================================================== */
+
+/* --- Layout & Containers --- */
+
+[data-theme="dark"] .ant-layout {
+  background: var(--tk-bg-layout);
+}
+
+[data-theme="dark"] .ant-layout-header {
+  background: var(--tk-bg-container);
+  border-bottom: 1px solid var(--tk-border-primary);
+  box-shadow: 0 1px 0 rgba(27, 31, 35, 0.04);
+}
+
+[data-theme="dark"] .ant-layout-sider {
+  background: var(--tk-bg-container);
+  border-right: 1px solid var(--tk-border-primary);
+}
+
+[data-theme="dark"] .ant-card {
+  background: var(--tk-bg-container);
+  border: 1px solid var(--tk-border-primary);
+  border-radius: 8px;
+  box-shadow: var(--tk-shadow-sm);
+  transition: all 0.2s ease;
+}
+
+[data-theme="dark"] .ant-card-head {
+  border-bottom: 1px solid var(--tk-border-primary);
+  background: linear-gradient(to bottom, var(--tk-bg-elevated), var(--tk-bg-container));
+  min-height: 48px;
+}
+
+[data-theme="dark"] .ant-card-head-title {
+  color: var(--tk-text-primary);
+  font-weight: 600;
+}
+
+/* --- Navigation --- */
+
+[data-theme="dark"] .ant-menu {
+  background: transparent;
+  color: var(--tk-text-secondary);
+  border-right: none;
+}
+
+[data-theme="dark"] .ant-menu-item,
+[data-theme="dark"] .ant-menu-submenu-title {
+  color: var(--tk-text-secondary);
+  border-radius: 6px;
+  margin-bottom: 4px;
+}
+
+[data-theme="dark"] .ant-menu-item:hover,
+[data-theme="dark"] .ant-menu-submenu-title:hover {
+  color: var(--tk-text-primary);
+  background-color: var(--tk-fill-primary);
+}
+
+[data-theme="dark"] .ant-menu-item-selected {
+  background-color: var(--tk-fill-secondary);
+  color: var(--tk-text-primary);
+  font-weight: 500;
+  position: relative;
+}
+
+[data-theme="dark"] .ant-menu-item-selected::after {
+  border-right: 3px solid #58a6ff; /* Accent indicator */
+}
+
+/* --- Inputs & Forms --- */
+
+[data-theme="dark"] .ant-input,
+[data-theme="dark"] .ant-input-number,
+[data-theme="dark"] .ant-input-password,
+[data-theme="dark"] .ant-input-affix-wrapper,
+[data-theme="dark"] .ant-input-textarea,
+[data-theme="dark"] textarea.ant-input,
+[data-theme="dark"] .ant-select-selector,
+[data-theme="dark"] .ant-picker {
+  background-color: var(--tk-bg-base) !important;
+  border-color: var(--tk-border-primary) !important;
+  color: var(--tk-text-primary) !important;
+  border-radius: 6px;
+  transition: all 0.2s ease;
+}
+
+[data-theme="dark"] .ant-input::placeholder,
+[data-theme="dark"] .ant-input-textarea textarea::placeholder,
+[data-theme="dark"] textarea.ant-input::placeholder {
+  color: var(--tk-text-tertiary) !important;
+  opacity: 1;
+}
+
+[data-theme="dark"] .ant-input:hover,
+[data-theme="dark"] .ant-select-selector:hover {
+  border-color: #8b949e !important;
+}
+
+[data-theme="dark"] .ant-input:focus,
+[data-theme="dark"] .ant-input-focused,
+[data-theme="dark"] .ant-select-focused .ant-select-selector {
+  border-color: #58a6ff !important;
+  box-shadow: 0 0 0 2px rgba(88, 166, 255, 0.3) !important; /* Blue glow */
+}
+
+[data-theme="dark"] .ant-input-group-addon {
+  background-color: var(--tk-bg-elevated);
+  border-color: var(--tk-border-primary);
+  color: var(--tk-text-secondary);
+}
+
+/* --- Buttons --- */
+
+[data-theme="dark"] .ant-btn {
+  border-radius: 6px;
+  box-shadow: var(--tk-shadow-sm);
+  transition: all 0.2s cubic-bezier(0.3, 0, 0.5, 1);
+}
+
+[data-theme="dark"] .ant-btn-default {
+  background-color: var(--tk-bg-elevated);
+  border-color: var(--tk-border-primary);
+  color: var(--tk-text-primary);
+}
+
+[data-theme="dark"] .ant-btn-default:hover {
+  background-color: var(--tk-fill-secondary);
+  border-color: #8b949e;
+  color: #fff;
+}
+
+[data-theme="dark"] .ant-btn-primary {
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.1);
+}
+
+/* --- Tables --- */
+
+[data-theme="dark"] .ant-table {
+  background: var(--tk-bg-container);
+  color: var(--tk-text-primary);
+  border-radius: 8px;
+  border: 1px solid var(--tk-border-primary);
+  overflow: hidden;
+}
+
+[data-theme="dark"] .ant-table-thead > tr > th {
+  background: var(--tk-bg-elevated);
+  border-bottom: 1px solid var(--tk-border-primary);
+  color: var(--tk-text-secondary);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .ant-table-tbody > tr > td {
+  border-bottom: 1px solid var(--tk-border-secondary);
+  transition: background 0.2s;
+}
+
+[data-theme="dark"] .ant-table-tbody > tr:hover > td {
+  background: var(--tk-fill-primary) !important;
+}
+
+[data-theme="dark"] .ant-table-tbody > tr.ant-table-row-selected > td {
+  background: rgba(56, 139, 253, 0.1); /* Subtle blue tint */
+}
+
+/* --- Modals & Drawers (Glassmorphism) --- */
+
+[data-theme="dark"] .ant-modal-content,
+[data-theme="dark"] .ant-drawer-content {
+  background-color: var(--tk-bg-elevated);
+  border: 1px solid var(--tk-border-primary);
+  box-shadow: var(--tk-shadow-lg);
+}
+
+/* Premium Glass Effect for Modals */
+[data-theme="dark"] .ant-modal-content {
+  background: var(--tk-glass-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--tk-glass-border);
+}
+
+[data-theme="dark"] .ant-modal-header {
+  background: transparent;
+  border-bottom: 1px solid var(--tk-border-primary);
+}
+
+[data-theme="dark"] .ant-modal-title {
+  color: var(--tk-text-primary);
+}
+
+[data-theme="dark"] .ant-modal-close {
+  color: var(--tk-text-secondary);
+}
+
+[data-theme="dark"] .ant-modal-close:hover {
+  color: var(--tk-text-primary);
+  background-color: var(--tk-fill-secondary);
+}
+
+/* --- Dropdowns & Popovers --- */
+
+[data-theme="dark"] .ant-dropdown-menu,
+[data-theme="dark"] .ant-popover-inner {
+  background-color: var(--tk-bg-elevated);
+  border: 1px solid var(--tk-border-primary);
+  box-shadow: var(--tk-shadow-lg);
+  border-radius: 8px;
+}
+
+[data-theme="dark"] .ant-dropdown-menu-item {
+  color: var(--tk-text-primary);
+  border-radius: 4px;
+}
+
+[data-theme="dark"] .ant-dropdown-menu-item:hover {
+  background-color: #1f6feb; /* GitHub blue hover */
+  color: #ffffff;
+}
+
+[data-theme="dark"] .ant-popover-title {
+  color: var(--tk-text-primary);
+  border-bottom: 1px solid var(--tk-border-primary);
+}
+
+/* --- Tabs --- */
+
+[data-theme="dark"] .ant-tabs-tab {
+  color: var(--tk-text-secondary);
+  transition: color 0.2s;
+}
+
+[data-theme="dark"] .ant-tabs-tab:hover {
+  color: var(--tk-text-primary);
+}
+
+[data-theme="dark"] .ant-tabs-tab.ant-tabs-tab-active .ant-tabs-tab-btn {
+  color: var(--tk-text-primary);
+  font-weight: 500;
+}
+
+[data-theme="dark"] .ant-tabs-ink-bar {
+  background: #f78166; /* Orange accent like GitHub actions or use primary */
+}
+
+/* --- Tags & Badges --- */
+
+[data-theme="dark"] .ant-tag {
+  background: var(--tk-fill-primary) !important;
+  border-color: var(--tk-border-primary) !important;
+  color: var(--tk-text-primary) !important;
+  border-radius: 2em; /* Pill shape */
+}
+
+[data-theme="dark"] .ant-tag-default,
+[data-theme="dark"] .ant-tag:not([class*="ant-tag-"]):not([class*="color"]) {
+  background: var(--tk-fill-primary) !important;
+  border-color: var(--tk-border-primary) !important;
+  color: var(--tk-text-secondary) !important;
+}
+
+[data-theme="dark"] .ant-tag-blue {
+  background: rgba(56, 139, 253, 0.15);
+  border-color: rgba(56, 139, 253, 0.4);
+  color: #58a6ff;
+}
+
+[data-theme="dark"] .ant-tag-green {
+  background: rgba(46, 160, 67, 0.15);
+  border-color: rgba(46, 160, 67, 0.4);
+  color: #3fb950;
+}
+
+[data-theme="dark"] .ant-tag-red {
+  background: rgba(248, 81, 73, 0.15);
+  border-color: rgba(248, 81, 73, 0.4);
+  color: #f85149;
+}
+
+/* --- Alerts & Notifications --- */
+
+[data-theme="dark"] .ant-alert {
+  background-color: var(--tk-bg-elevated);
+  border: 1px solid var(--tk-border-primary);
+}
+
+[data-theme="dark"] .ant-alert-info {
+  background-color: rgba(56, 139, 253, 0.1);
+  border-color: rgba(56, 139, 253, 0.4);
+}
+
+[data-theme="dark"] .ant-alert-success {
+  background-color: rgba(46, 160, 67, 0.1);
+  border-color: rgba(46, 160, 67, 0.4);
+}
+
+[data-theme="dark"] .ant-alert-warning {
+  background-color: rgba(210, 153, 34, 0.1);
+  border-color: rgba(210, 153, 34, 0.4);
+}
+
+[data-theme="dark"] .ant-alert-error {
+  background-color: rgba(248, 81, 73, 0.1);
+  border-color: rgba(248, 81, 73, 0.4);
+}
+
+[data-theme="dark"] .ant-notification-notice {
+  background: var(--tk-bg-elevated);
+  border: 1px solid var(--tk-border-primary);
+  box-shadow: var(--tk-shadow-lg);
+}
+
+[data-theme="dark"] .ant-notification-notice-message {
+  color: var(--tk-text-primary);
+}
+
+[data-theme="dark"] .ant-notification-notice-description {
+  color: var(--tk-text-secondary);
+}
+
+/* --- Tooltips --- */
+
+[data-theme="dark"] .ant-tooltip-inner {
+  background-color: #6e7681;
+  color: #ffffff;
+  box-shadow: var(--tk-shadow-md);
+}
+
+[data-theme="dark"] .ant-tooltip-arrow-content {
+  background-color: #6e7681;
+}
+
+/* --- Spinners --- */
+
+[data-theme="dark"] .ant-spin-dot-item {
+  background-color: #58a6ff;
+}
+
+/* --- Empty State --- */
+
+[data-theme="dark"] .ant-empty-description {
+  color: var(--tk-text-secondary);
+}
+
+/* --- Divider --- */
+
+[data-theme="dark"] .ant-divider {
+  border-top-color: var(--tk-border-primary);
+  color: var(--tk-text-secondary);
+}
+
+/* --- Steps --- */
+
+[data-theme="dark"] .ant-steps-item-title {
+  color: var(--tk-text-primary) !important;
+}
+
+[data-theme="dark"] .ant-steps-item-description {
+  color: var(--tk-text-secondary) !important;
+}
+
+[data-theme="dark"] .ant-steps-item-wait .ant-steps-item-icon {
+  background-color: var(--tk-bg-container);
+  border-color: var(--tk-border-secondary);
+}
+
+[data-theme="dark"] .ant-steps-item-process .ant-steps-item-icon {
+  background-color: #1f6feb;
+  border-color: #1f6feb;
+}
+
+/* --- Premium Glow Effects (Specific Components) --- */
+
+/* Add a subtle glow to primary buttons on hover */
+[data-theme="dark"] .ant-btn-primary:hover {
+  box-shadow: 0 0 12px rgba(88, 166, 255, 0.4);
+}
+
+/* Add a subtle glow to active inputs */
+[data-theme="dark"] .ant-input:focus,
+[data-theme="dark"] .ant-select-focused .ant-select-selector {
+  box-shadow:
+    0 0 0 2px rgba(88, 166, 255, 0.2),
+    0 0 8px rgba(88, 166, 255, 0.1) !important;
+}
+
+/* Card hover effect */
+[data-theme="dark"] .ant-card:hover {
+  border-color: #8b949e;
+  box-shadow: var(--tk-shadow-md);
+}

--- a/ui/src/styles/variables.css
+++ b/ui/src/styles/variables.css
@@ -1,0 +1,69 @@
+:root {
+  /* Light Theme (Default) */
+  --tk-bg-base: #ffffff;
+  --tk-bg-container: #ffffff;
+  --tk-bg-elevated: #ffffff;
+  --tk-bg-layout: #f0f2f5;
+  --tk-bg-spotlight: #000000;
+
+  --tk-border-primary: #d9d9d9;
+  --tk-border-secondary: #f0f0f0;
+
+  --tk-text-primary: rgba(0, 0, 0, 0.88);
+  --tk-text-secondary: rgba(0, 0, 0, 0.65);
+  --tk-text-tertiary: rgba(0, 0, 0, 0.45);
+  --tk-text-quaternary: rgba(0, 0, 0, 0.25);
+
+  --tk-fill-primary: #f5f5f5;
+  --tk-fill-secondary: #fafafa;
+
+  --tk-accent-glow: rgba(24, 144, 255, 0.2);
+  --tk-glass-bg: rgba(255, 255, 255, 0.9);
+  --tk-glass-border: rgba(255, 255, 255, 0.3);
+
+  --tk-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --tk-shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --tk-shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+}
+
+[data-theme="dark"] {
+  /* Dark Theme - Premium Palette */
+  /* Backgrounds - rich dark, not pure black */
+  --tk-bg-base: #0d1117;
+  --tk-bg-container: #161b22;
+  --tk-bg-elevated: #1c2128;
+  --tk-bg-layout: #0d1117;
+  --tk-bg-spotlight: #21262d;
+
+  /* Borders - subtle but visible */
+  --tk-border-primary: #30363d;
+  --tk-border-secondary: #21262d;
+
+  /* Text - high contrast */
+  --tk-text-primary: #e6edf3;
+  --tk-text-secondary: #8b949e;
+  --tk-text-tertiary: #6e7681;
+  --tk-text-quaternary: #484f58;
+
+  /* Fill colors */
+  --tk-fill-primary: #21262d;
+  --tk-fill-secondary: #30363d;
+  --tk-fill-tertiary: #161b22;
+  --tk-fill-quaternary: #0d1117;
+
+  /* Premium Effects */
+  --tk-accent-glow: rgba(94, 106, 210, 0.3); /* Linear-inspired purple */
+  --tk-glass-bg: rgba(28, 33, 40, 0.85);
+  --tk-glass-border: rgba(255, 255, 255, 0.08);
+
+  /* Shadows */
+  --tk-shadow-sm: 0 1px 0 rgba(27, 31, 35, 0.04);
+  --tk-shadow-md: 0 3px 6px rgba(140, 149, 159, 0.15);
+  --tk-shadow-lg: 0 8px 24px rgba(140, 149, 159, 0.2);
+  --tk-shadow-glow: 0 0 0 2px var(--tk-accent-glow);
+
+  /* Scrollbars */
+  --tk-scrollbar-track: #161b22;
+  --tk-scrollbar-thumb: #30363d;
+  --tk-scrollbar-thumb-hover: #484f58;
+}

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -22,6 +22,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
     "paths": {
+      "@/*": ["./src/*"],
       "@/modules/*": ["./src/modules/*"]
     }
   },

--- a/ui/vite.config.mts
+++ b/ui/vite.config.mts
@@ -3,6 +3,8 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import commonjs from "vite-plugin-commonjs";
 import tsconfigPaths from "vite-tsconfig-paths";
+
+
 export default defineConfig(() => {
   return {
     server: {
@@ -15,7 +17,20 @@ export default defineConfig(() => {
       rollupOptions: {
         output: {
           manualChunks: function (id) {
-            if (id.includes("react-icons")) return "icons";
+            if (id.includes('node_modules')) {
+              if (id.includes('react-icons')) return 'icons';
+              if (id.includes('antd')) return 'antd';
+              if (id.includes('@monaco-editor/react')) return 'monaco';
+              if (id.includes('reactflow')) return 'reactflow';
+              if (id.includes('react-vis')) return 'charts';
+              if (id.includes('react/') || id.includes('react-dom') || id.includes('react-router-dom')) return 'vendor';
+              // Markdown ecosystem
+              if (id.includes('react-markdown') || id.includes('remark-') || id.includes('rehype-') || id.includes('unified') || id.includes('mdast') || id.includes('hast')) return 'markdown';
+              // HCL parser
+              if (id.includes('hcl2-parser')) return 'hcl-parser';
+              // Unzipit
+              if (id.includes('unzipit')) return 'unzipit';
+            }
           },
         },
       },
@@ -25,6 +40,7 @@ export default defineConfig(() => {
       commonjs(),
       // Ensure path aliases are loaded from tsconfig.app.json where the paths are defined
       tsconfigPaths({ projects: ["./tsconfig.app.json"] }),
+
     ],
     rollup: {
       plugins: [dynamicImportVars()],

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -16,7 +16,7 @@
 
 "@ant-design/cssinjs-utils@^2.1.1":
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@ant-design/cssinjs-utils/-/cssinjs-utils-2.1.1.tgz#c70d86206204e882073a0fe4969a5ddf154c6915"
+  resolved "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-2.1.1.tgz"
   integrity sha512-RKxkj5pGFB+FkPJ5NGhoX3DK3xsv0pMltha7Ei1AnY3tILeq38L7tuhaWDPQI/5nlPxOog44wvqpNyyGcUsNMg==
   dependencies:
     "@ant-design/cssinjs" "^2.1.0"
@@ -25,7 +25,7 @@
 
 "@ant-design/cssinjs@^2.1.0":
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@ant-design/cssinjs/-/cssinjs-2.1.0.tgz#081394937f86aefe55e35198019d0483f405a484"
+  resolved "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-2.1.0.tgz"
   integrity sha512-eZFrPCnrYrF3XtL7qA4L75P0qA3TtZta8H3Yggy7UYFh8gZgu5bSMNF+v4UVCzGxzYmx8ZvPdgOce0BJ6PsW9g==
   dependencies:
     "@babel/runtime" "^7.11.1"
@@ -1159,7 +1159,7 @@
 
 "@esbuild/linux-x64@0.27.1":
   version "0.27.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.27.1.tgz#09c771de9e2d8169d5969adf298ae21581f08c7f"
+  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.1.tgz"
   integrity sha512-z3H/HYI9MM0HTv3hQZ81f+AKb+yEoCRlUby1F80vbQ5XdzEMyY/9iNlAmhqiBKw4MJXwfgsh7ERGEOhrM1niMA==
 
 "@esbuild/netbsd-arm64@0.27.1":
@@ -1314,11 +1314,6 @@
     strip-ansi-cjs "npm:strip-ansi@^6.0.1"
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
-
-"@isaacs/cliui@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-9.0.0.tgz#4d0a3f127058043bf2e7ee169eaf30ed901302f3"
-  integrity sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -1681,7 +1676,7 @@
 
 "@rc-component/cascader@~1.14.0":
   version "1.14.0"
-  resolved "https://registry.yarnpkg.com/@rc-component/cascader/-/cascader-1.14.0.tgz#74e1fca58cb14f8f75f6e4bf1debd90534aaea7c"
+  resolved "https://registry.npmjs.org/@rc-component/cascader/-/cascader-1.14.0.tgz"
   integrity sha512-Ip9356xwZUR2nbW5PRVGif4B/bDve4pLa/N+PGbvBaTnjbvmN4PFMBGQSmlDlzKP1ovxaYMvwF/dI9lXNLT4iQ==
   dependencies:
     "@rc-component/select" "~1.6.0"
@@ -1691,7 +1686,7 @@
 
 "@rc-component/checkbox@~2.0.0":
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@rc-component/checkbox/-/checkbox-2.0.0.tgz#90e0b30c276e507a5ab9942f626fe4572f5e4ff9"
+  resolved "https://registry.npmjs.org/@rc-component/checkbox/-/checkbox-2.0.0.tgz"
   integrity sha512-3CXGPpAR9gsPKeO2N78HAPOzU30UdemD6HGJoWVJOpa6WleaGB5kzZj3v6bdTZab31YuWgY/RxV3VKPctn0DwQ==
   dependencies:
     "@rc-component/util" "^1.3.0"
@@ -1709,7 +1704,7 @@
 
 "@rc-component/color-picker@~3.1.0":
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@rc-component/color-picker/-/color-picker-3.1.0.tgz#437586ea2fc27862e7429a754cf85e519e05f461"
+  resolved "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-3.1.0.tgz"
   integrity sha512-o7Vavj7yyfVxFmeynXf0fCHVlC0UTE9al74c6nYuLck+gjuVdQNWSVXR8Efq/mmWFy7891SCOsfaPq6Eqe1s/g==
   dependencies:
     "@ant-design/fast-color" "^3.0.0"
@@ -1818,10 +1813,10 @@
   dependencies:
     "@babel/runtime" "^7.18.0"
 
-"@rc-component/motion@^1.0.0", "@rc-component/motion@^1.1.3", "@rc-component/motion@^1.1.4", "@rc-component/motion@~1.1.6":
-  version "1.1.6"
-  resolved "https://registry.npmjs.org/@rc-component/motion/-/motion-1.1.6.tgz"
-  integrity sha512-aEQobs/YA0kqRvHIPjQvOytdtdRVyhf/uXAal4chBjxDu6odHckExJzjn2D+Ju1aKK6hx3pAs6BXdV9+86xkgQ==
+"@rc-component/motion@^1.0.0", "@rc-component/motion@^1.1.3", "@rc-component/motion@^1.1.4", "@rc-component/motion@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/@rc-component/motion/-/motion-1.3.1.tgz"
+  integrity sha512-Wo1mkd0tCcHtvYvpPOmlYJz546z16qlsiwaygmW7NPJpOZOF9GBjhGzdzZSsC2lEJ1IUkWLF4gMHlRA1aSA+Yw==
   dependencies:
     "@rc-component/util" "^1.2.0"
     clsx "^2.1.1"
@@ -1919,10 +1914,10 @@
     "@rc-component/util" "^1.3.0"
     clsx "^2.1.1"
 
-"@rc-component/select@~1.6.0", "@rc-component/select@~1.6.5":
-  version "1.6.10"
-  resolved "https://registry.yarnpkg.com/@rc-component/select/-/select-1.6.10.tgz#a8983b33b48ca7122ce67411080f21b8f3b8ec54"
-  integrity sha512-y4+2LnyGZrAorIBwflk78PmFVUWcSc9pcljiH72oHj7K1YY/BFUmj224pD7P4o7J+tbIFES45Z7LIpjVmvYlNA==
+"@rc-component/select@~1.6.0", "@rc-component/select@~1.6.12":
+  version "1.6.12"
+  resolved "https://registry.npmjs.org/@rc-component/select/-/select-1.6.12.tgz"
+  integrity sha512-jYXAglYdOb54BrpWAcjjhdBP16NyCv/HbEaWFMbEHZQAJVmGHPAtmBqbFuPPuvInAVsIwLbCj4Agag9udOamiQ==
   dependencies:
     "@rc-component/overflow" "^1.0.0"
     "@rc-component/trigger" "^3.0.0"
@@ -2008,7 +2003,7 @@
 
 "@rc-component/tree-select@~1.8.0":
   version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@rc-component/tree-select/-/tree-select-1.8.0.tgz#480e84221befbd1fa93ab2034423e2b064e41981"
+  resolved "https://registry.npmjs.org/@rc-component/tree-select/-/tree-select-1.8.0.tgz"
   integrity sha512-iYsPq3nuLYvGqdvFAW+l+I9ASRIOVbMXyA8FGZg2lGym/GwkaWeJGzI4eJ7c9IOEhRj0oyfIN4S92Fl3J05mjQ==
   dependencies:
     "@rc-component/select" "~1.6.0"
@@ -2018,7 +2013,7 @@
 
 "@rc-component/tree@~1.2.0", "@rc-component/tree@~1.2.3":
   version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@rc-component/tree/-/tree-1.2.3.tgz#a70ae847a768763f4f461375620c1feccfcc933a"
+  resolved "https://registry.npmjs.org/@rc-component/tree/-/tree-1.2.3.tgz"
   integrity sha512-mG8hF2ogQcKaEpfyxzPvMWqqkptofd7Sf+YiXOpPzuXLTLwNKfLDJtysc1/oybopbnzxNqWh2Vgwi+GYwNIb7w==
   dependencies:
     "@rc-component/motion" "^1.0.0"
@@ -2131,7 +2126,7 @@
 
 "@rolldown/pluginutils@1.0.0-rc.3":
   version "1.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz#8a88cc92a0f741befc7bc109cb1a4c6b9408e1c5"
+  resolved "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz"
   integrity sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==
 
 "@rollup/plugin-dynamic-import-vars@^2.1.5":
@@ -2231,12 +2226,12 @@
 
 "@rollup/rollup-linux-x64-gnu@4.46.2":
   version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.2.tgz#1e936446f90b2574ea4a83b4842a762cc0a0aed3"
+  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.2.tgz"
   integrity sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==
 
 "@rollup/rollup-linux-x64-musl@4.46.2":
   version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.2.tgz#c6f304dfba1d5faf2be5d8b153ccbd8b5d6f1166"
+  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.2.tgz"
   integrity sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==
 
 "@rollup/rollup-win32-arm64-msvc@4.46.2":
@@ -2699,7 +2694,7 @@
 
 "@types/node@*", "@types/node@^25.3.0":
   version "25.3.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.3.0.tgz#749b1bd4058e51b72e22bd41e9eab6ebd0180470"
+  resolved "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz"
   integrity sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==
   dependencies:
     undici-types "~7.18.0"
@@ -2716,16 +2711,9 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "19.2.13"
-  resolved "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz"
-  integrity sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==
-  dependencies:
-    csstype "^3.2.2"
-
-"@types/react@^19.2.14":
+"@types/react@*", "@types/react@^19.2.14":
   version "19.2.14"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.14.tgz#39604929b5e3957e3a6fa0001dafb17c7af70bad"
+  resolved "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz"
   integrity sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==
   dependencies:
     csstype "^3.2.2"
@@ -2762,34 +2750,23 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@8.56.0", "@typescript-eslint/eslint-plugin@^8.51.0":
-  version "8.56.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz#5aec3db807a6b8437ea5d5ebf7bd16b4119aba8d"
-  integrity sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==
+"@typescript-eslint/eslint-plugin@8.56.1", "@typescript-eslint/eslint-plugin@^8.51.0":
+  version "8.56.1"
+  resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz"
+  integrity sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==
   dependencies:
     "@eslint-community/regexpp" "^4.12.2"
-    "@typescript-eslint/scope-manager" "8.56.0"
-    "@typescript-eslint/type-utils" "8.56.0"
-    "@typescript-eslint/utils" "8.56.0"
-    "@typescript-eslint/visitor-keys" "8.56.0"
+    "@typescript-eslint/scope-manager" "8.56.1"
+    "@typescript-eslint/type-utils" "8.56.1"
+    "@typescript-eslint/utils" "8.56.1"
+    "@typescript-eslint/visitor-keys" "8.56.1"
     ignore "^7.0.5"
     natural-compare "^1.4.0"
     ts-api-utils "^2.4.0"
 
-"@typescript-eslint/parser@8.56.0":
-  version "8.56.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.56.0.tgz#8ecff1678b8b1a742d29c446ccf5eeea7f971d72"
-  integrity sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==
-  dependencies:
-    "@typescript-eslint/scope-manager" "8.56.0"
-    "@typescript-eslint/types" "8.56.0"
-    "@typescript-eslint/typescript-estree" "8.56.0"
-    "@typescript-eslint/visitor-keys" "8.56.0"
-    debug "^4.4.3"
-
-"@typescript-eslint/parser@^8.56.1":
+"@typescript-eslint/parser@8.56.1", "@typescript-eslint/parser@^8.56.1":
   version "8.56.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.56.1.tgz#21d13b3d456ffb08614c1d68bb9a4f8d9237cdc7"
+  resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz"
   integrity sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==
   dependencies:
     "@typescript-eslint/scope-manager" "8.56.1"
@@ -2798,89 +2775,47 @@
     "@typescript-eslint/visitor-keys" "8.56.1"
     debug "^4.4.3"
 
-"@typescript-eslint/project-service@8.56.0":
-  version "8.56.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.56.0.tgz#bb8562fecd8f7922e676fc6a1189c20dd7991d73"
-  integrity sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==
-  dependencies:
-    "@typescript-eslint/tsconfig-utils" "^8.56.0"
-    "@typescript-eslint/types" "^8.56.0"
-    debug "^4.4.3"
-
 "@typescript-eslint/project-service@8.56.1":
   version "8.56.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.56.1.tgz#65c8d645f028b927bfc4928593b54e2ecd809244"
+  resolved "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz"
   integrity sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==
   dependencies:
     "@typescript-eslint/tsconfig-utils" "^8.56.1"
     "@typescript-eslint/types" "^8.56.1"
     debug "^4.4.3"
 
-"@typescript-eslint/scope-manager@8.56.0":
-  version "8.56.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz#604030a4c6433df3728effdd441d47f45a86edb4"
-  integrity sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==
-  dependencies:
-    "@typescript-eslint/types" "8.56.0"
-    "@typescript-eslint/visitor-keys" "8.56.0"
-
 "@typescript-eslint/scope-manager@8.56.1":
   version "8.56.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz#254df93b5789a871351335dd23e20bc164060f24"
+  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz"
   integrity sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==
   dependencies:
     "@typescript-eslint/types" "8.56.1"
     "@typescript-eslint/visitor-keys" "8.56.1"
 
-"@typescript-eslint/tsconfig-utils@8.56.0", "@typescript-eslint/tsconfig-utils@^8.56.0":
-  version "8.56.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.0.tgz#2538ce83cbc376e685487960cbb24b65fe2abc4e"
-  integrity sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==
-
 "@typescript-eslint/tsconfig-utils@8.56.1", "@typescript-eslint/tsconfig-utils@^8.56.1":
   version "8.56.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz#1afa830b0fada5865ddcabdc993b790114a879b7"
+  resolved "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz"
   integrity sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==
 
-"@typescript-eslint/type-utils@8.56.0":
-  version "8.56.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.56.0.tgz#72b4edc1fc73988998f1632b3ec99c2a66eaac6e"
-  integrity sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==
-  dependencies:
-    "@typescript-eslint/types" "8.56.0"
-    "@typescript-eslint/typescript-estree" "8.56.0"
-    "@typescript-eslint/utils" "8.56.0"
-    debug "^4.4.3"
-    ts-api-utils "^2.4.0"
-
-"@typescript-eslint/types@8.56.0":
-  version "8.56.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.56.0.tgz#a2444011b9a98ca13d70411d2cbfed5443b3526a"
-  integrity sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==
-
-"@typescript-eslint/types@8.56.1", "@typescript-eslint/types@^8.56.0", "@typescript-eslint/types@^8.56.1":
+"@typescript-eslint/type-utils@8.56.1":
   version "8.56.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.56.1.tgz#975e5942bf54895291337c91b9191f6eb0632ab9"
-  integrity sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==
-
-"@typescript-eslint/typescript-estree@8.56.0":
-  version "8.56.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.0.tgz#fadbc74c14c5bac947db04980ff58bb178701c2e"
-  integrity sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==
+  resolved "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz"
+  integrity sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==
   dependencies:
-    "@typescript-eslint/project-service" "8.56.0"
-    "@typescript-eslint/tsconfig-utils" "8.56.0"
-    "@typescript-eslint/types" "8.56.0"
-    "@typescript-eslint/visitor-keys" "8.56.0"
+    "@typescript-eslint/types" "8.56.1"
+    "@typescript-eslint/typescript-estree" "8.56.1"
+    "@typescript-eslint/utils" "8.56.1"
     debug "^4.4.3"
-    minimatch "^9.0.5"
-    semver "^7.7.3"
-    tinyglobby "^0.2.15"
     ts-api-utils "^2.4.0"
+
+"@typescript-eslint/types@8.56.1", "@typescript-eslint/types@^8.56.1":
+  version "8.56.1"
+  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz"
+  integrity sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==
 
 "@typescript-eslint/typescript-estree@8.56.1":
   version "8.56.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz#3b9e57d8129a860c50864c42188f761bdef3eab0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz"
   integrity sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==
   dependencies:
     "@typescript-eslint/project-service" "8.56.1"
@@ -2893,27 +2828,19 @@
     tinyglobby "^0.2.15"
     ts-api-utils "^2.4.0"
 
-"@typescript-eslint/utils@8.56.0":
-  version "8.56.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.56.0.tgz#063ce6f702ec603de1b83ee795ed5e877d6f7841"
-  integrity sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==
+"@typescript-eslint/utils@8.56.1":
+  version "8.56.1"
+  resolved "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz"
+  integrity sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==
   dependencies:
     "@eslint-community/eslint-utils" "^4.9.1"
-    "@typescript-eslint/scope-manager" "8.56.0"
-    "@typescript-eslint/types" "8.56.0"
-    "@typescript-eslint/typescript-estree" "8.56.0"
-
-"@typescript-eslint/visitor-keys@8.56.0":
-  version "8.56.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.0.tgz#7d6592ab001827d3ce052155edf7ecad19688d7d"
-  integrity sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==
-  dependencies:
-    "@typescript-eslint/types" "8.56.0"
-    eslint-visitor-keys "^5.0.0"
+    "@typescript-eslint/scope-manager" "8.56.1"
+    "@typescript-eslint/types" "8.56.1"
+    "@typescript-eslint/typescript-estree" "8.56.1"
 
 "@typescript-eslint/visitor-keys@8.56.1":
   version "8.56.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz#50e03475c33a42d123dc99e63acf1841c0231f87"
+  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz"
   integrity sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==
   dependencies:
     "@typescript-eslint/types" "8.56.1"
@@ -2981,12 +2908,12 @@
 
 "@unrs/resolver-binding-linux-x64-gnu@1.7.11":
   version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.7.11.tgz#ab14b632f9524bd264319135250859074c890887"
+  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.7.11.tgz"
   integrity sha512-G9U7bVmylzRLma3cK39RBm3guoD1HOvY4o0NS4JNm37AD0lS7/xyMt7kn0JejYyc0Im8J+rH69/dXGM9DAJcSQ==
 
 "@unrs/resolver-binding-linux-x64-musl@1.7.11":
   version "1.7.11"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.7.11.tgz#86192443e8560c5ca9eb20b6fed3cbfad223a831"
+  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.7.11.tgz"
   integrity sha512-7qL20SBKomekSunm7M9Fe5L93bFbn+FbHiGJbfTlp0RKhPVoJDP73vOxf1QrmJHyDPECsGWPFnKa/f8fO2FsHw==
 
 "@unrs/resolver-binding-wasm32-wasi@1.7.11":
@@ -3013,7 +2940,7 @@
 
 "@vitejs/plugin-react@^5.1.4":
   version "5.1.4"
-  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz#5b477e060bf612a7394c4febacc5de33a219b0e4"
+  resolved "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz"
   integrity sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==
   dependencies:
     "@babel/core" "^7.29.0"
@@ -3094,6 +3021,11 @@ ansi-styles@^6.1.0:
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
+ansi-styles@^6.2.1:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
+
 ansi-to-react@^6.2.6:
   version "6.2.6"
   resolved "https://registry.npmjs.org/ansi-to-react/-/ansi-to-react-6.2.6.tgz"
@@ -3104,9 +3036,9 @@ ansi-to-react@^6.2.6:
     linkify-it "^3.0.3"
 
 antd@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/antd/-/antd-6.3.0.tgz#0ea0596d2d8c19cb5860e3fa6ad20128f6c8ffda"
-  integrity sha512-bbHJcASrRHp02wTpr940KtUHlTT6tvmaD4OAjqgOJXNmTQ/+qBDdBVWY/yeDV41p/WbWjTLlaqRGVbL3UEVpNw==
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/antd/-/antd-6.3.1.tgz"
+  integrity sha512-8pRjvxitZFyrYAtgwml93Km7fCXjw9IeqlmzpIsusRsmO3eWFVrOMum6+0TsGCtR/WrXVnPwfsgrFg3ChzGCeA==
   dependencies:
     "@ant-design/colors" "^8.0.1"
     "@ant-design/cssinjs" "^2.1.0"
@@ -3128,7 +3060,7 @@ antd@^6.3.0:
     "@rc-component/input-number" "~1.6.2"
     "@rc-component/mentions" "~1.6.0"
     "@rc-component/menu" "~1.2.0"
-    "@rc-component/motion" "~1.1.6"
+    "@rc-component/motion" "^1.3.1"
     "@rc-component/mutate-observer" "^2.0.1"
     "@rc-component/notification" "~1.2.0"
     "@rc-component/pagination" "~1.2.0"
@@ -3138,7 +3070,7 @@ antd@^6.3.0:
     "@rc-component/rate" "~1.0.1"
     "@rc-component/resize-observer" "^1.1.1"
     "@rc-component/segmented" "~1.3.0"
-    "@rc-component/select" "~1.6.5"
+    "@rc-component/select" "~1.6.12"
     "@rc-component/slider" "~1.0.1"
     "@rc-component/steps" "~1.2.2"
     "@rc-component/switch" "~1.0.3"
@@ -3426,11 +3358,9 @@ balanced-match@^1.0.0:
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 balanced-match@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.2.tgz#241591ea634702bef9c482696f2469406e16d233"
-  integrity sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==
-  dependencies:
-    jackspeak "^4.2.3"
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
 base64-js@^1.3.1:
   version "1.5.1"
@@ -3458,9 +3388,9 @@ brace-expansion@^2.0.1:
     balanced-match "^1.0.0"
 
 brace-expansion@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.2.tgz#b6c16d0791087af6c2bc463f52a8142046c06b6f"
-  integrity sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==
+  version "5.0.3"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz"
+  integrity sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -3508,6 +3438,13 @@ buffer@^6.0.3:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
+
+bundle-name@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bundle-name/-/bundle-name-4.1.0.tgz#f3b96b34160d6431a19d7688135af7cfb8797889"
+  integrity sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==
+  dependencies:
+    run-applescript "^7.0.0"
 
 call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
@@ -3621,6 +3558,15 @@ cliui@^8.0.1:
     string-width "^4.2.0"
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
+
+cliui@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-9.0.1.tgz#6f7890f386f6f1f79953adc1f78dec46fcc2d291"
+  integrity sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==
+  dependencies:
+    string-width "^7.2.0"
+    strip-ansi "^7.1.0"
+    wrap-ansi "^9.0.0"
 
 clsx@^2.1.1:
   version "2.1.1"
@@ -4005,6 +3951,19 @@ deepmerge@^4.3.1:
   resolved "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
+default-browser-id@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/default-browser-id/-/default-browser-id-5.0.1.tgz#f7a7ccb8f5104bf8e0f71ba3b1ccfa5eafdb21e8"
+  integrity sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==
+
+default-browser@^5.4.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/default-browser/-/default-browser-5.5.0.tgz#2792e886f2422894545947cc80e1a444496c5976"
+  integrity sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==
+  dependencies:
+    bundle-name "^4.1.0"
+    default-browser-id "^5.0.0"
+
 define-data-property@^1.0.1, define-data-property@^1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz"
@@ -4013,6 +3972,11 @@ define-data-property@^1.0.1, define-data-property@^1.1.4:
     es-define-property "^1.0.0"
     es-errors "^1.3.0"
     gopd "^1.0.1"
+
+define-lazy-prop@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
+  integrity sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==
 
 define-properties@^1.1.3, define-properties@^1.2.1:
   version "1.2.1"
@@ -4116,7 +4080,7 @@ dotenv@^16.4.5:
 
 dotenv@^17.3.1:
   version "17.3.1"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.3.1.tgz#2706f5b0165e45a1503348187b8468f87fe6aae2"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz"
   integrity sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==
 
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
@@ -4142,6 +4106,11 @@ emittery@^0.13.1:
   version "0.13.1"
   resolved "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz"
   integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
+
+emoji-regex@^10.3.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.6.0.tgz#bf3d6e8f7f8fd22a65d9703475bc0147357a6b0d"
+  integrity sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -4465,9 +4434,9 @@ eslint-plugin-react-hooks@^7.0.1:
     zod-validation-error "^3.5.0 || ^4.0.0"
 
 eslint-plugin-react-refresh@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.1.tgz#d13f1cfea4718a108060a41219d1849287278adc"
-  integrity sha512-Y5sJsreCUdGcF4mLD70iJNa47Z6CX4MsqJoJBARDC/fBhmacSby7k73UuValr0F9M7GfWKpEqS4NMsniWkVxQw==
+  version "0.5.2"
+  resolved "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.2.tgz"
+  integrity sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==
 
 eslint-plugin-react@^7.37.5:
   version "7.37.5"
@@ -4513,7 +4482,7 @@ eslint-visitor-keys@^4.2.1:
 
 eslint-visitor-keys@^5.0.0:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz#9e3c9489697824d2d4ce3a8ad12628f91e9f59be"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz"
   integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
 
 eslint@^9.39.2:
@@ -4772,7 +4741,7 @@ fs.realpath@^1.0.0:
 
 fsevents@^2.3.3, fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
@@ -4806,6 +4775,11 @@ get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-east-asian-width@^1.0.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz#ce7008fe345edcf5497a6f557cfa54bc318a9ce7"
+  integrity sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==
 
 get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.2.7, get-intrinsic@^1.3.0:
   version "1.3.0"
@@ -5003,7 +4977,7 @@ hasown@^2.0.2:
 
 hast-util-from-parse5@^8.0.0:
   version "8.0.3"
-  resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz#830a35022fff28c3fea3697a98c2f4cc6b835a2e"
+  resolved "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz"
   integrity sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -5017,14 +4991,14 @@ hast-util-from-parse5@^8.0.0:
 
 hast-util-parse-selector@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz#352879fa86e25616036037dd8931fb5f34cb4a27"
+  resolved "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz"
   integrity sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==
   dependencies:
     "@types/hast" "^3.0.0"
 
 hast-util-raw@^9.0.0:
   version "9.1.0"
-  resolved "https://registry.yarnpkg.com/hast-util-raw/-/hast-util-raw-9.1.0.tgz#79b66b26f6f68fb50dfb4716b2cdca90d92adf2e"
+  resolved "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz"
   integrity sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -5064,7 +5038,7 @@ hast-util-to-jsx-runtime@^2.0.0:
 
 hast-util-to-parse5@^8.0.0:
   version "8.0.1"
-  resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz#95aa391cc0514b4951418d01c883d1038af42f5d"
+  resolved "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz"
   integrity sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -5084,7 +5058,7 @@ hast-util-whitespace@^3.0.0:
 
 hastscript@^9.0.0:
   version "9.0.1"
-  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-9.0.1.tgz#dbc84bef6051d40084342c229c451cd9dc567dff"
+  resolved "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz"
   integrity sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -5152,7 +5126,7 @@ html-url-attributes@^3.0.0:
 
 html-void-elements@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
+  resolved "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz"
   integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
 
 htmlparser2@10.1.0:
@@ -5380,6 +5354,11 @@ is-decimal@^2.0.0:
   resolved "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz"
   integrity sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==
 
+is-docker@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-3.0.0.tgz#90093aa3106277d8a77a5910dbae71747e15a200"
+  integrity sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
@@ -5423,6 +5402,18 @@ is-hexadecimal@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz"
   integrity sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==
+
+is-in-ssh@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-in-ssh/-/is-in-ssh-1.0.0.tgz#8eb73c1cabba77748d389588eeea132a63057622"
+  integrity sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==
+
+is-inside-container@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-inside-container/-/is-inside-container-1.0.0.tgz#e81fba699662eb31dbdaf26766a61d4814717ea4"
+  integrity sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==
+  dependencies:
+    is-docker "^3.0.0"
 
 is-map@^2.0.3:
   version "2.0.3"
@@ -5533,6 +5524,13 @@ is-weakset@^2.0.3:
     call-bound "^1.0.3"
     get-intrinsic "^1.2.6"
 
+is-wsl@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-3.1.1.tgz#327897b26832a3eb117da6c27492d04ca132594f"
+  integrity sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==
+  dependencies:
+    is-inside-container "^1.0.0"
+
 isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz"
@@ -5605,13 +5603,6 @@ jackspeak@^3.1.2:
     "@isaacs/cliui" "^8.0.2"
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
-
-jackspeak@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-4.2.3.tgz#27ef80f33b93412037c3bea4f8eddf80e1931483"
-  integrity sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==
-  dependencies:
-    "@isaacs/cliui" "^9.0.0"
 
 jest-changed-files@30.2.0:
   version "30.2.0"
@@ -6740,14 +6731,7 @@ min-indent@^1.0.0:
 
 minimatch@^10.2.2:
   version "10.2.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.2.tgz#361603ee323cfb83496fea2ae17cc44ea4e1f99f"
-  integrity sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==
-  dependencies:
-    brace-expansion "^5.0.2"
-
-minimatch@^10.2.2:
-  version "10.2.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.2.tgz#361603ee323cfb83496fea2ae17cc44ea4e1f99f"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz"
   integrity sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==
   dependencies:
     brace-expansion "^5.0.2"
@@ -6759,7 +6743,7 @@ minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^9.0.4, minimatch@^9.0.5:
+minimatch@^9.0.4:
   version "9.0.5"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz"
   integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
@@ -6922,6 +6906,18 @@ onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+open@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-11.0.0.tgz#897e6132f994d3554cbcf72e0df98f176a7e5f62"
+  integrity sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==
+  dependencies:
+    default-browser "^5.4.0"
+    define-lazy-prop "^3.0.0"
+    is-in-ssh "^1.0.0"
+    is-inside-container "^1.0.0"
+    powershell-utils "^0.1.0"
+    wsl-utils "^0.3.0"
 
 optionator@^0.9.3:
   version "0.9.4"
@@ -7098,6 +7094,11 @@ postcss@^8.5.6:
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
+powershell-utils@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/powershell-utils/-/powershell-utils-0.1.0.tgz#5a42c9a824fb4f2f251ccb41aaae73314f5d6ac2"
+  integrity sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
@@ -7190,7 +7191,7 @@ raf@^3.1.0:
 
 react-dom@19.2.4:
   version "19.2.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.4.tgz#6fac6bd96f7db477d966c7ec17c1a2b1ad8e6591"
+  resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz"
   integrity sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==
   dependencies:
     scheduler "^0.27.0"
@@ -7393,7 +7394,7 @@ regjsparser@^0.13.0:
 
 rehype-raw@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/rehype-raw/-/rehype-raw-7.0.0.tgz#59d7348fd5dbef3807bbaa1d443efd2dd85ecee4"
+  resolved "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz"
   integrity sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -7492,6 +7493,16 @@ reusify@^1.0.4:
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz"
   integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
 
+rollup-plugin-visualizer@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-7.0.0.tgz#7abacfae91efeda6f2e0a445f97a9997249e884c"
+  integrity sha512-loo4kmhTg7GMO0hqaUv/azvLPUT2B4jXU3gNMG35gm1mWKpOzhV6rspb/Mqmsfg7oOTdkzdmOckCIwGB5Ca1CA==
+  dependencies:
+    open "^11.0.0"
+    picomatch "^4.0.2"
+    source-map "^0.7.4"
+    yargs "^18.0.0"
+
 rollup@^4.43.0:
   version "4.46.2"
   resolved "https://registry.npmjs.org/rollup/-/rollup-4.46.2.tgz"
@@ -7525,6 +7536,11 @@ rrweb-cssom@^0.8.0:
   version "0.8.0"
   resolved "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz"
   integrity sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==
+
+run-applescript@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-7.1.0.tgz#2e9e54c4664ec3106c5b5630e249d3d6595c4911"
+  integrity sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==
 
 run-parallel@^1.1.9:
   version "1.2.0"
@@ -7590,10 +7606,15 @@ semver@^6.3.1:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.5.3, semver@^7.5.4, semver@^7.7.1, semver@^7.7.2, semver@^7.7.3:
+semver@^7.5.3, semver@^7.5.4, semver@^7.7.1, semver@^7.7.2:
   version "7.7.3"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz"
   integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
+
+semver@^7.7.3:
+  version "7.7.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
 set-cookie-parser@^2.6.0:
   version "2.7.2"
@@ -7716,6 +7737,11 @@ source-map@^0.6.0, source-map@^0.6.1:
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+source-map@^0.7.4:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.6.tgz#a3658ab87e5b6429c8a1f3ba0083d4c61ca3ef02"
+  integrity sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==
+
 space-separated-tokens@^2.0.0:
   version "2.0.2"
   resolved "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz"
@@ -7795,6 +7821,15 @@ string-width@^5.0.1, string-width@^5.1.2:
     eastasianwidth "^0.2.0"
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
+
+string-width@^7.0.0, string-width@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
+  integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
+  dependencies:
+    emoji-regex "^10.3.0"
+    get-east-asian-width "^1.0.0"
+    strip-ansi "^7.1.0"
 
 string.prototype.includes@^2.0.1:
   version "2.0.1"
@@ -7890,6 +7925,13 @@ strip-ansi@^7.0.1:
   version "7.1.0"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz"
   integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
+  dependencies:
+    ansi-regex "^6.0.1"
+
+strip-ansi@^7.1.0:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.2.tgz#132875abde678c7ea8d691533f2e7e22bb744dba"
+  integrity sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==
   dependencies:
     ansi-regex "^6.0.1"
 
@@ -8167,14 +8209,14 @@ typed-array-length@^1.0.7:
     reflect.getprototypeof "^1.0.6"
 
 typescript-eslint@^8.56.0:
-  version "8.56.0"
-  resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-8.56.0.tgz#f4686ccaaf2fb86daf0133820da40ca5961a2236"
-  integrity sha512-c7toRLrotJ9oixgdW7liukZpsnq5CZ7PuKztubGYlNppuTqhIoWfhgHo/7EU0v06gS2l/x0i2NEFK1qMIf0rIg==
+  version "8.56.1"
+  resolved "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.1.tgz"
+  integrity sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==
   dependencies:
-    "@typescript-eslint/eslint-plugin" "8.56.0"
-    "@typescript-eslint/parser" "8.56.0"
-    "@typescript-eslint/typescript-estree" "8.56.0"
-    "@typescript-eslint/utils" "8.56.0"
+    "@typescript-eslint/eslint-plugin" "8.56.1"
+    "@typescript-eslint/parser" "8.56.1"
+    "@typescript-eslint/typescript-estree" "8.56.1"
+    "@typescript-eslint/utils" "8.56.1"
 
 typescript@^5.9.3:
   version "5.9.3"
@@ -8203,7 +8245,7 @@ unbox-primitive@^1.1.0:
 
 undici-types@~7.18.0:
   version "7.18.2"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz"
   integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
@@ -8358,7 +8400,7 @@ v8-to-istanbul@^9.0.1:
 
 vfile-location@^5.0.0:
   version "5.0.3"
-  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-5.0.3.tgz#cb9eacd20f2b6426d19451e0eafa3d0a846225c3"
+  resolved "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz"
   integrity sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==
   dependencies:
     "@types/unist" "^3.0.0"
@@ -8401,7 +8443,7 @@ vite-plugin-dynamic-import@^1.6.0:
 
 vite-tsconfig-paths@^6.1.1:
   version "6.1.1"
-  resolved "https://registry.yarnpkg.com/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz#d5c28cba79c89ebf76489ef1040024b21df6da3a"
+  resolved "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz"
   integrity sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==
   dependencies:
     debug "^4.1.1"
@@ -8438,7 +8480,7 @@ walker@^1.0.8:
 
 web-namespaces@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
+  resolved "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz"
   integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
 web-vitals@^5.1.0:
@@ -8568,6 +8610,15 @@ wrap-ansi@^8.1.0:
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
 
+wrap-ansi@^9.0.0:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.2.tgz#956832dea9494306e6d209eb871643bb873d7c98"
+  integrity sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==
+  dependencies:
+    ansi-styles "^6.2.1"
+    string-width "^7.0.0"
+    strip-ansi "^7.1.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
@@ -8585,6 +8636,14 @@ ws@^8.18.0:
   version "8.18.2"
   resolved "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz"
   integrity sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==
+
+wsl-utils@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/wsl-utils/-/wsl-utils-0.3.1.tgz#9479836ddf03be267aad3abfc3cb1f6e0c9f1ed1"
+  integrity sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==
+  dependencies:
+    is-wsl "^3.1.0"
+    powershell-utils "^0.1.0"
 
 xml-name-validator@^5.0.0:
   version "5.0.0"
@@ -8611,6 +8670,11 @@ yargs-parser@^21.1.1:
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
+yargs-parser@^22.0.0:
+  version "22.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-22.0.0.tgz#87b82094051b0567717346ecd00fd14804b357c8"
+  integrity sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==
+
 yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
@@ -8623,6 +8687,18 @@ yargs@^17.7.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+yargs@^18.0.0:
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-18.0.0.tgz#6c84259806273a746b09f579087b68a3c2d25bd1"
+  integrity sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==
+  dependencies:
+    cliui "^9.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    string-width "^7.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^22.0.0"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## Summary

Complete frontend redesign with HCP Terraform styling and comprehensive performance optimizations.

## UI Redesign
- Redesign login page to match HCP Terraform style
- Add HCP-style organization selector dropdown
- Add HCP-style Help and User menu dropdowns  
- Redesign workspace filter with dark theme support
- Refactor token page to HCP style

## Dark Mode
- Add comprehensive dark theme support
- Add color scheme switching (ThemeContext)
- Fix dark mode visibility issues across components

## Performance Optimizations
- Add `usePolling` hook with visibility API and cleanup
- Add `useAbortableFetch` hook for request cancellation
- Fix memory leaks from polling in Jobs/Workspaces details
- Convert waterfall requests to Promise.all (7 files)
- Fix N+1 delete pattern in VariableCollections
- Extract workspace utilities, reduce Details.tsx by 37%

## Code Quality
- Optimize bundle size with code splitting and lazy loading
- Add LoadingFallback component
- Fix various UI bugs and improvements

## Files Changed

68 files changed, +7098, -1487

## Testing

- ✅ Build passes
- ✅ All tests pass