### PR TITLE
feat: update buildpack to `jammy-java-tiny:0.0.104` in registry POM

### DIFF
--- a/registry/pom.xml
+++ b/registry/pom.xml
@@ -31,7 +31,7 @@
         <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}
         </sonar.coverage.jacoco.xmlReportPaths>
         <!--BUILDPACK DATA-->
-        <buildpack.builder>paketobuildpacks/builder-jammy-base:0.4.546</buildpack.builder>
+        <buildpack.builder>paketobuildpacks/builder-jammy-java-tiny:0.0.104</buildpack.builder>
         <buildpack.java>paketobuildpacks/java:21.2.0</buildpack.java>
         <buildpack.telemetry>paketobuildpacks/opentelemetry:2.23.0</buildpack.telemetry>
     </properties>


### PR DESCRIPTION
This will improve image size and packages inside the container when using buildpacks

## builder-jammy-base

### Image Size

```shell
docker image ls | grep 2.31.0-beta.1
WARNING: This output is designed for human readability. For machine-readable output, please use --format.
open-registry:2.31.0-beta.1                                                                 3d51ee846b1f        569MB             0B    
```

### Image CVEs

```shell
docker scout cves open-registry:2.31.0-beta.1
    i New version 1.20.2 available (installed version is 1.19.0) at https://github.com/docker/scout-cli
    ✓ Image stored for indexing
    ✓ Indexed 494 packages
    ✗ Detected 16 vulnerable packages with a total of 22 vulnerabilities


## Overview

                   │        Analyzed Image         
───────────────────┼───────────────────────────────
 Target            │  open-registry:2.31.0-beta.1  
   digest          │  3d51ee846b1f                 
   platform        │ linux/amd64                   
   vulnerabilities │    0C     5H     5M    12L    
   size            │ 302 MB                        
   packages        │ 494                           


## Packages and Vulnerabilities

   0C     3H     1M     1L  stdlib 1.26.0
pkg:golang/stdlib@1.26.0

    ✗ HIGH CVE-2026-27142
      https://scout.docker.com/v/CVE-2026-27142
      Affected range : >=1.26.0-0 
                     : <1.26.1    
      Fixed version  : 1.26.1     
    
    ✗ HIGH CVE-2026-27137
      https://scout.docker.com/v/CVE-2026-27137
      Affected range : >=1.26.0-0 
                     : <1.26.1    
      Fixed version  : 1.26.1     
    
    ✗ HIGH CVE-2026-25679
      https://scout.docker.com/v/CVE-2026-25679
      Affected range : >=1.26.0-0 
                     : <1.26.1    
      Fixed version  : 1.26.1     
    
    ✗ MEDIUM CVE-2026-27138
      https://scout.docker.com/v/CVE-2026-27138
      Affected range : >=1.26.0-0 
                     : <1.26.1    
      Fixed version  : 1.26.1     
    
    ✗ LOW CVE-2026-27139
      https://scout.docker.com/v/CVE-2026-27139
      Affected range : >=1.26.0-0 
                     : <1.26.1    
      Fixed version  : 1.26.1     
    

   0C     1H     0M     0L  com.fasterxml.jackson.core/jackson-core 2.19.4
pkg:maven/com.fasterxml.jackson.core/jackson-core@2.19.4

    ✗ HIGH GHSA-72hv-8253-57qq [Allocation of Resources Without Limits or Throttling]
      https://scout.docker.com/v/GHSA-72hv-8253-57qq
      Affected range : >=2.19.0                                                        
                     : <2.21.1                                                         
      Fixed version  : 2.21.1                                                          
      CVSS Score     : 8.7                                                             
      CVSS Vector    : CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N 
    

   0C     1H     0M     0L  golang.org/x/net 0.50.0
pkg:golang/golang.org/x/net@0.50.0

    ✗ HIGH CVE-2026-27141
      https://scout.docker.com/v/CVE-2026-27141
      Affected range : >=0.50.0 
                     : <0.51.0  
      Fixed version  : 0.51.0   
    

   0C     0H     1M     1L  gnupg2 2.2.27-3ubuntu2.5
pkg:deb/ubuntu/gnupg2@2.2.27-3ubuntu2.5?os_distro=jammy&os_name=ubuntu&os_version=22.04

    ✗ MEDIUM CVE-2025-68972
      https://scout.docker.com/v/CVE-2025-68972
      Affected range : >=0                                          
      Fixed version  : not fixed                                    
      CVSS Score     : 4.7                                          
      CVSS Vector    : CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N 
    
    ✗ LOW CVE-2022-3219
      https://scout.docker.com/v/CVE-2022-3219
      Affected range : >=0                                          
      Fixed version  : not fixed                                    
      CVSS Score     : 3.3                                          
      CVSS Vector    : CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L 
    

   0C     0H     1M     0L  tar 1.34+dfsg-1ubuntu0.1.22.04.2
pkg:deb/ubuntu/tar@1.34%2Bdfsg-1ubuntu0.1.22.04.2?os_distro=jammy&os_name=ubuntu&os_version=22.04

    ✗ MEDIUM CVE-2025-45582
      https://scout.docker.com/v/CVE-2025-45582
      Affected range : >=0       
      Fixed version  : not fixed 
    

   0C     0H     1M     0L  pam 1.4.0-11ubuntu2.6
pkg:deb/ubuntu/pam@1.4.0-11ubuntu2.6?os_distro=jammy&os_name=ubuntu&os_version=22.04

    ✗ MEDIUM CVE-2025-8941
      https://scout.docker.com/v/CVE-2025-8941
      Affected range : >=0       
      Fixed version  : not fixed 
    

   0C     0H     1M     0L  expat 2.4.7-1ubuntu0.7
pkg:deb/ubuntu/expat@2.4.7-1ubuntu0.7?os_distro=jammy&os_name=ubuntu&os_version=22.04

    ✗ MEDIUM CVE-2025-66382
      https://scout.docker.com/v/CVE-2025-66382
      Affected range : >=0                                          
      Fixed version  : not fixed                                    
      CVSS Score     : 5.5                                          
      CVSS Vector    : CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H 
    

   0C     0H     0M     2L  shadow 1:4.8.1-2ubuntu2.2
pkg:deb/ubuntu/shadow@1%3A4.8.1-2ubuntu2.2?os_distro=jammy&os_name=ubuntu&os_version=22.04

    ✗ LOW CVE-2023-29383
      https://scout.docker.com/v/CVE-2023-29383
      Affected range : >=0                                          
      Fixed version  : not fixed                                    
      CVSS Score     : 3.3                                          
      CVSS Vector    : CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N 
    
    ✗ LOW CVE-2024-56433
      https://scout.docker.com/v/CVE-2024-56433
      Affected range : >=0       
      Fixed version  : not fixed 
    

   0C     0H     0M     1L  coreutils 8.32-4.1ubuntu1.2
pkg:deb/ubuntu/coreutils@8.32-4.1ubuntu1.2?os_distro=jammy&os_name=ubuntu&os_version=22.04

    ✗ LOW CVE-2016-2781
      https://scout.docker.com/v/CVE-2016-2781
      Affected range : >=0                                          
      Fixed version  : not fixed                                    
      CVSS Score     : 6.5                                          
      CVSS Vector    : CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:N/I:H/A:N 
    

   0C     0H     0M     1L  gcc-12 12.3.0-1ubuntu1~22.04.3
pkg:deb/ubuntu/gcc-12@12.3.0-1ubuntu1~22.04.3?os_distro=jammy&os_name=ubuntu&os_version=22.04

    ✗ LOW CVE-2022-27943
      https://scout.docker.com/v/CVE-2022-27943
      Affected range : >=0                                          
      Fixed version  : not fixed                                    
      CVSS Score     : 5.5                                          
      CVSS Vector    : CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H 
    

   0C     0H     0M     1L  ncurses 6.3-2ubuntu0.1
pkg:deb/ubuntu/ncurses@6.3-2ubuntu0.1?os_distro=jammy&os_name=ubuntu&os_version=22.04

    ✗ LOW CVE-2023-50495
      https://scout.docker.com/v/CVE-2023-50495
      Affected range : >=0                                          
      Fixed version  : not fixed                                    
      CVSS Score     : 6.5                                          
      CVSS Vector    : CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H 
    

   0C     0H     0M     1L  pcre3 2:8.39-13ubuntu0.22.04.1
pkg:deb/ubuntu/pcre3@2%3A8.39-13ubuntu0.22.04.1?os_distro=jammy&os_name=ubuntu&os_version=22.04

    ✗ LOW CVE-2017-11164
      https://scout.docker.com/v/CVE-2017-11164
      Affected range : >=0                                          
      Fixed version  : not fixed                                    
      CVSS Score     : 7.5                                          
      CVSS Vector    : CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H 
    

   0C     0H     0M     1L  libgcrypt20 1.9.4-3ubuntu3
pkg:deb/ubuntu/libgcrypt20@1.9.4-3ubuntu3?os_distro=jammy&os_name=ubuntu&os_version=22.04

    ✗ LOW CVE-2024-2236
      https://scout.docker.com/v/CVE-2024-2236
      Affected range : >=0       
      Fixed version  : not fixed 
    

   0C     0H     0M     1L  libzstd 1.4.8+dfsg-3build1
pkg:deb/ubuntu/libzstd@1.4.8%2Bdfsg-3build1?os_distro=jammy&os_name=ubuntu&os_version=22.04

    ✗ LOW CVE-2022-4899
      https://scout.docker.com/v/CVE-2022-4899
      Affected range : >=0                                          
      Fixed version  : not fixed                                    
      CVSS Score     : 7.5                                          
      CVSS Vector    : CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H 
    

   0C     0H     0M     1L  pcre2 10.39-3ubuntu0.1
pkg:deb/ubuntu/pcre2@10.39-3ubuntu0.1?os_distro=jammy&os_name=ubuntu&os_version=22.04

    ✗ LOW CVE-2022-41409
      https://scout.docker.com/v/CVE-2022-41409
      Affected range : >=0                                          
      Fixed version  : not fixed                                    
      CVSS Score     : 7.5                                          
      CVSS Vector    : CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H 
    

   0C     0H     0M     1L  systemd 249.11-0ubuntu3.17
pkg:deb/ubuntu/systemd@249.11-0ubuntu3.17?os_distro=jammy&os_name=ubuntu&os_version=22.04

    ✗ LOW CVE-2023-7008
      https://scout.docker.com/v/CVE-2023-7008
      Affected range : >=0                                          
      Fixed version  : not fixed                                    
      CVSS Score     : 5.9                                          
      CVSS Vector    : CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N 
    


22 vulnerabilities found in 16 packages
  CRITICAL  0  
  HIGH      5  
  MEDIUM    5  
  LOW       12 
```

## builder-jammy-java-tiny

### Image Size

```shell
docker image ls | grep 2.31.0-beta.1
WARNING: This output is designed for human readability. For machine-readable output, please use --format.
open-registry:2.31.0-beta.1                                                                 6d891acabf16        480MB             0B 
```

### Image CVEs

```shell
docker scout cves open-registry:2.31.0-beta.1
    i New version 1.20.2 available (installed version is 1.19.0) at https://github.com/docker/scout-cli
    ✓ Image stored for indexing
    ✓ Indexed 344 packages
    ✗ Detected 4 vulnerable packages with a total of 8 vulnerabilities


## Overview

                   │        Analyzed Image         
───────────────────┼───────────────────────────────
 Target            │  open-registry:2.31.0-beta.1  
   digest          │  6d891acabf16                 
   platform        │ linux/amd64                   
   vulnerabilities │    0C     5H     1M     2L    
   size            │ 264 MB                        
   packages        │ 344                           


## Packages and Vulnerabilities

   0C     3H     1M     1L  stdlib 1.26.0
pkg:golang/stdlib@1.26.0

    ✗ HIGH CVE-2026-27142
      https://scout.docker.com/v/CVE-2026-27142
      Affected range : >=1.26.0-0 
                     : <1.26.1    
      Fixed version  : 1.26.1     
    
    ✗ HIGH CVE-2026-27137
      https://scout.docker.com/v/CVE-2026-27137
      Affected range : >=1.26.0-0 
                     : <1.26.1    
      Fixed version  : 1.26.1     
    
    ✗ HIGH CVE-2026-25679
      https://scout.docker.com/v/CVE-2026-25679
      Affected range : >=1.26.0-0 
                     : <1.26.1    
      Fixed version  : 1.26.1     
    
    ✗ MEDIUM CVE-2026-27138
      https://scout.docker.com/v/CVE-2026-27138
      Affected range : >=1.26.0-0 
                     : <1.26.1    
      Fixed version  : 1.26.1     
    
    ✗ LOW CVE-2026-27139
      https://scout.docker.com/v/CVE-2026-27139
      Affected range : >=1.26.0-0 
                     : <1.26.1    
      Fixed version  : 1.26.1     
    

   0C     1H     0M     0L  com.fasterxml.jackson.core/jackson-core 2.19.4
pkg:maven/com.fasterxml.jackson.core/jackson-core@2.19.4

    ✗ HIGH GHSA-72hv-8253-57qq [Allocation of Resources Without Limits or Throttling]
      https://scout.docker.com/v/GHSA-72hv-8253-57qq
      Affected range : >=2.19.0                                                        
                     : <2.21.1                                                         
      Fixed version  : 2.21.1                                                          
      CVSS Score     : 8.7                                                             
      CVSS Vector    : CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N 
    

   0C     1H     0M     0L  golang.org/x/net 0.50.0
pkg:golang/golang.org/x/net@0.50.0

    ✗ HIGH CVE-2026-27141
      https://scout.docker.com/v/CVE-2026-27141
      Affected range : >=0.50.0 
                     : <0.51.0  
      Fixed version  : 0.51.0   
    

   0C     0H     0M     1L  gcc-12 12.3.0-1ubuntu1~22.04.3
pkg:deb/ubuntu/gcc-12@12.3.0-1ubuntu1~22.04.3?os_distro=jammy&os_name=ubuntu&os_version=22.04

    ✗ LOW CVE-2022-27943
      https://scout.docker.com/v/CVE-2022-27943
      Affected range : >=0                                          
      Fixed version  : not fixed                                    
      CVSS Score     : 5.5                                          
      CVSS Vector    : CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H 
    


8 vulnerabilities found in 4 packages
  CRITICAL  0 
  HIGH      5 
  MEDIUM    1 
  LOW       2 
```