### PR TITLE
fix: use Base64.getUrlDecoder() for JWT token decoding

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolver.java
+++ b/api/src/main/java/io/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolver.java
@@ -78,7 +78,7 @@ public class DexAuthenticationManagerResolver implements AuthenticationManagerRe
     private String getJwtClaim(HttpServletRequest request, String claim) {
         String tokenRequest = request.getHeader("authorization").replace("Bearer ", "");
         String[] chunksToken = tokenRequest.split("\\.");
-        Base64.Decoder decoder = Base64.getDecoder();
+        Base64.Decoder decoder = Base64.getUrlDecoder();
         String payloadFromToken = new String(decoder.decode(chunksToken[1]));
         String claimJwt = "";
         try {

--- a/registry/src/main/java/io/terrakube/registry/configuration/authentication/dex/RegistryAuthenticationManagerResolver.java
+++ b/registry/src/main/java/io/terrakube/registry/configuration/authentication/dex/RegistryAuthenticationManagerResolver.java
@@ -57,7 +57,7 @@ public class RegistryAuthenticationManagerResolver implements AuthenticationMana
     private String getJwtIssuer(HttpServletRequest request) {
         String token = request.getHeader("authorization").replace("Bearer ", "");
         String[] chunks = token.split("\\.");
-        Base64.Decoder decoder = Base64.getDecoder();
+        Base64.Decoder decoder = Base64.getUrlDecoder();
         String payload = new String(decoder.decode(chunks[1]));
         String issuer = "";
         try {


### PR DESCRIPTION
JWT tokens use base64url encoding which allows underscore (_) and hyphen (-) characters. Using Base64.getDecoder() causes IllegalArgumentException when tokens contain these characters, which happens with Entra ID / Microsoft connector via Dex.

Fixes #3001