### PR TITLE
fix: standardize boolean property usage in RBAC changelog updates

### DIFF
--- a/api/src/main/resources/db/changelog/local/changelog-rbac-v2-plan-approve.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-rbac-v2-plan-approve.xml
@@ -5,6 +5,13 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
+    <property name="boolean.true" value="1" dbms="mssql"/>
+    <property name="boolean.false" value="0" dbms="mssql"/>
+    <property name="boolean.true" value="true" dbms="postgresql"/>
+    <property name="boolean.false" value="false" dbms="postgresql"/>
+    <property name="boolean.true" value="true" dbms="h2"/>
+    <property name="boolean.false" value="false" dbms="h2"/>
+
     <!-- Add plan_job and approve_job columns to team table -->
     <changeSet id="add-plan-approve-to-team" author="terrakube">
         <addColumn tableName="team">
@@ -24,7 +31,7 @@
         <update tableName="team">
             <column name="plan_job" valueBoolean="true"/>
             <column name="approve_job" valueBoolean="true"/>
-            <where>manage_job = true</where>
+            <where>manage_job = ${boolean.true}</where>
         </update>
     </changeSet>
 
@@ -33,7 +40,7 @@
         <update tableName="team">
             <column name="plan_job" valueBoolean="false"/>
             <column name="approve_job" valueBoolean="false"/>
-            <where>manage_job = false</where>
+            <where>manage_job = ${boolean.false}</where>
         </update>
     </changeSet>
 
@@ -61,7 +68,7 @@
         <update tableName="access">
             <column name="plan_job" valueBoolean="true"/>
             <column name="approve_job" valueBoolean="true"/>
-            <where>manage_job = true</where>
+            <where>manage_job = ${boolean.true}</where>
         </update>
     </changeSet>
 
@@ -70,7 +77,7 @@
         <update tableName="access">
             <column name="plan_job" valueBoolean="false"/>
             <column name="approve_job" valueBoolean="false"/>
-            <where>manage_job = false</where>
+            <where>manage_job = ${boolean.false}</where>
         </update>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
- Added database-specific boolean property mappings for MSSQL, PostgreSQL, and H2.
- Updated changelog queries to use `${boolean.true}` and `${boolean.false}` for consistency.

Tested using  devcontainer with mssql in docker-compose

```yaml
  mssql-service:
    image: mcr.microsoft.com/mssql/server:2022-latest
    container_name: mssql-service
    restart: unless-stopped
    environment:
      - ACCEPT_EULA=Y
      - MSSQL_SA_PASSWORD=P@ssw0rd!
```



<img width="1821" height="420" alt="imagen" src="https://github.com/user-attachments/assets/808e3417-0622-4f14-a284-dd9756addaab" />

Tested also with postgresql, start version 2.31.1

```shell
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::               (v3.5.11)

2026-03-06T22:38:11.849Z  INFO 1 --- [           main] io.terrakube.api.ServerApplication       : Starting ServerApplication v2.30.1 using Java 25.0.2 with PID 1 (/workspace/BOOT-INF/classes started by cnb in /workspace)
2026-03-06T22:38:11.851Z  INFO 1 --- [           main] io.terrakube.api.ServerApplication       : The following 1 profile is active: "demo"
2026-03-06T22:38:12.795Z  INFO 1 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Multiple Spring Data modules found, entering strict repository configuration mode
2026-03-06T22:38:12.796Z  INFO 1 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JPA repositories in DEFAULT mode.
2026-03-06T22:38:12.948Z  INFO 1 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 141 ms. Found 32 JPA repository interfaces.
2026-03-06T22:38:13.619Z  INFO 1 --- [           main] o.s.cloud.context.scope.GenericScope     : BeanFactory id=fb2c92ec-f260-3241-b4ed-3b9dc245f432
2026-03-06T22:38:14.141Z  INFO 1 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port 8080 (http)
2026-03-06T22:38:14.151Z  INFO 1 --- [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
2026-03-06T22:38:14.152Z  INFO 1 --- [           main] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/10.1.52]
2026-03-06T22:38:14.238Z  INFO 1 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
2026-03-06T22:38:14.239Z  INFO 1 --- [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 2321 ms
2026-03-06T22:38:14.575Z  INFO 1 --- [           main] i.t.a.p.s.StreamingConfiguration         : Using default Redis connection
2026-03-06T22:38:14.576Z  INFO 1 --- [           main] i.t.a.p.s.StreamingConfiguration         : Redis connection is not using username parameter
2026-03-06T22:38:14.576Z  INFO 1 --- [           main] i.t.a.p.s.StreamingConfiguration         : Redis User: NULL username, Hostname: terrakube-redis-master, Port: 6379, Ssl: false
2026-03-06T22:38:14.629Z  INFO 1 --- [           main] i.t.a.p.d.DataSourceAutoConfiguration    : DataSourceType: POSTGRESQL
```

Later starting a custom build (2.30.2) with the fix and the app can start without any issue

<img width="1520" height="785" alt="imagen" src="https://github.com/user-attachments/assets/bfd9ce95-25ab-4863-96e0-1cb55394d441" />

fix #3025