### PR TITLE
fix: add instanceOwner-based permission checks in TeamTokenController and fix ui logic (#3023)

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/token/team/TeamTokenController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/token/team/TeamTokenController.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -23,15 +24,22 @@ import java.util.UUID;
 
 @Slf4j
 @RestController
-@AllArgsConstructor
 @RequestMapping("/access-token/v1/teams")
 public class TeamTokenController {
 
     private final WorkspaceRepository workspaceRepository;
     private final RbacService rbacService;
-    TeamTokenService teamTokenService;
-    TeamRepository teamRepository;
-    AccessRepository accessRepository;
+    private final TeamTokenService teamTokenService;
+    private final TeamRepository teamRepository;
+    private final String instanceOwner;
+
+    public TeamTokenController(WorkspaceRepository workspaceRepository, RbacService rbacService, TeamTokenService teamTokenService, TeamRepository teamRepository, @Value("${io.terrakube.owner}") String instanceOwner) {
+        this.workspaceRepository = workspaceRepository;
+        this.rbacService = rbacService;
+        this.teamTokenService = teamTokenService;
+        this.teamRepository = teamRepository;
+        this.instanceOwner = instanceOwner;
+    }
 
     @PostMapping
     public ResponseEntity<TeamToken> createToken(@RequestBody GroupTokenRequest groupTokenRequest,
@@ -74,7 +82,12 @@ public class TeamTokenController {
             permissions.setManageJob(permissions.manageJob || rbacService.canManageJob(group));
             permissions.setPlanJob(permissions.planJob || rbacService.canPlanJob(group));
             permissions.setApproveJob(permissions.approveJob || rbacService.canApproveJob(group));
+            permissions.setManagePermission(permissions.managePermission || rbacService.canManageWorkspace(group));
         });
+
+        if (groups.contains(instanceOwner)) {
+            permissions.setManagePermission(true);
+        }
 
         log.debug("Permissions: {}", permissions);
         return new ResponseEntity<>(permissions, HttpStatus.ACCEPTED);
@@ -98,6 +111,7 @@ public class TeamTokenController {
             permissions.setManageJob(permissions.manageJob || rbacService.canManageJob(group));
             permissions.setPlanJob(permissions.planJob || rbacService.canPlanJob(group));
             permissions.setApproveJob(permissions.approveJob || rbacService.canApproveJob(group));
+            permissions.setManagePermission(permissions.managePermission || rbacService.canManageWorkspace(group));
         });
 
         workspaceRepository.findById(UUID.fromString(workspaceId)).ifPresent(workspace -> {
@@ -165,5 +179,6 @@ public class TeamTokenController {
         private boolean manageJob;
         private boolean planJob;
         private boolean approveJob;
+        private boolean managePermission;
     }
 }

--- a/ui/src/domain/Settings/Actions.tsx
+++ b/ui/src/domain/Settings/Actions.tsx
@@ -67,6 +67,7 @@ export const ActionSettings = ({ managePermission = true }: Props) => {
   const [isEditing, setIsEditing] = useState(false);
   const [mode, setMode] = useState("create");
   const [actionId, setActionId] = useState<string>();
+  const [actionContent, setActionContent] = useState<string>("");
   const [form] = Form.useForm();
   const editorRef = useRef<IStandaloneCodeEditor>(null);
   const { token } = theme.useToken();
@@ -137,6 +138,10 @@ export const ActionSettings = ({ managePermission = true }: Props) => {
   const onCancel = () => {
     setIsEditing(false);
     form.resetFields();
+    setActionContent("");
+    if (editorRef.current) {
+      editorRef.current.setValue("");
+    }
   };
 
   const onEdit = (id: string) => {
@@ -153,7 +158,10 @@ export const ActionSettings = ({ managePermission = true }: Props) => {
           displayCriteria: JSON.parse(action.attributes.displayCriteria),
         });
         const actionDecoded = Buffer.from(action.attributes.action, "base64").toString("ascii");
-        editorRef.current.setValue(actionDecoded);
+        setActionContent(actionDecoded);
+        if (editorRef.current) {
+          editorRef.current.setValue(actionDecoded);
+        }
       })
       .catch((err) => {
         message.error(getErrorMessage(err));
@@ -165,6 +173,10 @@ export const ActionSettings = ({ managePermission = true }: Props) => {
     form.resetFields();
     setIsEditing(true);
     setMode("create");
+    setActionContent("");
+    if (editorRef.current) {
+      editorRef.current.setValue("");
+    }
   };
 
   const onDelete = (id: string) => {
@@ -180,7 +192,8 @@ export const ActionSettings = ({ managePermission = true }: Props) => {
   };
 
   const onCreate = (values: CreateActionForm) => {
-    const actionEncoded = Buffer.from(editorRef.current.getValue()).toString("base64");
+    const editorValue = editorRef.current ? editorRef.current.getValue() : actionContent;
+    const actionEncoded = Buffer.from(editorValue).toString("base64");
     const displayCriteria = JSON.stringify(values.displayCriteria);
     const body = {
       data: {
@@ -207,7 +220,8 @@ export const ActionSettings = ({ managePermission = true }: Props) => {
   };
 
   const onUpdate = (values: EditActionForm) => {
-    const actionEncoded = Buffer.from(editorRef.current.getValue()).toString("base64");
+    const editorValue = editorRef.current ? editorRef.current.getValue() : actionContent;
+    const actionEncoded = Buffer.from(editorValue).toString("base64");
     const displayCriteria = JSON.stringify(values.displayCriteria);
     const body = {
       data: {
@@ -255,6 +269,9 @@ export const ActionSettings = ({ managePermission = true }: Props) => {
 
   function handleEditorDidMount(editor: IStandaloneCodeEditor) {
     editorRef.current = editor;
+    if (actionContent) {
+      editor.setValue(actionContent);
+    }
   }
 
   return (

--- a/ui/src/domain/Settings/Settings.tsx
+++ b/ui/src/domain/Settings/Settings.tsx
@@ -63,11 +63,11 @@ export const OrganizationSettings = ({ selectedTab, vcsMode, collectionMode = "l
   const renderContent = () => {
     switch (activeKey) {
       case "1":
-        return <GeneralSettings managePermission={permissions.manageWorkspace} />;
+        return <GeneralSettings managePermission={permissions.managePermission} />;
       case "2":
-        return <TeamSettings key={activeKey} managePermission={permissions.manageWorkspace} />;
+        return <TeamSettings key={activeKey} managePermission={permissions.managePermission} />;
       case "3":
-        return <GlobalVariablesSettings managePermission={permissions.manageWorkspace} />;
+        return <GlobalVariablesSettings managePermission={permissions.managePermission} />;
       case "4":
         return <VCSSettings vcsMode={vcsMode} managePermission={permissions.manageVcs} />;
       case "5":
@@ -77,13 +77,13 @@ export const OrganizationSettings = ({ selectedTab, vcsMode, collectionMode = "l
       case "7":
         return <TagsSettings managePermission={permissions.manageWorkspace} />;
       case "8":
-        return <AgentSettings managePermission={permissions.manageWorkspace} />;
+        return <AgentSettings managePermission={permissions.managePermission} />;
       case "9":
         return renderCollectionContent();
       case "10":
-        return <ActionSettings managePermission={permissions.manageTemplate} />;
+        return <ActionSettings managePermission={permissions.managePermission} />;
       default:
-        return <GeneralSettings managePermission={permissions.manageWorkspace} />;
+        return <GeneralSettings managePermission={permissions.managePermission} />;
     }
   };
 

--- a/ui/src/modules/permissions/useOrgPermissions.ts
+++ b/ui/src/modules/permissions/useOrgPermissions.ts
@@ -17,6 +17,7 @@ export interface OrgPermissionSet {
   manageJob: boolean;
   planJob: boolean;
   approveJob: boolean;
+  managePermission: boolean;
 }
 
 const defaultPermissions: OrgPermissionSet = {
@@ -30,6 +31,7 @@ const defaultPermissions: OrgPermissionSet = {
   manageJob: false,
   planJob: false,
   approveJob: false,
+  managePermission: false,
 };
 
 /**
@@ -68,6 +70,7 @@ export function useOrgPermissions() {
           manageJob: response.data.manageJob ?? false,
           planJob: response.data.planJob ?? false,
           approveJob: response.data.approveJob ?? false,
+          managePermission: response.data.managePermission ?? false,
         });
       })
       .catch((err) => {


### PR DESCRIPTION
- Introduced `instanceOwner` property for enhanced permission validation.
- Updated token creation to grant `managePermission` if group includes instance owner.
- Fix issues in the UI to enable/disable options based on current permissions
- Fix "can't access property "setValue", editorRef.current is null" when click Actions edit button

fix #3019 