### PR TITLE
fix(ui): Add regex validation for workspace webhook branch/file fields

### DIFF
--- a/ui/src/domain/Workspaces/Settings/Webhook.tsx
+++ b/ui/src/domain/Workspaces/Settings/Webhook.tsx
@@ -21,6 +21,21 @@ import axiosInstance from "../../../config/axiosConfig";
 import { Template, VcsType, WebhookEvent, Workspace } from "../../types";
 import { atomicHeader, renderVCSLogo } from "../Workspaces";
 
+const isValidRegexList = (str: string | undefined) => {
+  if (!str) return true;
+  return str
+    .split(",")
+    .map((s) => s.trim())
+    .every((s) => {
+      try {
+        new RegExp(s);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+};
+
 type Props = {
   workspace: Workspace;
   manageWorkspace: boolean;
@@ -170,6 +185,26 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
     if (inputError) {
       setWaiting(false);
       message.error("Event, Branch, File and Template are required fields");
+      setWebhookEvents([...webhookEvents]);
+      return;
+    }
+    // Verify regex patterns
+    let regexError = false;
+    webhookEvents
+      .filter((_, index) => index < recordIndex - 1)
+      .forEach((event) => {
+        if (!isValidRegexList(event.branch)) {
+          event.branchStatus = "error";
+          regexError = true;
+        }
+        if (!isValidRegexList(event.file)) {
+          event.fileStatus = "error";
+          regexError = true;
+        }
+      });
+    if (regexError) {
+      setWaiting(false);
+      message.error("Branch and File must be valid regex patterns");
       setWebhookEvents([...webhookEvents]);
       return;
     }


### PR DESCRIPTION
## Description
When configuring workspace webhooks, invalid regex patterns in the "Branch/release" and "File" fields could be saved without validation, causing webhook execution failures. This PR adds client-side regex validation to prevent invalid patterns from being submitted.

## Problem
- Users could save invalid regular expressions (e.g., `*.tf`).
- Invalid patterns would cause runtime errors when processing webhooks.
- No immediate feedback to users about validation errors.

## Solution
- Added `isValidRegexList()` helper function to validate regex patterns.
- Validates each comma-separated regex pattern individually.
- Displays a dedicated error message "Branch and File must be valid regex patterns" if validation fails.
- Error validation runs after required field checks for clarity.

## Changes
- Added regex validation function in `Webhook.tsx`
- Updated `onFinish()` to include regex pattern validation before submission
- Invalid patterns now show error status and prevent form submission

## Testing
Tested manually with various inputs:
- Valid single regex: ✅
- Valid comma-separated regexes: ✅
- Invalid regex patterns: ✅ (caught and displays error)
- Empty fields: ✅ (unaffected by this change)

## Screenshots

<img width="719" height="682" alt="image" src="https://github.com/user-attachments/assets/f5042a53-c76f-4a74-8a27-9e9649205017" />

