### PR TITLE
feat(webhooks): shared repo-level VCS webhooks for GitHub

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
@@ -3,10 +3,14 @@ package io.terrakube.api.plugin.vcs;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import io.terrakube.api.plugin.scheduler.ScheduleJobService;
@@ -14,11 +18,14 @@ import io.terrakube.api.plugin.vcs.provider.bitbucket.BitBucketWebhookService;
 import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
 import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
 import io.terrakube.api.repository.JobRepository;
+import io.terrakube.api.repository.VcsWebhookRepository;
 import io.terrakube.api.repository.WebhookEventRepository;
 import io.terrakube.api.repository.WebhookRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.webhook.VcsWebhook;
 import io.terrakube.api.rs.webhook.Webhook;
 import io.terrakube.api.rs.webhook.WebhookEvent;
 import io.terrakube.api.rs.webhook.WebhookEventType;
@@ -26,22 +33,53 @@ import io.terrakube.api.rs.workspace.Workspace;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@AllArgsConstructor
 @Slf4j
 @Service
 public class WebhookService {
 
-    WebhookRepository webhookRepository;
-    WebhookEventRepository webhookEventRepository;
-    GitHubWebhookService gitHubWebhookService;
-    GitLabWebhookService gitLabWebhookService;
-    BitBucketWebhookService bitBucketWebhookService;
-    JobRepository jobRepository;
-    ScheduleJobService scheduleJobService;
-    ObjectMapper objectMapper;
+    private final WebhookRepository webhookRepository;
+    private final WebhookEventRepository webhookEventRepository;
+    private final VcsWebhookRepository vcsWebhookRepository;
+    private final WorkspaceRepository workspaceRepository;
+    private final GitHubWebhookService gitHubWebhookService;
+    private final GitLabWebhookService gitLabWebhookService;
+    private final BitBucketWebhookService bitBucketWebhookService;
+    private final JobRepository jobRepository;
+    private final ScheduleJobService scheduleJobService;
+    private final ObjectMapper objectMapper;
+
+    @Value("${io.terrakube.hostname}")
+    private String hostname;
+
+    public WebhookService(
+            WebhookRepository webhookRepository,
+            WebhookEventRepository webhookEventRepository,
+            VcsWebhookRepository vcsWebhookRepository,
+            WorkspaceRepository workspaceRepository,
+            GitHubWebhookService gitHubWebhookService,
+            GitLabWebhookService gitLabWebhookService,
+            BitBucketWebhookService bitBucketWebhookService,
+            JobRepository jobRepository,
+            ScheduleJobService scheduleJobService,
+            ObjectMapper objectMapper) {
+        this.webhookRepository = webhookRepository;
+        this.webhookEventRepository = webhookEventRepository;
+        this.vcsWebhookRepository = vcsWebhookRepository;
+        this.workspaceRepository = workspaceRepository;
+        this.gitHubWebhookService = gitHubWebhookService;
+        this.gitLabWebhookService = gitLabWebhookService;
+        this.bitBucketWebhookService = bitBucketWebhookService;
+        this.jobRepository = jobRepository;
+        this.scheduleJobService = scheduleJobService;
+        this.objectMapper = objectMapper;
+    }
+
+    public Webhook getWebhookById(String webhookId) {
+        return webhookRepository.findById(UUID.fromString(webhookId))
+                .orElseThrow(() -> new IllegalArgumentException("Webhook not found: " + webhookId));
+    }
 
     @Transactional
     public String processWebhook(String webhookId, String jsonPayload, Map<String, String> headers) {
@@ -122,13 +160,27 @@ public class WebhookService {
             throw new IllegalArgumentException("No VCS defined for workspace");
         }
 
-        String webhookRemoteId = "";
-
         Vcs vcs = workspace.getVcs();
+
+        // GitHub uses shared VcsWebhook mode for new webhooks
+        if (vcs.getVcsType() == io.terrakube.api.rs.vcs.VcsType.GITHUB) {
+            // If this is an update to an existing legacy webhook, keep using legacy mode
+            if (webhook.getRemoteHookId() != null && !webhook.getRemoteHookId().isEmpty()) {
+                String webhookRemoteId = gitHubWebhookService.createOrUpdateWebhook(workspace, webhook);
+                if (webhookRemoteId == null || webhookRemoteId.isEmpty()) {
+                    throw new IllegalArgumentException("Error updating the legacy webhook");
+                }
+                webhook.setRemoteHookId(webhookRemoteId);
+                return;
+            }
+
+            createOrReuseSharedWebhook(workspace, webhook, vcs);
+            return;
+        }
+
+        // GitLab and Bitbucket continue with legacy per-workspace mode
+        String webhookRemoteId = "";
         switch (vcs.getVcsType()) {
-            case GITHUB:
-                webhookRemoteId = gitHubWebhookService.createOrUpdateWebhook(workspace, webhook);
-                break;
             case GITLAB:
                 webhookRemoteId = gitLabWebhookService.createOrUpdateWebhook(workspace, webhook);
                 break;
@@ -147,32 +199,121 @@ public class WebhookService {
         webhook.setRemoteHookId(webhookRemoteId);
     }
 
+    private void createOrReuseSharedWebhook(Workspace workspace, Webhook webhook, Vcs vcs) {
+        String normalizedUrl = WebhookServiceBase.normalizeRepositoryUrl(workspace.getSource());
+        VcsWebhook vcsWebhook = vcsWebhookRepository.findByVcsAndRepositoryUrl(vcs, normalizedUrl)
+                .orElse(null);
+
+        if (vcsWebhook == null) {
+            vcsWebhook = new VcsWebhook();
+            vcsWebhook.setVcs(vcs);
+            vcsWebhook.setRepositoryUrl(normalizedUrl);
+            vcsWebhook.setSecret(UUID.randomUUID().toString());
+            vcsWebhook = vcsWebhookRepository.save(vcsWebhook);
+
+            String callbackUrl = String.format("https://%s/webhook/v1/vcs/%s", hostname, vcsWebhook.getId().toString());
+            List<String> events = collectEventTypes(webhook);
+            String remoteHookId = gitHubWebhookService.createSharedWebhook(vcs, workspace.getSource(), callbackUrl, vcsWebhook.getSecret(), events);
+            if (remoteHookId == null) {
+                vcsWebhookRepository.delete(vcsWebhook);
+                throw new IllegalArgumentException("Error creating shared GitHub webhook");
+            }
+            vcsWebhook.setRemoteHookId(remoteHookId);
+            vcsWebhookRepository.save(vcsWebhook);
+            log.info("Created shared VcsWebhook {} for repo {}", vcsWebhook.getId(), normalizedUrl);
+        } else {
+            // Shared webhook exists — update event types on GitHub if needed
+            List<String> allEvents = collectAllEventTypesForRepo(vcs, normalizedUrl, webhook);
+            gitHubWebhookService.updateSharedWebhookEvents(vcs, workspace.getSource(), vcsWebhook.getRemoteHookId(), allEvents);
+            log.info("Reusing shared VcsWebhook {} for workspace {}", vcsWebhook.getId(), workspace.getName());
+        }
+
+        // Workspace webhook doesn't own a remote hook in shared mode
+        webhook.setRemoteHookId(null);
+    }
+
+    private List<String> collectEventTypes(Webhook webhook) {
+        return webhook.getEvents().stream()
+                .map(WebhookEvent::getEvent)
+                .distinct()
+                .map(e -> String.valueOf(e).toLowerCase())
+                .collect(Collectors.toList());
+    }
+
+    private List<String> collectAllEventTypesForRepo(Vcs vcs, String normalizedUrl, Webhook newWebhook) {
+        Set<String> events = new HashSet<>();
+        // Collect from existing workspaces on this repo
+        for (Workspace ws : workspaceRepository.findByVcsAndWebhookIsNotNull(vcs)) {
+            if (WebhookServiceBase.normalizeRepositoryUrl(ws.getSource()).equals(normalizedUrl)) {
+                ws.getWebhook().getEvents().forEach(e -> events.add(String.valueOf(e.getEvent()).toLowerCase()));
+            }
+        }
+        // Add events from the new webhook being created
+        if (newWebhook != null && newWebhook.getEvents() != null) {
+            newWebhook.getEvents().forEach(e -> events.add(String.valueOf(e.getEvent()).toLowerCase()));
+        }
+        return List.copyOf(events);
+    }
+
     @Transactional
     public void deleteWorkspaceWebhook(Webhook webhook) {
         Workspace workspace = webhook.getWorkspace();
         if (workspace.getVcs() == null) {
-            log.warn("There is no VCS defined for workspace {}, skipping webhook creation", workspace.getName());
-            return;
-        }
-        if (webhook.getRemoteHookId() == null || webhook.getRemoteHookId().isEmpty()) {
-            log.warn("No remote hook id found for webhook {} on workspace {}, skipping webhook deletion",
-                    webhook.getId(), workspace.getName());
+            log.warn("There is no VCS defined for workspace {}, skipping webhook deletion", workspace.getName());
             return;
         }
 
         Vcs vcs = workspace.getVcs();
-        switch (vcs.getVcsType()) {
-            case GITHUB:
-                gitHubWebhookService.deleteWebhook(workspace, webhook.getRemoteHookId());
-                break;
-            case GITLAB:
-                gitLabWebhookService.deleteWebhook(workspace, webhook.getRemoteHookId());
-                break;
-            case BITBUCKET:
-                bitBucketWebhookService.deleteWebhook(workspace, webhook.getRemoteHookId());
-                break;
-            default:
-                break;
+
+        // Legacy mode: webhook owns its own remote hook
+        if (webhook.getRemoteHookId() != null && !webhook.getRemoteHookId().isEmpty()) {
+            switch (vcs.getVcsType()) {
+                case GITHUB:
+                    gitHubWebhookService.deleteWebhook(workspace, webhook.getRemoteHookId());
+                    break;
+                case GITLAB:
+                    gitLabWebhookService.deleteWebhook(workspace, webhook.getRemoteHookId());
+                    break;
+                case BITBUCKET:
+                    bitBucketWebhookService.deleteWebhook(workspace, webhook.getRemoteHookId());
+                    break;
+                default:
+                    break;
+            }
+            return;
+        }
+
+        // Shared mode: check if VcsWebhook should be cleaned up
+        if (vcs.getVcsType() == io.terrakube.api.rs.vcs.VcsType.GITHUB) {
+            cleanupSharedWebhookIfNeeded(workspace, vcs);
+        }
+    }
+
+    private void cleanupSharedWebhookIfNeeded(Workspace workspace, Vcs vcs) {
+        String normalizedUrl = WebhookServiceBase.normalizeRepositoryUrl(workspace.getSource());
+        VcsWebhook vcsWebhook = vcsWebhookRepository.findByVcsAndRepositoryUrl(vcs, normalizedUrl)
+                .orElse(null);
+
+        if (vcsWebhook == null) {
+            return;
+        }
+
+        // Count other workspaces still using this repo with webhooks (excluding the one being deleted)
+        long remaining = workspaceRepository.findByVcsAndWebhookIsNotNull(vcs).stream()
+                .filter(ws -> WebhookServiceBase.normalizeRepositoryUrl(ws.getSource()).equals(normalizedUrl))
+                .filter(ws -> !ws.getId().equals(workspace.getId()))
+                .count();
+
+        if (remaining == 0) {
+            // Last workspace — delete the shared GitHub hook and VcsWebhook record
+            gitHubWebhookService.deleteSharedWebhook(vcs, workspace.getSource(), vcsWebhook.getRemoteHookId());
+            vcsWebhookRepository.delete(vcsWebhook);
+            log.info("Deleted shared VcsWebhook {} for repo {} (no remaining workspaces)", vcsWebhook.getId(), normalizedUrl);
+        } else {
+            // Other workspaces remain — recalculate event types
+            List<String> remainingEvents = collectAllEventTypesForRepo(vcs, normalizedUrl, null);
+            gitHubWebhookService.updateSharedWebhookEvents(vcs, workspace.getSource(), vcsWebhook.getRemoteHookId(), remainingEvents);
+            log.info("Updated shared VcsWebhook {} events after removing workspace {}", vcsWebhook.getId(), workspace.getName());
         }
     }
 
@@ -224,6 +365,128 @@ public class WebhookService {
                 .orElseThrow(() -> new IllegalArgumentException(
                         "No valid template found for the configured webhook event " + result.getEvent() + "normalized " + result.getNormalizedEvent()))
                 .getTemplateId();
+    }
+
+    @Transactional
+    public void processSharedWebhook(String vcsWebhookId, String jsonPayload, Map<String, String> headers) {
+        VcsWebhook vcsWebhook = vcsWebhookRepository.findById(UUID.fromString(vcsWebhookId))
+                .orElseThrow(() -> new IllegalArgumentException("VcsWebhook not found: " + vcsWebhookId));
+
+        Vcs vcs = vcsWebhook.getVcs();
+        WebhookResult webhookResult;
+
+        switch (vcs.getVcsType()) {
+            case GITHUB:
+                webhookResult = gitHubWebhookService.processSharedWebhook(jsonPayload, headers, vcsWebhook.getSecret(), vcs);
+                break;
+            default:
+                log.warn("Shared webhooks not supported for VCS type {}", vcs.getVcsType());
+                return;
+        }
+
+        log.info("Shared webhook result {}", webhookResult);
+
+        if (!webhookResult.isValid()
+                || webhookResult.getEvent().equals(String.valueOf(WebhookEventType.PING).toLowerCase())) {
+            return;
+        }
+
+        // Fan out to all workspaces on this repo
+        String normalizedUrl = vcsWebhook.getRepositoryUrl();
+        List<Workspace> workspaces = workspaceRepository.findByVcsAndWebhookIsNotNull(vcs).stream()
+                .filter(ws -> WebhookServiceBase.normalizeRepositoryUrl(ws.getSource()).equals(normalizedUrl))
+                .collect(Collectors.toList());
+
+        log.info("Shared webhook fan-out: {} workspaces matched for repo {}", workspaces.size(), normalizedUrl);
+
+        for (Workspace workspace : workspaces) {
+            try {
+                // Skip workspaces with legacy webhooks (they have their own GitHub hook)
+                Webhook webhook = workspace.getWebhook();
+                if (webhook.getRemoteHookId() != null && !webhook.getRemoteHookId().isEmpty()) {
+                    log.debug("Skipping workspace {} — has legacy webhook", workspace.getName());
+                    continue;
+                }
+
+                String templateId = webhookResult.isRelease()
+                        ? findTemplateIdRelease(webhookResult, webhook)
+                        : findTemplateId(webhookResult, webhook);
+
+                log.info("Shared webhook: matched workspace {} with template {}", workspace.getName(), templateId);
+                Job job = new Job();
+                job.setTemplateReference(templateId);
+                job.setRefresh(true);
+                job.setPlanChanges(true);
+                job.setRefreshOnly(false);
+                job.setOverrideBranch(webhookResult.isRelease() ? "refs/tags/" + webhookResult.getBranch() : webhookResult.getBranch());
+                job.setOrganization(workspace.getOrganization());
+                job.setWorkspace(workspace);
+                job.setCreatedBy(webhookResult.getCreatedBy());
+                job.setUpdatedBy(webhookResult.getCreatedBy());
+                Date triggerDate = new Date(System.currentTimeMillis());
+                job.setCreatedDate(triggerDate);
+                job.setUpdatedDate(triggerDate);
+                job.setVia(webhookResult.getVia());
+                job.setCommitId(webhookResult.getCommit());
+                Job savedJob = jobRepository.save(job);
+                if (!webhookResult.isRelease()) {
+                    sendCommitStatus(savedJob);
+                }
+                scheduleJobService.createJobContext(savedJob);
+            } catch (Exception e) {
+                log.error("Error processing shared webhook for workspace {}", workspace.getName(), e);
+            }
+        }
+    }
+
+    @Transactional
+    public void migrateToSharedWebhook(Webhook webhook) {
+        Workspace workspace = webhook.getWorkspace();
+        Vcs vcs = workspace.getVcs();
+
+        if (vcs == null || vcs.getVcsType() != io.terrakube.api.rs.vcs.VcsType.GITHUB) {
+            throw new IllegalArgumentException("Migration to shared webhook is only supported for GitHub");
+        }
+
+        if (webhook.getRemoteHookId() == null || webhook.getRemoteHookId().isEmpty()) {
+            throw new IllegalArgumentException("Webhook is already using shared mode");
+        }
+
+        // Delete the old per-workspace GitHub hook
+        gitHubWebhookService.deleteWebhook(workspace, webhook.getRemoteHookId());
+
+        // Create or reuse the shared VcsWebhook
+        String normalizedUrl = WebhookServiceBase.normalizeRepositoryUrl(workspace.getSource());
+        VcsWebhook vcsWebhook = vcsWebhookRepository.findByVcsAndRepositoryUrl(vcs, normalizedUrl)
+                .orElse(null);
+
+        if (vcsWebhook == null) {
+            vcsWebhook = new VcsWebhook();
+            vcsWebhook.setVcs(vcs);
+            vcsWebhook.setRepositoryUrl(normalizedUrl);
+            vcsWebhook.setSecret(UUID.randomUUID().toString());
+            vcsWebhook = vcsWebhookRepository.save(vcsWebhook);
+
+            String callbackUrl = String.format("https://%s/webhook/v1/vcs/%s", hostname, vcsWebhook.getId().toString());
+            List<String> events = collectAllEventTypesForRepo(vcs, normalizedUrl, webhook);
+            String remoteHookId = gitHubWebhookService.createSharedWebhook(vcs, workspace.getSource(), callbackUrl, vcsWebhook.getSecret(), events);
+            if (remoteHookId == null) {
+                vcsWebhookRepository.delete(vcsWebhook);
+                throw new IllegalArgumentException("Error creating shared GitHub webhook during migration");
+            }
+            vcsWebhook.setRemoteHookId(remoteHookId);
+            vcsWebhookRepository.save(vcsWebhook);
+        } else {
+            // Update event types on the existing shared hook
+            List<String> allEvents = collectAllEventTypesForRepo(vcs, normalizedUrl, webhook);
+            gitHubWebhookService.updateSharedWebhookEvents(vcs, workspace.getSource(), vcsWebhook.getRemoteHookId(), allEvents);
+        }
+
+        // Clear the per-workspace remote hook ID to mark as shared mode
+        webhook.setRemoteHookId(null);
+        webhookRepository.save(webhook);
+
+        log.info("Migrated workspace {} webhook to shared VcsWebhook {}", workspace.getName(), vcsWebhook.getId());
     }
 
     private void sendCommitStatus(Job job) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookServiceBase.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookServiceBase.java
@@ -105,6 +105,46 @@ public class WebhookServiceBase {
         return restTemplate.exchange(apiUrl, method, entity, String.class);
     }
 
+    public static String normalizeRepositoryUrl(String repoUrl) {
+        if (repoUrl == null) {
+            return null;
+        }
+        String normalized = repoUrl.toLowerCase().trim();
+        if (normalized.endsWith(".git")) {
+            normalized = normalized.substring(0, normalized.length() - 4);
+        }
+        if (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
+    }
+
+    protected WebhookResult handleWebhookWithSecret(String jsonPayload, Map<String, String> headers,
+            String secret, String signatureHeader, String via,
+            TriFunction<String, WebhookResult, Map<String, String>, WebhookResult> handleEvent) {
+        WebhookResult result = new WebhookResult();
+        result.setBranch("");
+        result.setVia(via);
+
+        log.info("verify signature for shared " + via + " webhook");
+        result.setValid(verifySignature(headers, signatureHeader, secret, jsonPayload));
+
+        if (!result.isValid()) {
+            log.info("Signature verification failed for shared webhook");
+            return result;
+        }
+
+        log.info("Parsing shared " + via + " webhook payload");
+
+        try {
+            result = handleEvent.apply(jsonPayload, result, headers);
+        } catch (Exception e) {
+            log.info("Error processing the shared webhook", e);
+        }
+
+        return result;
+    }
+
     protected WebhookResult handleWebhook(String jsonPayload, Map<String, String> headers, String token,
             String signatureHeader, String via,
             TriFunction<String, WebhookResult, Map<String, String>, WebhookResult> handleEvent) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/controller/WebHookController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/controller/WebHookController.java
@@ -39,4 +39,33 @@ public class WebHookController {
         }
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/webhook/v1/vcs/{vcsWebhookId}")
+    public ResponseEntity<String> processVcsWebhook(@PathVariable String vcsWebhookId, @RequestBody Map<String, Object> payload, @RequestHeader Map<String, String> headers) {
+
+        log.info("Processing shared VCS webhook {}", vcsWebhookId);
+        try {
+            String jsonPayload = objectMapper.writeValueAsString(payload);
+            log.info("shared webhook payload: {}", jsonPayload);
+            webhookService.processSharedWebhook(vcsWebhookId, jsonPayload, headers);
+        } catch (Exception e) {
+            log.error("Error processing shared VCS webhook", e);
+            return ResponseEntity.internalServerError().build();
+        }
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/api/v1/webhook/{webhookId}/migrate")
+    public ResponseEntity<String> migrateWebhook(@PathVariable String webhookId) {
+
+        log.info("Migrating webhook {} to shared mode", webhookId);
+        try {
+            webhookService.migrateToSharedWebhook(
+                    webhookService.getWebhookById(webhookId));
+        } catch (Exception e) {
+            log.error("Error migrating webhook to shared mode", e);
+            return ResponseEntity.internalServerError().build();
+        }
+        return ResponseEntity.ok().build();
+    }
 }

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -54,6 +54,63 @@ public class GitHubWebhookService extends WebhookServiceBase {
                 (payload, result, headerMap) -> handleEvent(payload, result, headerMap, vcs));
     }
 
+    public WebhookResult processSharedWebhook(String jsonPayload, Map<String, String> headers, String secret, Vcs vcs) {
+        return handleWebhookWithSecret(jsonPayload, headers, secret, "x-hub-signature-256", JobVia.Github.name(),
+                (payload, result, headerMap) -> handleEvent(payload, result, headerMap, vcs));
+    }
+
+    public String createSharedWebhook(Vcs vcs, String repoSource, String callbackUrl, String secret, List<String> events) {
+        String[] ownerAndRepo = extractOwnerAndRepo(repoSource);
+        String eventsJson = events.stream()
+                .map(e -> "\"" + e.toLowerCase() + "\"")
+                .collect(Collectors.joining(","));
+        String body = "{\"name\":\"web\",\"active\":true,\"events\":[" + eventsJson
+                + "],\"config\":{\"url\":\"" + callbackUrl
+                + "\",\"secret\":\"" + secret + "\",\"content_type\":\"json\",\"insecure_ssl\":\"1\"}}";
+        String apiUrl = vcs.getApiUrl() + "/repos/" + String.join("/", ownerAndRepo) + "/hooks";
+
+        ResponseEntity<String> response = callGitHubApi(vcs, ownerAndRepo, body, apiUrl, HttpMethod.POST);
+        if (response != null && response.getStatusCode().value() == 201) {
+            try {
+                JsonNode rootNode = objectMapper.readTree(response.getBody());
+                String id = rootNode.path("id").asText();
+                log.info("Shared GitHub webhook created for repo {} with remote id {}", repoSource, id);
+                return id;
+            } catch (Exception e) {
+                log.error("Error parsing GitHub webhook creation response", e);
+            }
+        }
+        return null;
+    }
+
+    public void updateSharedWebhookEvents(Vcs vcs, String repoSource, String remoteHookId, List<String> events) {
+        String[] ownerAndRepo = extractOwnerAndRepo(repoSource);
+        String eventsJson = events.stream()
+                .map(e -> "\"" + e.toLowerCase() + "\"")
+                .collect(Collectors.joining(","));
+        String body = "{\"active\":true, \"events\":[" + eventsJson + "]}";
+        String apiUrl = vcs.getApiUrl() + "/repos/" + String.join("/", ownerAndRepo) + "/hooks/" + remoteHookId;
+
+        ResponseEntity<String> response = callGitHubApi(vcs, ownerAndRepo, body, apiUrl, HttpMethod.PATCH);
+        if (response != null && response.getStatusCode().value() == 200) {
+            log.info("Shared GitHub webhook events updated for repo {}", repoSource);
+        } else {
+            log.error("Failed to update shared GitHub webhook events for repo {}", repoSource);
+        }
+    }
+
+    public void deleteSharedWebhook(Vcs vcs, String repoSource, String remoteHookId) {
+        String[] ownerAndRepo = extractOwnerAndRepo(repoSource);
+        String apiUrl = vcs.getApiUrl() + "/repos/" + String.join("/", ownerAndRepo) + "/hooks/" + remoteHookId;
+
+        ResponseEntity<String> response = callGitHubApi(vcs, ownerAndRepo, "", apiUrl, HttpMethod.DELETE);
+        if (response != null && response.getStatusCode().value() == 204) {
+            log.info("Shared GitHub webhook deleted for repo {}", repoSource);
+        } else {
+            log.warn("Failed to delete shared GitHub webhook for repo {}, remote id {}", repoSource, remoteHookId);
+        }
+    }
+
     private WebhookResult handleEvent(String jsonPayload, WebhookResult result, Map<String, String> headers, Vcs vcs) {
         String event = headers.get("x-github-event");
         result.setEvent(event);

--- a/api/src/main/java/io/terrakube/api/repository/VcsWebhookRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/VcsWebhookRepository.java
@@ -1,0 +1,13 @@
+package io.terrakube.api.repository;
+
+import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.webhook.VcsWebhook;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface VcsWebhookRepository extends JpaRepository<VcsWebhook, UUID> {
+
+    Optional<VcsWebhook> findByVcsAndRepositoryUrl(Vcs vcs, String repositoryUrl);
+}

--- a/api/src/main/java/io/terrakube/api/repository/WorkspaceRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/WorkspaceRepository.java
@@ -1,6 +1,7 @@
 package io.terrakube.api.repository;
 
 import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.vcs.Vcs;
 import io.terrakube.api.rs.workspace.Workspace;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -15,5 +16,7 @@ public interface WorkspaceRepository extends JpaRepository<Workspace, UUID> {
     Optional<List<Workspace>> findWorkspacesByOrganizationNameAndNameStartingWith(String organizationName, String workspaceNameStartingWidth);
 
     Optional<List<Workspace>> findWorkspacesByOrganization(Organization organization);
+
+    List<Workspace> findByVcsAndWebhookIsNotNull(Vcs vcs);
 
 }

--- a/api/src/main/java/io/terrakube/api/rs/webhook/VcsWebhook.java
+++ b/api/src/main/java/io/terrakube/api/rs/webhook/VcsWebhook.java
@@ -1,0 +1,44 @@
+package io.terrakube.api.rs.webhook;
+
+import java.sql.Types;
+import java.util.UUID;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import io.terrakube.api.plugin.security.audit.GenericAuditFields;
+import io.terrakube.api.rs.IdConverter;
+import io.terrakube.api.rs.vcs.Vcs;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity(name = "vcs_webhook")
+public class VcsWebhook extends GenericAuditFields {
+
+    @Id
+    @JdbcTypeCode(Types.VARCHAR)
+    @Convert(converter = IdConverter.class)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private Vcs vcs;
+
+    @Column(name = "repository_url", length = 1024, nullable = false)
+    private String repositoryUrl;
+
+    @Column(name = "remote_hook_id")
+    private String remoteHookId;
+
+    @Column(name = "secret", length = 128)
+    private String secret;
+}

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -94,4 +94,5 @@
     <include file="/db/changelog/local/changelog-2.30.0-provider-imported.xml" />
     <include file="db/changelog/local/changelog-rbac-v2-team-role.xml"/>
     <include file="db/changelog/local/changelog-rbac-v2-plan-approve.xml"/>
+    <include file="db/changelog/local/changelog-2.31.0-vcs-webhook.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.31.0-vcs-webhook.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.31.0-vcs-webhook.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-31-0-1" author="Dennis Webb (denniswebb@users.noreply.github.com)">
+        <createTable tableName="vcs_webhook">
+            <column name="id" type="varchar(36)">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+            <column name="vcs_id" type="varchar(36)">
+                <constraints nullable="false" />
+            </column>
+            <column name="repository_url" type="varchar(1024)">
+                <constraints nullable="false" />
+            </column>
+            <column name="remote_hook_id" type="varchar(220)" />
+            <column name="secret" type="varchar(128)" />
+            <column name="created_date" type="datetime" />
+            <column name="updated_date" type="datetime" />
+            <column name="created_by" type="varchar(128)" />
+            <column name="updated_by" type="varchar(128)" />
+        </createTable>
+        <addForeignKeyConstraint baseTableName="vcs_webhook" baseColumnNames="vcs_id"
+            constraintName="fk_vcs_webhook_vcs_id" referencedTableName="vcs"
+            referencedColumnNames="id" />
+        <addUniqueConstraint tableName="vcs_webhook" columnNames="vcs_id, repository_url"
+            constraintName="uq_vcs_webhook_vcs_repo" />
+    </changeSet>
+</databaseChangeLog>

--- a/ui/src/domain/Workspaces/Settings/Webhook.tsx
+++ b/ui/src/domain/Workspaces/Settings/Webhook.tsx
@@ -1,5 +1,6 @@
 import { InfoCircleOutlined } from "@ant-design/icons";
 import {
+  Alert,
   Button,
   Col,
   Flex,
@@ -18,6 +19,7 @@ import {
 import { useEffect, useState } from "react";
 import { v7 as uuid } from "uuid";
 import axiosInstance from "../../../config/axiosConfig";
+import { axiosRegistry } from "../../../config/axiosConfig";
 import { Template, VcsType, WebhookEvent, Workspace } from "../../types";
 import { atomicHeader, renderVCSLogo } from "../Workspaces";
 
@@ -56,6 +58,8 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
   ]);
   const workspaceId = workspace.id;
   const [remoteHookId, setRemoteHookId] = useState("");
+  const [isLegacyWebhook, setIsLegacyWebhook] = useState(false);
+  const [migrating, setMigrating] = useState(false);
   const webhookId = workspace.relationships.webhook?.data?.id;
 
   useEffect(() => {
@@ -76,7 +80,9 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
       axiosInstance.get(`organization/${organizationId}/workspace/${workspaceId}/webhook/${webhookId}/events`),
     ])
       .then(([webhookRes, eventsRes]) => {
-        setRemoteHookId(webhookRes.data.data.attributes.remoteHookId);
+        const hookId = webhookRes.data.data.attributes.remoteHookId;
+        setRemoteHookId(hookId);
+        setIsLegacyWebhook(!!hookId);
 
         let i = 1;
         const events = eventsRes.data.data
@@ -123,6 +129,27 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
   };
   const handleWebhookClick = () => {
     setWebhookEnabled(!webhookEnabled);
+  };
+  const handleMigrate = () => {
+    if (!webhookId) return;
+    setMigrating(true);
+    axiosRegistry
+      .post(`/api/v1/webhook/${webhookId}/migrate`)
+      .then((response) => {
+        if (response.status === 200) {
+          message.success("Webhook migrated to shared mode");
+          setRemoteHookId("");
+          setIsLegacyWebhook(false);
+        } else {
+          message.error("Failed to migrate webhook");
+        }
+      })
+      .catch(() => {
+        message.error("Failed to migrate webhook");
+      })
+      .finally(() => {
+        setMigrating(false);
+      });
   };
   const onDelete = (record: any) => {
     const newWebhookEvents = webhookEvents.filter((item) => item.key !== record.key);
@@ -407,13 +434,47 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
           >
             <Switch onChange={handleWebhookClick} checked={webhookEnabled} disabled={!manageWorkspace} />
           </Form.Item>
+          {webhookEnabled && isLegacyWebhook && vcsProvider === VcsType.GITHUB && (
+            <Alert
+              style={{ marginBottom: 16 }}
+              type="info"
+              showIcon
+              message="Legacy per-workspace webhook"
+              description={
+                <Space>
+                  <span>This workspace uses its own GitHub webhook. Migrate to a shared webhook to reduce the number of hooks on your repository.</span>
+                  <Popconfirm
+                    title="Migrate to shared webhook?"
+                    description="This will delete the per-workspace GitHub hook and attach to a shared one. Event rules are preserved."
+                    onConfirm={handleMigrate}
+                    okText="Migrate"
+                    cancelText="Cancel"
+                    disabled={!manageWorkspace}
+                  >
+                    <Button type="primary" size="small" loading={migrating} disabled={!manageWorkspace}>
+                      Migrate to shared
+                    </Button>
+                  </Popconfirm>
+                </Space>
+              }
+            />
+          )}
+          {webhookEnabled && !isLegacyWebhook && !remoteHookId && webhookId && (
+            <Alert
+              style={{ marginBottom: 16 }}
+              type="success"
+              showIcon
+              message="Shared webhook"
+              description="This workspace uses a shared repository webhook. Multiple workspaces on this repository share a single GitHub hook."
+            />
+          )}
           <Row hidden={!webhookEnabled}>
             <Col span={12}>
               <Form.Item label="ID" hidden={!webhookEnabled}>
                 {webhookId}
               </Form.Item>
             </Col>
-            <Col span={12}>
+            <Col span={12} hidden={!remoteHookId}>
               <Form.Item hidden={!webhookEnabled} label={renderVCSLogo(vcsProvider!)}>
                 {remoteHookId}
               </Form.Item>


### PR DESCRIPTION
## Summary

Terrakube creates **one GitHub webhook per workspace** (1:1 relationship). When a GitHub repository hosts 30-40 Terraform workspaces, it hits [GitHub's 20-webhook-per-repo limit](https://docs.github.com/en/rest/webhooks/repos). This PR introduces **shared repository-level webhooks** where a single GitHub hook per repository fans out to all workspaces using that repo.

## Problem

- Each workspace that enables webhooks creates its own GitHub webhook on the repository
- GitHub enforces a limit of 20 webhooks per repository
- Organizations with many Terraform workspaces backed by the same repo cannot enable webhooks for all of them
- This is a GitHub-specific limitation (GitLab/Bitbucket don't have this constraint)

## Solution

### New `vcs_webhook` table

One row per unique `(vcs_id, repository_url)` pair — one shared GitHub webhook per repo per VCS connection. A single VCS connection can have many repos, each with its own VcsWebhook.

| Column | Purpose |
|--------|---------|
| `id` | PK (UUID) |
| `vcs_id` | FK to VCS connection |
| `repository_url` | Normalized repo URL (lowercase, no `.git` suffix) |
| `remote_hook_id` | GitHub's webhook ID |
| `secret` | Random UUID used as HMAC secret for payload verification |

### Two coexisting callback paths

| Path | Mode | Description |
|------|------|-------------|
| `POST /webhook/v1/{webhookId}` | Legacy | Existing per-workspace webhooks, **completely unchanged** |
| `POST /webhook/v1/vcs/{vcsWebhookId}` | Shared | New fan-out endpoint for shared webhooks |

The **URL path alone** determines which mode handles the request. There is no ambiguity or runtime detection needed.

### How fan-out works

1. GitHub sends a push/PR/release event to `/webhook/v1/vcs/{vcsWebhookId}`
2. Load the `VcsWebhook` record, verify HMAC signature using its stored secret
3. Parse the payload once (branch, changed files, event type, commit)
4. Query all workspaces where `vcs = this VCS AND normalized(source) = this repo AND webhook IS NOT NULL`
5. For each workspace, check its `WebhookEvent` rules (branch regex, path regex, event type, priority)
6. Create a Job for each matching workspace (exceptions are caught per-workspace so one failure doesn't block others)
7. Workspaces with legacy per-workspace hooks (those with `remoteHookId` set) are skipped during fan-out — they receive events via their own `/webhook/v1/{webhookId}` path

### Key design decisions

**No FK from `webhook` to `vcs_webhook`:** The fan-out query uses the workspace's existing `vcs` and `source` fields to find matching workspaces. This means **zero changes to the existing `webhook` table schema**.

**Random secret per VcsWebhook:** Each shared webhook gets a `UUID.randomUUID()` as its HMAC secret, stored in the `secret` column. This is different from the legacy approach which uses `Base64(workspaceId)` as the secret. A random secret is more secure — if one repo's secret leaks, it doesn't compromise others. The legacy approach continues to work unchanged for existing webhooks.

**URL normalization:** Repository URLs are normalized (lowercase, strip `.git`, strip trailing `/`) for matching. This is done via a static `WebhookServiceBase.normalizeRepositoryUrl()` method used consistently across creation, deletion, and fan-out.

**GitHub only for now:** Only GitHub gets shared webhook support. GitLab and Bitbucket continue with per-workspace webhooks (GitLab doesn't have this limit; Bitbucket can be added later).

**Event type union:** When multiple workspaces share a webhook, the GitHub hook is configured with the **union** of all event types across those workspaces. For example, if workspace A subscribes to PUSH and workspace B subscribes to PUSH + PULL_REQUEST, the GitHub hook gets both event types. When a workspace is removed, the union is recalculated and the GitHub hook is PATCHed.

**Migration endpoint requires auth:** The new `/api/v1/webhook/{webhookId}/migrate` endpoint is placed under `/api/v1/` (not `/webhook/v1/`) so it goes through the standard authentication filter. The `/webhook/v1/**` paths are `permitAll()` since they receive unauthenticated payloads from VCS providers.

## Changes

### New files

| File | Description |
|------|-------------|
| `VcsWebhook.java` | JPA entity for `vcs_webhook` table |
| `VcsWebhookRepository.java` | Spring Data repository with `findByVcsAndRepositoryUrl` |
| `changelog-2.31.0-vcs-webhook.xml` | Liquibase migration (create table + unique constraint + FK) |

### Modified files

| File | Description |
|------|-------------|
| `WebhookService.java` | Core shared logic: creation, deletion cleanup, fan-out processing, migration |
| `WebhookServiceBase.java` | Added `normalizeRepositoryUrl()` and `handleWebhookWithSecret()` |
| `GitHubWebhookService.java` | Added `processSharedWebhook`, `createSharedWebhook`, `updateSharedWebhookEvents`, `deleteSharedWebhook` |
| `WebHookController.java` | Added shared inbound endpoint and authenticated migration endpoint |
| `WorkspaceRepository.java` | Added `findByVcsAndWebhookIsNotNull(Vcs)` query |
| `changelog.xml` | Registered new migration |
| `Webhook.tsx` | Alert banners for shared/legacy mode, "Migrate to shared" button |

### Unchanged

- `Webhook.java` — no entity changes
- `WebhookEvent.java` — no entity changes
- `webhook` table schema — no column additions or modifications
- Legacy `/webhook/v1/{webhookId}` processing — completely untouched

## Backward compatibility

- All existing per-workspace webhooks continue to work identically
- The legacy `processWebhook()` code path is not modified
- No database migration touches existing tables
- New webhooks on GitHub VCS connections automatically use shared mode
- A "Migrate to shared" button in the UI lets users opt-in for existing legacy webhooks

## Test plan

- [ ] Create webhook for workspace A on repo X → creates VcsWebhook + GitHub hook at `/v1/vcs/`
- [ ] Create webhook for workspace B on same repo → reuses VcsWebhook, no new GitHub API call
- [ ] Push to repo → `/webhook/v1/vcs/{id}` receives event, jobs created for both A and B based on their WebhookEvent rules
- [ ] Delete workspace A webhook → VcsWebhook persists, GitHub hook stays
- [ ] Delete workspace B webhook (last one) → VcsWebhook and GitHub hook both deleted
- [ ] Event union: workspace A has PUSH, workspace B has PUSH + PR → GitHub hook configured with both. Remove B → PATCHed to PUSH only
- [ ] Legacy webhooks: existing `/webhook/v1/{webhookId}` flow unchanged
- [ ] Migration: click "Migrate to shared" → old GitHub hook deleted, workspace uses shared VcsWebhook, WebhookEvent rules preserved
- [ ] Signature verification: shared endpoint uses VcsWebhook.secret, legacy uses Base64(workspace.id)