### PR TITLE
Fix VCS form validation to prevent PKCS#1 private key errors

### DIFF
--- a/ui/src/domain/Settings/AddVCS.tsx
+++ b/ui/src/domain/Settings/AddVCS.tsx
@@ -48,6 +48,39 @@ export const AddVCS = ({ setMode, loadVCS }: Props) => {
   const [vcsType, setVcsType] = useState<VcsTypeExtended>(vcsName ? vcsName : VcsTypeExtended.GITHUB);
   const [connectionType, setConnectionType] = useState(VcsConnectionType.OAUTH);
   const [uuid] = useState(uuidv1());
+
+  const validatePrivateKeyFormat = (_: any, value: string) => {
+    if (!value) {
+      return Promise.resolve();
+    }
+
+    if (!value.includes("-----BEGIN PRIVATE KEY-----")) {
+      return Promise.reject(new Error("Private key must be in PKCS#8 format (-----BEGIN PRIVATE KEY-----)"));
+    }
+
+    if (!value.includes("-----END PRIVATE KEY-----")) {
+      return Promise.reject(new Error("Private key is incomplete (missing -----END PRIVATE KEY-----)"));
+    }
+
+    return Promise.resolve();
+  };
+
+  const validateUrlFormat = (_: any, value: string) => {
+    if (!value) {
+      return Promise.resolve();
+    }
+
+    try {
+      const url = new URL(value);
+      if (url.protocol !== "http:" && url.protocol !== "https:") {
+        return Promise.reject(new Error("URL must start with http:// or https://"));
+      }
+      return Promise.resolve();
+    } catch {
+      return Promise.reject(new Error("Please enter a valid URL"));
+    }
+  };
+
   const handleChange = (currentVal: number) => {
     setCurrent(currentVal);
   };
@@ -826,7 +859,7 @@ export const AddVCS = ({ setMode, loadVCS }: Props) => {
             <Form.Item
               name="endpoint"
               label="HTTPS URL"
-              rules={[{ required: !httpsHidden(vcsType) }]}
+              rules={[{ required: !httpsHidden(vcsType) }, { validator: validateUrlFormat }]}
               hidden={httpsHidden(vcsType)}
             >
               <Input placeholder={getHttpsPlaceholder(vcsType)} />
@@ -834,7 +867,7 @@ export const AddVCS = ({ setMode, loadVCS }: Props) => {
             <Form.Item
               name="apiUrl"
               label="API URL"
-              rules={[{ required: !apiUrlHidden(vcsType) }]}
+              rules={[{ required: !apiUrlHidden(vcsType) }, { validator: validateUrlFormat }]}
               hidden={apiUrlHidden(vcsType)}
             >
               <Input placeholder={getAPIUrlPlaceholder(vcsType)} />
@@ -854,7 +887,7 @@ export const AddVCS = ({ setMode, loadVCS }: Props) => {
             <Form.Item
               name="privateKey"
               label={getSecretIdName(vcsType)}
-              rules={[{ required: connectionType != "OAUTH" ? true : false }]}
+              rules={[{ required: connectionType != "OAUTH" ? true : false }, { validator: validatePrivateKeyFormat }]}
               hidden={connectionType === "OAUTH"}
             >
               <TextArea placeholder="-----BEGIN PRIVATE KEY-----" style={{ minHeight: "200px" }} />


### PR DESCRIPTION
## Description
This PR fixes an issue where entering PKCS#1 format private keys in the VCS provider configuration form caused internal server errors. The fix adds client-side validation to prevent invalid key formats from being submitted.

## Problem
Users could enter PKCS#1 format private keys, which caused internal server errors when the backend tried to process them. This happened because the system expected PKCS#8 format keys.

## Solution
Added input validation to the VCS provider configuration form:

- **Private Key Validation**: Ensures private keys are in PKCS#8 format (contains `-----BEGIN PRIVATE KEY-----` and `-----END PRIVATE KEY-----`)
- **URL Validation**: Validates that endpoint and API URL fields contain valid URLs starting with `http://` or `https://`

## Changes
- Added `validatePrivateKeyFormat()` function to check PKCS#8 format
- Added `validateUrlFormat()` function to validate URL formats
- Updated form validation rules for `privateKey`, `endpoint`, and `apiUrl` fields

## Error Messages
- Private key: "Private key must be in PKCS#8 format" or "Private key is incomplete"
- URLs: "URL must start with http:// or https://" or "Please enter a valid URL"

## Testing
1. Try entering a PKCS#1 format private key (should show validation error)
2. Try entering invalid URLs (should show validation error)
3. Verify valid PKCS#8 keys and URLs are accepted
4. Verify form submission is blocked for invalid inputs

## Screenshots

<img width="1064" height="883" alt="image" src="https://github.com/user-attachments/assets/9c5067e4-12bc-48df-8f94-85f098ab0482" />

<img width="1069" height="882" alt="image" src="https://github.com/user-attachments/assets/22b5733e-72eb-4066-baf8-c47310b04f74" />

