### PR TITLE
fix: remove redundant Azure Storage Blob (#3020)

### DIFF
--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -101,7 +101,6 @@
 		<dependency>
 			<groupId>com.azure</groupId>
 			<artifactId>azure-storage-blob</artifactId>
-			<version>${azure-storage-blob.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>2.29.0</revision>
+        <revision>2.30.1</revision>
         <sonar.organization>azbuilder</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.project.key>AzBuilder_azb-server</sonar.project.key>


### PR DESCRIPTION


- Updated project revision to 2.30.1 in the parent POM.
- Removed the explicit version tag for the Azure Storage Blob dependency in the executor POM.