### PR TITLE
fix: remove redundant Azure Storage Blob version

### DIFF
--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -101,7 +101,6 @@
 		<dependency>
 			<groupId>com.azure</groupId>
 			<artifactId>azure-storage-blob</artifactId>
-			<version>${azure-storage-blob.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>2.29.0</revision>
+        <revision>2.30.1</revision>
         <sonar.organization>azbuilder</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.project.key>AzBuilder_azb-server</sonar.project.key>


### PR DESCRIPTION
- Updated project revision to 2.30.1 in the parent POM.
- Removed the explicit version tag for the Azure Storage Blob dependency in the executor POM.

Logs now:

```shell
Added 1 additional CA certificate(s) to system truststore
Calculated JVM Memory Configuration: -XX:MaxDirectMemorySize=10M -Xmx1348848K -XX:MaxMetaspaceSize=236303K -XX:ReservedCodeCacheSize=240M -Xss1M (Total Memory: 2G, Thread Count: 250, Loaded Class Count: 39306, Headroom: 0%)
Enabling Java Native Memory Tracking
Adding 147 container CA certificates to JVM truststore
Spring Cloud Bindings Enabled
Picked up JAVA_TOOL_OPTIONS: -Djava.security.properties=/layers/paketo-buildpacks_bellsoft-liberica/java-security-properties/java-security.properties -XX:+ExitOnOutOfMemoryError -javaagent:/layers/paketo-buildpacks_opentelemetry/opentelemetry-java/opentelemetry-javaagent.jar -XX:MaxDirectMemorySize=10M -Xmx1348848K -XX:MaxMetaspaceSize=236303K -XX:ReservedCodeCacheSize=240M -Xss1M -XX:+UnlockDiagnosticVMOptions -XX:NativeMemoryTracking=summary -XX:+PrintNMTStatistics -Dorg.springframework.cloud.bindings.boot.enable=true
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
[otel.javaagent 2026-03-03 16:49:16:882 +0000] [main] INFO io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: 2.25.0

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::               (v3.5.11)

2026-03-03T16:49:18.185Z  INFO 1 --- [           main] i.t.executor.ExecutorApplication         : Starting ExecutorApplication v2.30.1 using Java 25.0.2 with PID 1 (/workspace/BOOT-INF/classes started by cnb in /workspace)
2026-03-03T16:49:18.187Z  INFO 1 --- [           main] i.t.executor.ExecutorApplication         : No active profile set, falling back to 1 default profile: "default"
2026-03-03T16:49:18.980Z  INFO 1 --- [           main] o.s.c.i.support.PropertySourceProcessor  : Properties location [classpath:application-${spring.profiles.active}.properties] not resolvable: Could not resolve placeholder 'spring.profiles.active' in value "classpath:application-${spring.profiles.active}.properties"
2026-03-03T16:49:18.988Z  INFO 1 --- [           main] o.s.c.i.support.PropertySourceProcessor  : Properties location [classpath:application-${spring.profiles.active}.properties] not resolvable: Could not resolve placeholder 'spring.profiles.active' in value "classpath:application-${spring.profiles.active}.properties"
2026-03-03T16:49:19.025Z  INFO 1 --- [           main] o.s.c.i.support.PropertySourceProcessor  : Properties location [classpath:application-${spring.profiles.active}.properties] not resolvable: Could not resolve placeholder 'spring.profiles.active' in value "classpath:application-${spring.profiles.active}.properties"
2026-03-03T16:49:19.027Z  INFO 1 --- [           main] o.s.c.i.support.PropertySourceProcessor  : Properties location [classpath:application-${spring.profiles.active}.properties] not resolvable: Could not resolve placeholder 'spring.profiles.active' in value "classpath:application-${spring.profiles.active}.properties"
2026-03-03T16:49:19.030Z  INFO 1 --- [           main] o.s.c.i.support.PropertySourceProcessor  : Properties location [classpath:application-${spring.profiles.active}.properties] not resolvable: Could not resolve placeholder 'spring.profiles.active' in value "classpath:application-${spring.profiles.active}.properties"
2026-03-03T16:49:19.032Z  INFO 1 --- [           main] o.s.c.i.support.PropertySourceProcessor  : Properties location [classpath:application-${spring.profiles.active}.properties] not resolvable: Could not resolve placeholder 'spring.profiles.active' in value "classpath:application-${spring.profiles.active}.properties"
2026-03-03T16:49:20.979Z  INFO 1 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Multiple Spring Data modules found, entering strict repository configuration mode
2026-03-03T16:49:20.980Z  INFO 1 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data Redis repositories in DEFAULT mode.
2026-03-03T16:49:21.185Z  INFO 1 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 190 ms. Found 0 Redis repository interfaces.
2026-03-03T16:49:21.332Z  INFO 1 --- [           main] o.s.c.i.support.PropertySourceProcessor  : Properties location [classpath:application-${spring.profiles.active}.properties] not resolvable: Could not resolve placeholder 'spring.profiles.active' in value "classpath:application-${spring.profiles.active}.properties"
2026-03-03T16:49:21.333Z  INFO 1 --- [           main] o.s.c.i.support.PropertySourceProcessor  : Properties location [classpath:application-${spring.profiles.active}.properties] not resolvable: Could not resolve placeholder 'spring.profiles.active' in value "classpath:application-${spring.profiles.active}.properties"
2026-03-03T16:49:22.151Z  INFO 1 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port 8090 (http)
2026-03-03T16:49:22.188Z  INFO 1 --- [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
2026-03-03T16:49:22.188Z  INFO 1 --- [           main] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/10.1.52]
2026-03-03T16:49:22.346Z  INFO 1 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
2026-03-03T16:49:22.347Z  INFO 1 --- [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 3669 ms
2026-03-03T16:49:23.836Z  INFO 1 --- [           main] c.a.c.h.n.implementation.NettyUtility    : {"az.sdk.message":"The following Netty versions were found on the classpath and have a mismatch with the versions used by azure-core-http-netty. If your application runs without issue this message can be ignored, otherwise please align the Netty versions used in your application. For more information, see https://aka.ms/azsdk/java/dependency/troubleshoot.","azure-netty-version":"4.1.127.Final","azure-netty-native-version":"2.0.74.Final","classpath-netty-version-io.netty:netty-common":"4.1.131.Final","classpath-netty-version-io.netty:netty-handler":"4.1.131.Final","classpath-netty-version-io.netty:netty-handler-proxy":"4.1.131.Final","classpath-netty-version-io.netty:netty-buffer":"4.1.131.Final","classpath-netty-version-io.netty:netty-codec":"4.1.131.Final","classpath-netty-version-io.netty:netty-codec-http":"4.1.131.Final","classpath-netty-version-io.netty:netty-codec-http2":"4.1.131.Final","classpath-netty-version-io.netty:netty-transport-native-unix-common":"4.1.131.Final","classpath-netty-version-io.netty:netty-transport-native-epoll":"4.1.131.Final","classpath-netty-version-io.netty:netty-transport-native-kqueue":"4.1.131.Final","classpath-native-netty-version-io.netty:netty-tcnative-boringssl-static":"2.0.75.Final"}
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::allocateMemory has been called by io.netty.util.internal.PlatformDependent0$2 (file:/workspace/BOOT-INF/lib/netty-common-4.1.131.Final.jar)
WARNING: Please consider reporting this to the maintainers of class io.netty.util.internal.PlatformDependent0$2
WARNING: sun.misc.Unsafe::allocateMemory will be removed in a future release
2026-03-03T16:49:24.240Z  INFO 1 --- [           main] i.t.e.c.RedisAutoConfiguration           : Redis connection with default configuration
2026-03-03T16:49:24.241Z  INFO 1 --- [           main] i.t.e.c.RedisAutoConfiguration           : Redis User NULL username, Hostname terrakube-redis-master, Port 6379, SSL false
2026-03-03T16:49:24.878Z  INFO 1 --- [           main] i.t.e.configuration.LocalConfiguration   : State/Output Enabled: AzureTerraformStateImpl
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by io.netty.util.internal.NativeLibraryUtil in an unnamed module (file:/workspace/BOOT-INF/lib/netty-common-4.1.131.Final.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

2026-03-03T16:49:26.034Z  WARN 1 --- [           main] .b.a.g.t.GroovyTemplateAutoConfiguration : Cannot find template location: classpath:/templates/ (please add some templates, check your Groovy configuration, or set spring.groovy.template.check-template-location=false)
2026-03-03T16:49:26.378Z  INFO 1 --- [           main] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 1 endpoint beneath base path '/actuator'
2026-03-03T16:49:26.520Z  INFO 1 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port 8090 (http) with context path '/'
2026-03-03T16:49:26.533Z  INFO 1 --- [           main] i.t.e.s.mode.batch.BatchModeServiceImpl  : Ephemeral mode is enable: false
2026-03-03T16:49:26.535Z  INFO 1 --- [           main] i.t.executor.ExecutorApplication         : Started ExecutorApplication in 9.141 seconds (process running for 9.987)
2026-03-03T16:49:30.796Z  INFO 1 --- [nio-8090-exec-1] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring DispatcherServlet 'dispatcherServlet'
2026-03-03T16:49:30.797Z  INFO 1 --- [nio-8090-exec-1] o.s.web.servlet.DispatcherServlet        : Initializing Servlet 'dispatcherServlet'
2026-03-03T16:49:30.799Z  INFO 1 --- [nio-8090-exec-1] o.s.web.servlet.DispatcherServlet        : Completed initialization in 2 ms
```

Fix #3018