### PR TITLE
feat: configure HikariCP for improved datasource connection pooling

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/datasource/DataSourceAutoConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/plugin/datasource/DataSourceAutoConfiguration.java
@@ -1,14 +1,14 @@
 package io.terrakube.api.plugin.datasource;
 
 import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import lombok.extern.slf4j.Slf4j;
 import org.postgresql.ds.PGSimpleDataSource;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.jdbc.datasource.DriverManagerDataSource;
-
 import javax.sql.DataSource;
 
 @Slf4j
@@ -22,7 +22,13 @@ public class DataSourceAutoConfiguration {
     @Bean
     public DataSource getDataSource(DataSourceConfigurationProperties dataSourceConfigurationProperties) {
         log.info("DataSourceType: {}", dataSourceConfigurationProperties.getType());
-        DataSource dataSource = null;
+        HikariConfig config = new HikariConfig();
+        config.setMaximumPoolSize(dataSourceConfigurationProperties.getPoolSize());
+        config.setMinimumIdle(dataSourceConfigurationProperties.getPoolMinIdle());
+        config.setConnectionTimeout(dataSourceConfigurationProperties.getPoolConnectionTimeout());
+        config.setIdleTimeout(dataSourceConfigurationProperties.getPoolIdleTimeout());
+        config.setMaxLifetime(dataSourceConfigurationProperties.getPoolMaxLifetime());
+
         switch (dataSourceConfigurationProperties.getType()) {
             case SQL_AZURE:
                 SQLServerDataSource sqlServerDataSource = new SQLServerDataSource();
@@ -34,7 +40,7 @@ public class DataSourceAutoConfiguration {
                 sqlServerDataSource.setLoginTimeout(30);
                 sqlServerDataSource.setTrustServerCertificate(dataSourceConfigurationProperties.isTrustCertificate());
 
-                dataSource = sqlServerDataSource;
+                config.setDataSource(sqlServerDataSource);
                 break;
             case POSTGRESQL:
                 log.info("postgresql datasource using SSL Mode: {}", dataSourceConfigurationProperties.getSslMode());
@@ -53,17 +59,15 @@ public class DataSourceAutoConfiguration {
                 ds.setPassword(dataSourceConfigurationProperties.getDatabasePassword());
                 ds.setCurrentSchema(dataSourceConfigurationProperties.getDatabaseSchema());
                 ds.setSslMode(dataSourceConfigurationProperties.getSslMode());
-                dataSource = ds;
+                config.setDataSource(ds);
                 break;
             default:
-                DriverManagerDataSource h2DataSource = new DriverManagerDataSource();
-                h2DataSource.setDriverClassName("org.h2.Driver");
-                h2DataSource.setUrl("jdbc:h2:mem:db;DB_CLOSE_DELAY=-1");
-                h2DataSource.setUsername("sa");
-                h2DataSource.setPassword("sa");
-                dataSource = h2DataSource;
+                config.setDriverClassName("org.h2.Driver");
+                config.setJdbcUrl("jdbc:h2:mem:db;DB_CLOSE_DELAY=-1");
+                config.setUsername("sa");
+                config.setPassword("sa");
                 break;
         }
-        return dataSource;
+        return new HikariDataSource(config);
     }
 }

--- a/api/src/main/java/io/terrakube/api/plugin/datasource/DataSourceConfigurationProperties.java
+++ b/api/src/main/java/io/terrakube/api/plugin/datasource/DataSourceConfigurationProperties.java
@@ -4,9 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.stereotype.Component;
 
-@Component
 @Getter
 @Setter
 @PropertySource(value = "classpath:application.properties", ignoreResourceNotFound = true)
@@ -24,4 +22,10 @@ public class DataSourceConfigurationProperties {
     private boolean awsIamAuth;
     private boolean trustCertificate;
     private String awsRegion;
+
+    private int poolSize = 10;
+    private int poolMinIdle = 5;
+    private long poolConnectionTimeout = 30000;
+    private long poolIdleTimeout = 600000;
+    private long poolMaxLifetime = 1800000;
 }

--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -54,6 +54,11 @@ io.terrakube.api.plugin.datasource.databasePort=${DatasourcePort:5432}
 io.terrakube.api.plugin.datasource.databaseSchema=${DatasourceSchema:public}
 io.terrakube.api.plugin.datasource.awsIamAuth=${DatasourceAwsIamAuth:false}
 io.terrakube.api.plugin.datasource.awsRegion=${DatasourceAwsRegion:aws-region-not-set}
+io.terrakube.api.plugin.datasource.poolSize=${DatasourcePoolSize:10}
+io.terrakube.api.plugin.datasource.poolMinIdle=${DatasourcePoolMinIdle:5}
+io.terrakube.api.plugin.datasource.poolConnectionTimeout=${DatasourcePoolConnectionTimeout:30000}
+io.terrakube.api.plugin.datasource.poolIdleTimeout=${DatasourcePoolIdleTimeout:600000}
+io.terrakube.api.plugin.datasource.poolMaxLifetime=${DatasourcePoolMaxLifetime:1800000}
 
 ################
 #OWNER INSTANCE#

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -54,6 +54,11 @@ io.terrakube.api.plugin.datasource.databasePort=${DatasourcePort:5432}
 io.terrakube.api.plugin.datasource.databaseSchema=${DatasourceSchema:public}
 io.terrakube.api.plugin.datasource.awsIamAuth=${DatasourceAwsIamAuth:false}
 io.terrakube.api.plugin.datasource.awsRegion=${DatasourceAwsRegion:aws-region-not-set}
+io.terrakube.api.plugin.datasource.poolSize=${DatasourcePoolSize:10}
+io.terrakube.api.plugin.datasource.poolMinIdle=${DatasourcePoolMinIdle:5}
+io.terrakube.api.plugin.datasource.poolConnectionTimeout=${DatasourcePoolConnectionTimeout:30000}
+io.terrakube.api.plugin.datasource.poolIdleTimeout=${DatasourcePoolIdleTimeout:600000}
+io.terrakube.api.plugin.datasource.poolMaxLifetime=${DatasourcePoolMaxLifetime:1800000}
 
 ################
 #OWNER INSTANCE#


### PR DESCRIPTION
- Replaced `DriverManagerDataSource` with `HikariDataSource` in `DataSourceAutoConfiguration`.
- Added new connection pool properties (`poolSize`, `poolMinIdle`, `poolConnectionTimeout`, `poolIdleTimeout`, `poolMaxLifetime`) in `DataSourceConfigurationProperties`.
- Updated `application.properties` and `application-demo.properties` to include default pool configurations.