### PR TITLE
feat(webhooks): shared repo-level VCS webhooks v2

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
+++ b/api/src/main/java/io/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
@@ -49,7 +49,7 @@ public class DexWebSecurityAdapter {
                 http.cors(Customizer.withDefaults())
                                 .csrf(crsf -> crsf.ignoringRequestMatchers("/remote/tfe/v2/configuration-versions/*",
                                                 "/tfstate/v1/archive/*/terraform.tfstate",
-                                                "/tfstate/v1/archive/*/terraform.json.tfstate", "/webhook/v1/**"))
+                                                "/tfstate/v1/archive/*/terraform.json.tfstate", "/webhook/v1/**", "/webhook/v2/**"))
                                 .authorizeHttpRequests(authz -> {
                                         authz
                                                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
@@ -57,6 +57,7 @@ public class DexWebSecurityAdapter {
                                                         .requestMatchers("/error").permitAll()
                                                         .requestMatchers("/callback/v1/**").permitAll()
                                                         .requestMatchers("/webhook/v1/**").permitAll()
+                                                        .requestMatchers("/webhook/v2/**").permitAll()
                                                         .requestMatchers("/.well-known/terraform.json").permitAll()
                                                         .requestMatchers("/.well-known/openid-configuration")
                                                         .permitAll()

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/RepoUrlNormalizer.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/RepoUrlNormalizer.java
@@ -1,0 +1,21 @@
+package io.terrakube.api.plugin.vcs;
+
+public final class RepoUrlNormalizer {
+
+    private RepoUrlNormalizer() {
+    }
+
+    public static String normalize(String url) {
+        if (url == null) {
+            return null;
+        }
+        String normalized = url.trim().toLowerCase();
+        if (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        if (normalized.endsWith(".git")) {
+            normalized = normalized.substring(0, normalized.length() - 4);
+        }
+        return normalized;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
@@ -175,7 +175,7 @@ public class RepoWebhookService {
             job.setVia(webhookResult.getVia());
             job.setCommitId(webhookResult.getCommit());
             Job savedJob = jobRepository.save(job);
-            if (!webhookResult.isRelease()) {
+            if (!webhookResult.isRelease() && workspace.getVcs() != null) {
                 gitHubWebhookService.sendCommitStatus(savedJob, JobStatus.pending);
             }
             scheduleJobService.createJobContext(savedJob);

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
@@ -113,8 +113,7 @@ public class RepoWebhookService {
             throw new SecurityException("HMAC signature verification failed");
         }
 
-        WebhookResult webhookResult = gitHubWebhookService.parseGitHubPayload(jsonPayload, headers,
-                repoWebhook.getVcs());
+        WebhookResult webhookResult = gitHubWebhookService.parseGitHubPayload(jsonPayload, headers);
 
         if (webhookResult.getEvent() != null && webhookResult.getEvent().equals("ping")) {
             log.info("Received ping for repo webhook {}", repoWebhookId);
@@ -145,6 +144,17 @@ public class RepoWebhookService {
         if (workspace.getWebhook() == null) {
             log.warn("Workspace {} has no webhook despite being returned by migrated query", workspace.getName());
             return;
+        }
+
+        if (webhookResult.getPrFilesUrl() != null) {
+            if (workspace.getVcs() != null) {
+                List<String> prFiles = gitHubWebhookService.fetchPrFileChanges(
+                        workspace.getVcs(), workspace.getSource(), webhookResult.getPrFilesUrl());
+                webhookResult.setFileChanges(prFiles);
+            } else {
+                log.warn("Workspace {} has no VCS, cannot fetch PR file changes", workspace.getName());
+                return;
+            }
         }
 
         try {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
@@ -1,0 +1,226 @@
+package io.terrakube.api.plugin.vcs;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.terrakube.api.plugin.scheduler.ScheduleJobService;
+import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
+import io.terrakube.api.repository.JobRepository;
+import io.terrakube.api.repository.RepoWebhookRepository;
+import io.terrakube.api.repository.WebhookEventRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.webhook.RepoWebhook;
+import io.terrakube.api.rs.webhook.WebhookEvent;
+import io.terrakube.api.rs.webhook.WebhookEventType;
+import io.terrakube.api.rs.workspace.Workspace;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@AllArgsConstructor
+@Slf4j
+@Service
+public class RepoWebhookService {
+
+    RepoWebhookRepository repoWebhookRepository;
+    WorkspaceRepository workspaceRepository;
+    WebhookEventRepository webhookEventRepository;
+    GitHubWebhookService gitHubWebhookService;
+    JobRepository jobRepository;
+    ScheduleJobService scheduleJobService;
+
+    @Transactional
+    public RepoWebhook getOrCreateRepoWebhook(Workspace workspace) {
+        String normalizedUrl = RepoUrlNormalizer.normalize(workspace.getSource());
+        return repoWebhookRepository.findByRepositoryUrl(normalizedUrl)
+                .orElseGet(() -> {
+                    try {
+                        RepoWebhook repoWebhook = new RepoWebhook();
+                        repoWebhook.setRepositoryUrl(normalizedUrl);
+                        repoWebhook.setWebhookSecret(UUID.randomUUID().toString());
+                        repoWebhook.setVcs(workspace.getVcs());
+                        return repoWebhookRepository.save(repoWebhook);
+                    } catch (DataIntegrityViolationException e) {
+                        return repoWebhookRepository.findByRepositoryUrl(normalizedUrl)
+                                .orElseThrow(() -> new IllegalStateException(
+                                        "Failed to create or find RepoWebhook for " + normalizedUrl, e));
+                    }
+                });
+    }
+
+    @Transactional
+    public void createOrUpdateSharedWebhook(RepoWebhook repoWebhook) {
+        List<Workspace> workspaces = workspaceRepository
+                .findByNormalizedSourceWithMigratedWebhook(repoWebhook.getRepositoryUrl());
+
+        Set<WebhookEventType> eventTypes = new HashSet<>();
+        for (Workspace ws : workspaces) {
+            if (ws.getWebhook() != null && ws.getWebhook().getEvents() != null) {
+                for (WebhookEvent event : ws.getWebhook().getEvents()) {
+                    eventTypes.add(event.getEvent());
+                }
+            }
+        }
+
+        if (eventTypes.isEmpty()) {
+            log.warn("No webhook event types found for repo webhook {}", repoWebhook.getId());
+            return;
+        }
+
+        String remoteHookId = gitHubWebhookService.createOrUpdateRepoWebhook(repoWebhook, eventTypes);
+        repoWebhook.setRemoteHookId(remoteHookId);
+        repoWebhookRepository.save(repoWebhook);
+    }
+
+    @Transactional
+    public void cleanupIfOrphan(RepoWebhook repoWebhook) {
+        List<Workspace> workspaces = workspaceRepository
+                .findByNormalizedSourceWithMigratedWebhook(repoWebhook.getRepositoryUrl());
+
+        if (workspaces.isEmpty()) {
+            gitHubWebhookService.deleteRepoWebhook(repoWebhook);
+            repoWebhookRepository.delete(repoWebhook);
+            log.info("Deleted orphan repo webhook {} for {}", repoWebhook.getId(), repoWebhook.getRepositoryUrl());
+        } else {
+            createOrUpdateSharedWebhook(repoWebhook);
+        }
+    }
+
+    @Transactional
+    public void processV2Webhook(String repoWebhookId, String jsonPayload, Map<String, String> headers) {
+        RepoWebhook repoWebhook = repoWebhookRepository.findById(UUID.fromString(repoWebhookId))
+                .orElseThrow(() -> new IllegalArgumentException("Repo webhook not found: " + repoWebhookId));
+
+        if (!verifyHmacSignature(headers, repoWebhook.getWebhookSecret(), jsonPayload)) {
+            log.error("Signature verification failed for repo webhook {}", repoWebhookId);
+            throw new SecurityException("HMAC signature verification failed");
+        }
+
+        WebhookResult webhookResult = gitHubWebhookService.parseGitHubPayload(jsonPayload, headers,
+                repoWebhook.getVcs());
+
+        if (webhookResult.getEvent() != null && webhookResult.getEvent().equals("ping")) {
+            log.info("Received ping for repo webhook {}", repoWebhookId);
+            return;
+        }
+
+        if (!webhookResult.isValid()) {
+            log.warn("Invalid webhook result for repo webhook {}", repoWebhookId);
+            return;
+        }
+
+        String normalizedUrl = repoWebhook.getRepositoryUrl();
+        List<Workspace> workspaces = workspaceRepository
+                .findByNormalizedSourceWithMigratedWebhook(normalizedUrl);
+
+        log.info("Processing v2 webhook for {} workspaces on repo {}", workspaces.size(), normalizedUrl);
+
+        for (Workspace workspace : workspaces) {
+            try {
+                processWorkspaceWebhook(workspace, webhookResult);
+            } catch (Exception e) {
+                log.error("Error processing v2 webhook for workspace {}: {}", workspace.getName(), e.getMessage(), e);
+            }
+        }
+    }
+
+    private void processWorkspaceWebhook(Workspace workspace, WebhookResult webhookResult) {
+        if (workspace.getWebhook() == null) {
+            log.warn("Workspace {} has no webhook despite being returned by migrated query", workspace.getName());
+            return;
+        }
+
+        try {
+            String templateId = webhookResult.isRelease()
+                    ? WebhookEventMatcher.findTemplateIdRelease(webhookResult, workspace.getWebhook(),
+                            webhookEventRepository)
+                    : WebhookEventMatcher.findTemplateId(webhookResult, workspace.getWebhook(),
+                            webhookEventRepository);
+
+            log.info("V2 webhook event {} for workspace {}, using template {}", webhookResult.getNormalizedEvent(),
+                    workspace.getName(), templateId);
+
+            Job job = new Job();
+            job.setTemplateReference(templateId);
+            job.setRefresh(true);
+            job.setPlanChanges(true);
+            job.setRefreshOnly(false);
+            job.setOverrideBranch(webhookResult.isRelease()
+                    ? "refs/tags/" + webhookResult.getBranch()
+                    : webhookResult.getBranch());
+            job.setOrganization(workspace.getOrganization());
+            job.setWorkspace(workspace);
+            job.setCreatedBy(webhookResult.getCreatedBy());
+            job.setUpdatedBy(webhookResult.getCreatedBy());
+            Date triggerDate = new Date(System.currentTimeMillis());
+            job.setCreatedDate(triggerDate);
+            job.setUpdatedDate(triggerDate);
+            job.setVia(webhookResult.getVia());
+            job.setCommitId(webhookResult.getCommit());
+            Job savedJob = jobRepository.save(job);
+            if (!webhookResult.isRelease()) {
+                gitHubWebhookService.sendCommitStatus(savedJob, JobStatus.pending);
+            }
+            scheduleJobService.createJobContext(savedJob);
+        } catch (IllegalArgumentException e) {
+            log.info("No matching template for workspace {} on event {}: {}", workspace.getName(),
+                    webhookResult.getNormalizedEvent(), e.getMessage());
+        } catch (Exception e) {
+            log.error("Error creating job for workspace {}", workspace.getName(), e);
+        }
+    }
+
+    private boolean verifyHmacSignature(Map<String, String> headers, String secret, String payload) {
+        try {
+            String signatureHeader = headers.get("x-hub-signature-256");
+            if (signatureHeader == null) {
+                log.error("x-hub-signature-256 header is missing!");
+                return false;
+            }
+            Mac mac = Mac.getInstance("HmacSHA256");
+            SecretKeySpec secretKeySpec = new SecretKeySpec(
+                    secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+            mac.init(secretKeySpec);
+            byte[] computedHash = mac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hexString = new StringBuilder(2 * computedHash.length);
+            for (byte b : computedHash) {
+                String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) {
+                    hexString.append('0');
+                }
+                hexString.append(hex);
+            }
+            String expectedSignature = "sha256=" + hexString.toString();
+            if (!MessageDigest.isEqual(
+                    signatureHeader.getBytes(StandardCharsets.UTF_8),
+                    expectedSignature.getBytes(StandardCharsets.UTF_8))) {
+                log.error("Request signature didn't match!");
+                return false;
+            }
+            return true;
+        } catch (NoSuchAlgorithmException e) {
+            log.error("Error processing the webhook", e);
+            return false;
+        } catch (InvalidKeyException e) {
+            log.error("Error parsing the secret", e);
+            return false;
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookEventMatcher.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookEventMatcher.java
@@ -19,7 +19,7 @@ public final class WebhookEventMatcher {
         String[] branchList = webhookEvent.getBranch().split(",");
         for (String branch : branchList) {
             branch = branch.trim();
-            if (webhookBranch.matches(branch)) {
+            if (globMatch(webhookBranch, branch)) {
                 return true;
             }
         }
@@ -30,7 +30,7 @@ public final class WebhookEventMatcher {
         String[] triggeredPath = webhookEvent.getPath().split(",");
         for (String file : files) {
             for (int i = 0; i < triggeredPath.length; i++) {
-                if (file.matches(triggeredPath[i])) {
+                if (globMatch(file, triggeredPath[i].trim())) {
                     log.info("Changed file {} matches set trigger pattern {}", file, triggeredPath[i]);
                     return true;
                 }
@@ -38,6 +38,38 @@ public final class WebhookEventMatcher {
         }
         log.info("Changed files {} doesn't match any of the trigger path pattern {}", files, triggeredPath);
         return false;
+    }
+
+    static boolean globMatch(String input, String globPattern) {
+        try {
+            String regex = globToSafeRegex(globPattern);
+            return input.matches(regex);
+        } catch (Exception e) {
+            log.warn("Invalid glob pattern '{}': {}", globPattern, e.getMessage());
+            return false;
+        }
+    }
+
+    static String globToSafeRegex(String glob) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < glob.length(); i++) {
+            char c = glob.charAt(i);
+            switch (c) {
+                case '*':
+                    sb.append(".*");
+                    break;
+                case '?':
+                    sb.append(".");
+                    break;
+                default:
+                    if ("()[]{}|+^$\\.".indexOf(c) >= 0) {
+                        sb.append('\\');
+                    }
+                    sb.append(c);
+                    break;
+            }
+        }
+        return sb.toString();
     }
 
     public static String findTemplateId(WebhookResult result, Webhook webhook,

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookEventMatcher.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookEventMatcher.java
@@ -1,0 +1,71 @@
+package io.terrakube.api.plugin.vcs;
+
+import java.util.List;
+
+import io.terrakube.api.repository.WebhookEventRepository;
+import io.terrakube.api.rs.webhook.Webhook;
+import io.terrakube.api.rs.webhook.WebhookEvent;
+import io.terrakube.api.rs.webhook.WebhookEventType;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public final class WebhookEventMatcher {
+
+    private WebhookEventMatcher() {
+    }
+
+    public static boolean checkBranch(String webhookBranch, WebhookEvent webhookEvent) {
+        String[] branchList = webhookEvent.getBranch().split(",");
+        for (String branch : branchList) {
+            branch = branch.trim();
+            if (webhookBranch.matches(branch)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean checkFileChanges(List<String> files, WebhookEvent webhookEvent) {
+        String[] triggeredPath = webhookEvent.getPath().split(",");
+        for (String file : files) {
+            for (int i = 0; i < triggeredPath.length; i++) {
+                if (file.matches(triggeredPath[i])) {
+                    log.info("Changed file {} matches set trigger pattern {}", file, triggeredPath[i]);
+                    return true;
+                }
+            }
+        }
+        log.info("Changed files {} doesn't match any of the trigger path pattern {}", files, triggeredPath);
+        return false;
+    }
+
+    public static String findTemplateId(WebhookResult result, Webhook webhook,
+            WebhookEventRepository webhookEventRepository) {
+        return webhookEventRepository
+                .findByWebhookAndEventOrderByPriorityAsc(webhook,
+                        WebhookEventType.valueOf(result.getNormalizedEvent().toUpperCase()))
+                .stream()
+                .filter(webhookEvent -> checkBranch(result.getBranch(), webhookEvent)
+                        && checkFileChanges(result.getFileChanges(), webhookEvent))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "No valid template found for the configured webhook event " + result.getEvent()
+                                + " normalized " + result.getNormalizedEvent()))
+                .getTemplateId();
+    }
+
+    public static String findTemplateIdRelease(WebhookResult result, Webhook webhook,
+            WebhookEventRepository webhookEventRepository) {
+        return webhookEventRepository
+                .findByWebhookAndEventOrderByPriorityAsc(webhook,
+                        WebhookEventType.valueOf(result.getNormalizedEvent().toUpperCase()))
+                .stream()
+                .filter(webhookEvent -> checkBranch(result.getBranch(), webhookEvent))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "No valid template found for the configured webhook event " + result.getEvent()
+                                + " normalized " + result.getNormalizedEvent()))
+                .getTemplateId();
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookResult.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookResult.java
@@ -22,6 +22,7 @@ public class WebhookResult {
     private String commit;
     private Number prNumber;
     private boolean isRelease;
+    private String prFilesUrl;
 
     public String getNormalizedEvent() {
         String normalizedEvent = "";

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
@@ -3,7 +3,6 @@ package io.terrakube.api.plugin.vcs;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -20,7 +19,6 @@ import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.vcs.Vcs;
 import io.terrakube.api.rs.webhook.Webhook;
-import io.terrakube.api.rs.webhook.WebhookEvent;
 import io.terrakube.api.rs.webhook.WebhookEventType;
 import io.terrakube.api.rs.workspace.Workspace;
 
@@ -176,54 +174,12 @@ public class WebhookService {
         }
     }
 
-    private boolean checkBranch(String webhookBranch, WebhookEvent webhookEvent) {
-        String[] branchList = webhookEvent.getBranch().split(",");
-        for (String branch : branchList) {
-            branch = branch.trim();
-            if (webhookBranch.matches(branch)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean checkFileChanges(List<String> files, WebhookEvent webhookEvent) {
-        String[] triggeredPath = webhookEvent.getPath().split(",");
-        for (String file : files) {
-            for (int i = 0; i < triggeredPath.length; i++) {
-                if (file.matches(triggeredPath[i])) {
-                    log.info("Changed file {} matches set trigger pattern {}", file, triggeredPath[i]);
-                    return true;
-                }
-            }
-        }
-        log.info("Changed files {} doesn't match any of the trigger path pattern {}", files, triggeredPath);
-        return false;
-    }
-
     private String findTemplateId(WebhookResult result, Webhook webhook) {
-        return webhookEventRepository
-                .findByWebhookAndEventOrderByPriorityAsc(webhook,
-                        WebhookEventType.valueOf(result.getNormalizedEvent().toUpperCase()))
-                .stream()
-                .filter(webhookEvent -> checkBranch(result.getBranch(), webhookEvent)
-                        && checkFileChanges(result.getFileChanges(), webhookEvent))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "No valid template found for the configured webhook event " + result.getEvent() + "normalized " + result.getNormalizedEvent()))
-                .getTemplateId();
+        return WebhookEventMatcher.findTemplateId(result, webhook, webhookEventRepository);
     }
 
     private String findTemplateIdRelease(WebhookResult result, Webhook webhook) {
-        return webhookEventRepository
-                .findByWebhookAndEventOrderByPriorityAsc(webhook,
-                        WebhookEventType.valueOf(result.getNormalizedEvent().toUpperCase()))
-                .stream()
-                .filter(webhookEvent -> checkBranch(result.getBranch(), webhookEvent))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "No valid template found for the configured webhook event " + result.getEvent() + "normalized " + result.getNormalizedEvent()))
-                .getTemplateId();
+        return WebhookEventMatcher.findTemplateIdRelease(result, webhook, webhookEventRepository);
     }
 
     private void sendCommitStatus(Job job) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookServiceBase.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookServiceBase.java
@@ -3,6 +3,7 @@ package io.terrakube.api.plugin.vcs;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Base64;
@@ -75,12 +76,14 @@ public class WebhookServiceBase {
                 return false;
             }
             Mac mac = Mac.getInstance("HmacSHA256");
-            SecretKeySpec secretKeySpec = new SecretKeySpec(token.getBytes(StandardCharsets.UTF_8), "HmacSHA1");
+            SecretKeySpec secretKeySpec = new SecretKeySpec(token.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
             mac.init(secretKeySpec);
             byte[] computedHash = mac.doFinal(jsonPayload.getBytes(StandardCharsets.UTF_8));
             String expectedSignature = "sha256=" + bytesToHex(computedHash);
 
-            if (!signatureHeader.equals(expectedSignature)) {
+            if (!MessageDigest.isEqual(
+                    signatureHeader.getBytes(StandardCharsets.UTF_8),
+                    expectedSignature.getBytes(StandardCharsets.UTF_8))) {
                 log.error("Request signature didn't match!");
                 return false;
             }

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/controller/WebHookController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/controller/WebHookController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
+import io.terrakube.api.plugin.vcs.RepoWebhookService;
 import io.terrakube.api.plugin.vcs.WebhookService;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -23,6 +24,9 @@ public class WebHookController {
     WebhookService webhookService;
 
     @Autowired
+    RepoWebhookService repoWebhookService;
+
+    @Autowired
     ObjectMapper objectMapper;
 
     @PostMapping("/webhook/v1/{webhookId}")
@@ -35,6 +39,25 @@ public class WebHookController {
             webhookService.processWebhook(webhookId, jsonPayload,headers);
         } catch (Exception e) {
             log.error("Error processing webhook", e);
+            return ResponseEntity.internalServerError().build();
+        }
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/webhook/v2/{repoWebhookId}")
+    public ResponseEntity<String> processV2Webhook(@PathVariable String repoWebhookId, @RequestBody Map<String, Object> payload, @RequestHeader Map<String, String> headers) {
+        log.info("Processing v2 webhook {}", repoWebhookId);
+        try {
+            String jsonPayload = objectMapper.writeValueAsString(payload);
+            repoWebhookService.processV2Webhook(repoWebhookId, jsonPayload, headers);
+        } catch (IllegalArgumentException e) {
+            log.warn("Bad v2 webhook request: {}", e.getMessage());
+            return ResponseEntity.badRequest().build();
+        } catch (SecurityException e) {
+            log.warn("V2 webhook signature verification failed for {}", repoWebhookId);
+            return ResponseEntity.status(401).build();
+        } catch (Exception e) {
+            log.error("Error processing v2 webhook", e);
             return ResponseEntity.internalServerError().build();
         }
         return ResponseEntity.ok().build();

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/controller/WebHookController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/controller/WebHookController.java
@@ -15,10 +15,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
+import java.util.regex.Pattern;
 
 @Slf4j
 @RestController
 public class WebHookController {
+
+    private static final Pattern UUID_PATTERN = Pattern.compile(
+            "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
 
     @Autowired
     WebhookService webhookService;
@@ -35,7 +39,6 @@ public class WebHookController {
         log.info("Processing webhook {}", webhookId);
         try {
             String jsonPayload = objectMapper.writeValueAsString(payload);
-            log.info("webhook payload: {}", jsonPayload);
             webhookService.processWebhook(webhookId, jsonPayload,headers);
         } catch (Exception e) {
             log.error("Error processing webhook", e);
@@ -46,15 +49,15 @@ public class WebHookController {
 
     @PostMapping("/webhook/v2/{repoWebhookId}")
     public ResponseEntity<String> processV2Webhook(@PathVariable String repoWebhookId, @RequestBody Map<String, Object> payload, @RequestHeader Map<String, String> headers) {
-        log.info("Processing v2 webhook {}", repoWebhookId);
+        if (!UUID_PATTERN.matcher(repoWebhookId).matches()) {
+            return ResponseEntity.status(401).build();
+        }
+        log.info("Processing v2 webhook");
         try {
             String jsonPayload = objectMapper.writeValueAsString(payload);
             repoWebhookService.processV2Webhook(repoWebhookId, jsonPayload, headers);
-        } catch (IllegalArgumentException e) {
-            log.warn("Bad v2 webhook request: {}", e.getMessage());
-            return ResponseEntity.badRequest().build();
-        } catch (SecurityException e) {
-            log.warn("V2 webhook signature verification failed for {}", repoWebhookId);
+        } catch (IllegalArgumentException | SecurityException e) {
+            log.warn("V2 webhook request rejected");
             return ResponseEntity.status(401).build();
         } catch (Exception e) {
             log.error("Error processing v2 webhook", e);

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -22,8 +23,10 @@ import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.job.JobVia;
 import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.webhook.RepoWebhook;
 import io.terrakube.api.rs.webhook.Webhook;
 import io.terrakube.api.rs.webhook.WebhookEvent;
+import io.terrakube.api.rs.webhook.WebhookEventType;
 import io.terrakube.api.rs.workspace.Workspace;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -351,6 +354,75 @@ public class GitHubWebhookService extends WebhookServiceBase {
         } else {
             log.warn("Failed to delete webhook with remote hook id {} on repository {}, message {}", webhookRemoteId,
                     workspace.getSource(), response.getBody());
+        }
+    }
+
+    public WebhookResult parseGitHubPayload(String jsonPayload, Map<String, String> headers, Vcs vcs) {
+        WebhookResult result = new WebhookResult();
+        result.setBranch("");
+        result.setVia(JobVia.Github.name());
+        result.setValid(true);
+        return handleEvent(jsonPayload, result, headers, vcs);
+    }
+
+    public String createOrUpdateRepoWebhook(RepoWebhook repoWebhook, Set<WebhookEventType> eventTypes) {
+        String id = repoWebhook.getRemoteHookId();
+        String webhookUrl = String.format("https://%s/webhook/v2/%s", hostname, repoWebhook.getId().toString());
+        String[] ownerAndRepo = extractOwnerAndRepo(repoWebhook.getRepositoryUrl());
+
+        String events = eventTypes.stream()
+                .map(e -> "\"" + e.name().toLowerCase() + "\"")
+                .collect(Collectors.joining(","));
+
+        String body;
+        String apiUrl = repoWebhook.getVcs().getApiUrl() + "/repos/" + String.join("/", ownerAndRepo) + "/hooks";
+        HttpMethod httpMethod;
+
+        if (id != null && !id.isEmpty()) {
+            body = "{\"active\":true, \"events\":[" + events + "]}";
+            apiUrl = apiUrl + "/" + id;
+            httpMethod = HttpMethod.PATCH;
+        } else {
+            body = "{\"name\":\"web\",\"active\":true,\"events\":[" + events + "],\"config\":{\"url\":\""
+                    + webhookUrl
+                    + "\",\"secret\":\"" + repoWebhook.getWebhookSecret() + "\",\"content_type\":\"json\",\"insecure_ssl\":\"1\"}}";
+            httpMethod = HttpMethod.POST;
+        }
+
+        ResponseEntity<String> response = callGitHubApi(repoWebhook.getVcs(), ownerAndRepo, body, apiUrl, httpMethod);
+        if (response != null && (response.getStatusCode().value() == 201 || response.getStatusCode().value() == 200)) {
+            if (id == null || id.isEmpty()) {
+                try {
+                    JsonNode rootNode = objectMapper.readTree(response.getBody());
+                    id = rootNode.path("id").asText();
+                } catch (Exception e) {
+                    log.error("Error parsing JSON response", e);
+                }
+            }
+            log.info("GitHub repo webhook created/updated successfully with id {}", id);
+        }
+
+        return id;
+    }
+
+    public void deleteRepoWebhook(RepoWebhook repoWebhook) {
+        if (repoWebhook.getRemoteHookId() == null || repoWebhook.getRemoteHookId().isEmpty()) {
+            log.warn("No remote hook id found for repo webhook {}, skipping deletion", repoWebhook.getId());
+            return;
+        }
+        String[] ownerAndRepo = extractOwnerAndRepo(repoWebhook.getRepositoryUrl());
+        String apiUrl = repoWebhook.getVcs().getApiUrl() + "/repos/" + String.join("/", ownerAndRepo) + "/hooks/" + repoWebhook.getRemoteHookId();
+
+        ResponseEntity<String> response = callGitHubApi(repoWebhook.getVcs(), ownerAndRepo, "", apiUrl, HttpMethod.DELETE);
+        if (response == null) {
+            log.error("Failed to delete repo webhook with remote hook id {}", repoWebhook.getRemoteHookId());
+            return;
+        }
+
+        if (response.getStatusCode().value() == 204) {
+            log.info("Repo webhook with remote hook id {} deleted successfully", repoWebhook.getRemoteHookId());
+        } else {
+            log.warn("Failed to delete repo webhook with remote hook id {}, message {}", repoWebhook.getRemoteHookId(), response.getBody());
         }
     }
 

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -46,6 +46,8 @@ public class GitHubWebhookService extends WebhookServiceBase {
     private String hostname;
     @Value("${io.terrakube.ui.url}")
     private String uiUrl;
+    @Value("${io.terrakube.webhook.insecure-ssl:1}")
+    private String insecureSsl;
 
     public GitHubWebhookService(ObjectMapper objectMapper, TokenService tokenService) {
         this.objectMapper = objectMapper;
@@ -123,9 +125,11 @@ public class GitHubWebhookService extends WebhookServiceBase {
                 result.setCreatedBy(prUser);
                 
                 String prFilesUrl = rootNode.path("pull_request").path("url").asText() + "/files";
-                // Fetch file changes for the PR
-                List<String> prFileChanges = getPrFileChanges(vcs, new String[]{repoOwner, repoName}, prFilesUrl);
-                result.setFileChanges(prFileChanges);
+                result.setPrFilesUrl(prFilesUrl);
+                if (vcs != null) {
+                    List<String> prFileChanges = getPrFileChanges(vcs, new String[]{repoOwner, repoName}, prFilesUrl);
+                    result.setFileChanges(prFileChanges);
+                }
             } else {
                 result.setValid(false);
                 log.error("No valid github pull request event: {} ", action);
@@ -304,7 +308,7 @@ public class GitHubWebhookService extends WebhookServiceBase {
         } else {
             body = "{\"name\":\"web\",\"active\":true,\"events\":[" + events + "],\"config\":{\"url\":\""
                     + webhookUrl
-                    + "\",\"secret\":\"" + secret + "\",\"content_type\":\"json\",\"insecure_ssl\":\"1\"}}";
+                    + "\",\"secret\":\"" + secret + "\",\"content_type\":\"json\",\"insecure_ssl\":\"" + insecureSsl + "\"}}";
         }
 
         ResponseEntity<String> response = callGitHubApi(workspace.getVcs(), ownerAndRepo, body, apiUrl,
@@ -365,6 +369,15 @@ public class GitHubWebhookService extends WebhookServiceBase {
         return handleEvent(jsonPayload, result, headers, vcs);
     }
 
+    public WebhookResult parseGitHubPayload(String jsonPayload, Map<String, String> headers) {
+        return parseGitHubPayload(jsonPayload, headers, null);
+    }
+
+    public List<String> fetchPrFileChanges(Vcs vcs, String source, String prFilesUrl) {
+        String[] ownerAndRepo = extractOwnerAndRepo(source);
+        return getPrFileChanges(vcs, ownerAndRepo, prFilesUrl);
+    }
+
     public String createOrUpdateRepoWebhook(RepoWebhook repoWebhook, Set<WebhookEventType> eventTypes) {
         String id = repoWebhook.getRemoteHookId();
         String webhookUrl = String.format("https://%s/webhook/v2/%s", hostname, repoWebhook.getId().toString());
@@ -385,7 +398,7 @@ public class GitHubWebhookService extends WebhookServiceBase {
         } else {
             body = "{\"name\":\"web\",\"active\":true,\"events\":[" + events + "],\"config\":{\"url\":\""
                     + webhookUrl
-                    + "\",\"secret\":\"" + repoWebhook.getWebhookSecret() + "\",\"content_type\":\"json\",\"insecure_ssl\":\"1\"}}";
+                    + "\",\"secret\":\"" + repoWebhook.getWebhookSecret() + "\",\"content_type\":\"json\",\"insecure_ssl\":\"" + insecureSsl + "\"}}";
             httpMethod = HttpMethod.POST;
         }
 

--- a/api/src/main/java/io/terrakube/api/repository/RepoWebhookRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/RepoWebhookRepository.java
@@ -1,0 +1,10 @@
+package io.terrakube.api.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import io.terrakube.api.rs.webhook.RepoWebhook;
+
+public interface RepoWebhookRepository extends JpaRepository<RepoWebhook, UUID> {
+    Optional<RepoWebhook> findByRepositoryUrl(String repositoryUrl);
+}

--- a/api/src/main/java/io/terrakube/api/repository/WorkspaceRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/WorkspaceRepository.java
@@ -3,6 +3,8 @@ package io.terrakube.api.repository;
 import io.terrakube.api.rs.Organization;
 import io.terrakube.api.rs.workspace.Workspace;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,5 +17,8 @@ public interface WorkspaceRepository extends JpaRepository<Workspace, UUID> {
     Optional<List<Workspace>> findWorkspacesByOrganizationNameAndNameStartingWith(String organizationName, String workspaceNameStartingWidth);
 
     Optional<List<Workspace>> findWorkspacesByOrganization(Organization organization);
+
+    @Query("SELECT w FROM workspace w JOIN w.webhook wh WHERE LOWER(w.source) = :normalizedSource AND wh.migratedV2 = true")
+    List<Workspace> findByNormalizedSourceWithMigratedWebhook(@Param("normalizedSource") String normalizedSource);
 
 }

--- a/api/src/main/java/io/terrakube/api/repository/WorkspaceRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/WorkspaceRepository.java
@@ -18,7 +18,12 @@ public interface WorkspaceRepository extends JpaRepository<Workspace, UUID> {
 
     Optional<List<Workspace>> findWorkspacesByOrganization(Organization organization);
 
-    @Query("SELECT w FROM workspace w JOIN w.webhook wh WHERE LOWER(w.source) = :normalizedSource AND wh.migratedV2 = true")
+    @Query("SELECT w FROM workspace w JOIN w.webhook wh " +
+           "WHERE (LOWER(w.source) = :normalizedSource " +
+           "OR LOWER(w.source) = CONCAT(:normalizedSource, '.git') " +
+           "OR LOWER(w.source) = CONCAT(:normalizedSource, '/') " +
+           "OR LOWER(w.source) = CONCAT(:normalizedSource, '.git/')) " +
+           "AND wh.migratedV2 = true")
     List<Workspace> findByNormalizedSourceWithMigratedWebhook(@Param("normalizedSource") String normalizedSource);
 
 }

--- a/api/src/main/java/io/terrakube/api/rs/hooks/webhook/WebhookManageHook.java
+++ b/api/src/main/java/io/terrakube/api/rs/hooks/webhook/WebhookManageHook.java
@@ -4,7 +4,13 @@ import java.util.Optional;
 
 import org.apache.hc.core5.http.HttpStatus;
 import org.springframework.beans.factory.annotation.Autowired;
+import io.terrakube.api.plugin.vcs.RepoUrlNormalizer;
+import io.terrakube.api.plugin.vcs.RepoWebhookService;
 import io.terrakube.api.plugin.vcs.WebhookService;
+import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
+import io.terrakube.api.repository.RepoWebhookRepository;
+import io.terrakube.api.rs.vcs.VcsType;
+import io.terrakube.api.rs.webhook.RepoWebhook;
 import io.terrakube.api.rs.webhook.Webhook;
 
 import com.yahoo.elide.annotation.LifeCycleHookBinding.Operation;
@@ -20,6 +26,15 @@ public class WebhookManageHook implements LifeCycleHook<Webhook> {
     @Autowired
     WebhookService webhookService;
 
+    @Autowired
+    RepoWebhookService repoWebhookService;
+
+    @Autowired
+    GitHubWebhookService gitHubWebhookService;
+
+    @Autowired
+    RepoWebhookRepository repoWebhookRepository;
+
     @Override
     public void execute(Operation operation, TransactionPhase phase, Webhook elideEntity, RequestScope requestScope,
             Optional<ChangeSpec> changes) {
@@ -29,7 +44,20 @@ public class WebhookManageHook implements LifeCycleHook<Webhook> {
                 switch (phase) {
                     case PRECOMMIT:
                         try {
-                            webhookService.createOrUpdateWorkspaceWebhook(elideEntity);
+                            if (elideEntity.isMigratedV2()
+                                    && elideEntity.getWorkspace().getVcs() != null
+                                    && elideEntity.getWorkspace().getVcs().getVcsType() == VcsType.GITHUB) {
+                                // V2 shared webhook path
+                                RepoWebhook repoWebhook = repoWebhookService.getOrCreateRepoWebhook(elideEntity.getWorkspace());
+                                repoWebhookService.createOrUpdateSharedWebhook(repoWebhook);
+                                // Delete old per-workspace hook if it exists
+                                if (elideEntity.getRemoteHookId() != null && !elideEntity.getRemoteHookId().isEmpty()) {
+                                    gitHubWebhookService.deleteWebhook(elideEntity.getWorkspace(), elideEntity.getRemoteHookId());
+                                    elideEntity.setRemoteHookId(null);
+                                }
+                            } else {
+                                webhookService.createOrUpdateWorkspaceWebhook(elideEntity);
+                            }
                         } catch (Exception e) {
                             throw new WebhookManagementException(HttpStatus.SC_FAILED_DEPENDENCY,
                                     "Failed to create/update webhook: " + e.getMessage());
@@ -44,7 +72,15 @@ public class WebhookManageHook implements LifeCycleHook<Webhook> {
                 switch (phase) {
                     case POSTCOMMIT:
                         try {
-                            webhookService.deleteWorkspaceWebhook(elideEntity);
+                            if (elideEntity.isMigratedV2()
+                                    && elideEntity.getWorkspace().getVcs() != null
+                                    && elideEntity.getWorkspace().getVcs().getVcsType() == VcsType.GITHUB) {
+                                String normalizedUrl = RepoUrlNormalizer.normalize(elideEntity.getWorkspace().getSource());
+                                repoWebhookRepository.findByRepositoryUrl(normalizedUrl)
+                                        .ifPresent(repoWebhookService::cleanupIfOrphan);
+                            } else {
+                                webhookService.deleteWorkspaceWebhook(elideEntity);
+                            }
                         } catch (Exception e) {
                             throw new WebhookManagementException(HttpStatus.SC_FAILED_DEPENDENCY,
                                     "Failed to delete webhook: " + e.getMessage());

--- a/api/src/main/java/io/terrakube/api/rs/webhook/RepoWebhook.java
+++ b/api/src/main/java/io/terrakube/api/rs/webhook/RepoWebhook.java
@@ -1,0 +1,44 @@
+package io.terrakube.api.rs.webhook;
+
+import java.sql.Types;
+import java.util.UUID;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import io.terrakube.api.plugin.security.audit.GenericAuditFields;
+import io.terrakube.api.rs.IdConverter;
+import io.terrakube.api.rs.vcs.Vcs;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity(name = "repo_webhook")
+public class RepoWebhook extends GenericAuditFields {
+
+    @Id
+    @JdbcTypeCode(Types.VARCHAR)
+    @Convert(converter = IdConverter.class)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "repository_url", length = 1024, unique = true)
+    private String repositoryUrl;
+
+    @Column(name = "remote_hook_id")
+    private String remoteHookId;
+
+    @Column(name = "webhook_secret")
+    private String webhookSecret;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
+    private Vcs vcs;
+}

--- a/api/src/main/java/io/terrakube/api/rs/webhook/Webhook.java
+++ b/api/src/main/java/io/terrakube/api/rs/webhook/Webhook.java
@@ -44,6 +44,9 @@ public class Webhook extends GenericAuditFields {
     @OneToOne(fetch = FetchType.LAZY, optional = false)
     private Workspace workspace;
     
+    @Column(name = "migrated_v2")
+    private boolean migratedV2 = false;
+
     @OneToMany(mappedBy = "webhook", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<WebhookEvent> events;
 }

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -94,4 +94,5 @@
     <include file="/db/changelog/local/changelog-2.30.0-provider-imported.xml" />
     <include file="db/changelog/local/changelog-rbac-v2-team-role.xml"/>
     <include file="db/changelog/local/changelog-rbac-v2-plan-approve.xml"/>
+    <include file="db/changelog/local/changelog-2.31.0-repo-webhooks.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.31.0-repo-webhooks.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.31.0-repo-webhooks.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-31-0-1" author="Dennis Webb (denniswebb)">
+        <createTable tableName="repo_webhook">
+            <column name="id" type="varchar(36)">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+            <column name="repository_url" type="varchar(1024)">
+                <constraints nullable="false" />
+            </column>
+            <column name="remote_hook_id" type="varchar(220)" />
+            <column name="webhook_secret" type="varchar(36)">
+                <constraints nullable="false" />
+            </column>
+            <column name="vcs_id" type="varchar(36)" />
+            <column name="created_date" type="datetime" />
+            <column name="updated_date" type="datetime" />
+            <column name="created_by" type="varchar(128)" />
+            <column name="updated_by" type="varchar(128)" />
+        </createTable>
+        <addForeignKeyConstraint baseTableName="repo_webhook" baseColumnNames="vcs_id"
+            constraintName="fk_repo_webhook_vcs_id" referencedTableName="vcs"
+            referencedColumnNames="id" />
+        <createIndex tableName="repo_webhook" indexName="idx_repo_webhook_repository_url" unique="true">
+            <column name="repository_url" />
+        </createIndex>
+    </changeSet>
+    <changeSet id="2-31-0-2" author="Dennis Webb (denniswebb)">
+        <addColumn tableName="webhook">
+            <column name="migrated_v2" type="boolean" defaultValueBoolean="false" />
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/RepoUrlNormalizerTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/RepoUrlNormalizerTest.java
@@ -1,0 +1,67 @@
+package io.terrakube.api.plugin.vcs;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RepoUrlNormalizerTest {
+
+    @Test
+    void trailingSlashRemoved() {
+        assertThat(RepoUrlNormalizer.normalize("https://github.com/org/repo/"))
+                .isEqualTo("https://github.com/org/repo");
+    }
+
+    @Test
+    void gitSuffixStripped() {
+        assertThat(RepoUrlNormalizer.normalize("https://github.com/org/repo.git"))
+                .isEqualTo("https://github.com/org/repo");
+    }
+
+    @Test
+    void mixedCaseLowered() {
+        assertThat(RepoUrlNormalizer.normalize("https://GitHub.Com/Org/Repo"))
+                .isEqualTo("https://github.com/org/repo");
+    }
+
+    @Test
+    void nullReturnsNull() {
+        assertThat(RepoUrlNormalizer.normalize(null)).isNull();
+    }
+
+    @Test
+    void alreadyNormalizedReturnsSame() {
+        assertThat(RepoUrlNormalizer.normalize("https://github.com/org/repo"))
+                .isEqualTo("https://github.com/org/repo");
+    }
+
+    @Test
+    void httpsUrlNormalized() {
+        assertThat(RepoUrlNormalizer.normalize("HTTPS://GITHUB.COM/ORG/REPO.GIT"))
+                .isEqualTo("https://github.com/org/repo");
+    }
+
+    @Test
+    void httpUrlNormalized() {
+        assertThat(RepoUrlNormalizer.normalize("HTTP://github.com/org/repo.git"))
+                .isEqualTo("http://github.com/org/repo");
+    }
+
+    @Test
+    void nestedPathsPreserved() {
+        assertThat(RepoUrlNormalizer.normalize("https://gitlab.com/group/subgroup/repo"))
+                .isEqualTo("https://gitlab.com/group/subgroup/repo");
+    }
+
+    @Test
+    void trailingSlashAndGitCombined() {
+        assertThat(RepoUrlNormalizer.normalize("https://github.com/org/repo.git/"))
+                .isEqualTo("https://github.com/org/repo");
+    }
+
+    @Test
+    void whitespaceTrimmed() {
+        assertThat(RepoUrlNormalizer.normalize("  https://github.com/org/repo  "))
+                .isEqualTo("https://github.com/org/repo");
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
@@ -330,7 +330,7 @@ class RepoWebhookServiceTest {
             WebhookResult pingResult = new WebhookResult();
             pingResult.setEvent("ping");
             pingResult.setValid(true);
-            when(gitHubWebhookService.parseGitHubPayload(eq(payload), any(), any())).thenReturn(pingResult);
+            when(gitHubWebhookService.parseGitHubPayload(eq(payload), any())).thenReturn(pingResult);
 
             subject.processV2Webhook(rw.getId().toString(), payload, headers);
 
@@ -358,7 +358,7 @@ class RepoWebhookServiceTest {
             pushResult.setVia("Github");
             pushResult.setCommit("abc123");
             pushResult.setFileChanges(List.of("main.tf"));
-            when(gitHubWebhookService.parseGitHubPayload(eq(payload), any(), any())).thenReturn(pushResult);
+            when(gitHubWebhookService.parseGitHubPayload(eq(payload), any())).thenReturn(pushResult);
 
             // Create two workspaces with matching webhook events
             Workspace ws1 = workspaceWithSource("https://github.com/owner/repo");
@@ -367,7 +367,7 @@ class RepoWebhookServiceTest {
             WebhookEvent event1 = new WebhookEvent();
             event1.setEvent(WebhookEventType.PUSH);
             event1.setBranch("main");
-            event1.setPath(".*");
+            event1.setPath("*");
             event1.setTemplateId("template-1");
             wh1.setEvents(List.of(event1));
             ws1.setWebhook(wh1);
@@ -378,7 +378,7 @@ class RepoWebhookServiceTest {
             WebhookEvent event2 = new WebhookEvent();
             event2.setEvent(WebhookEventType.PUSH);
             event2.setBranch("main");
-            event2.setPath(".*");
+            event2.setPath("*");
             event2.setTemplateId("template-2");
             wh2.setEvents(List.of(event2));
             ws2.setWebhook(wh2);
@@ -416,7 +416,7 @@ class RepoWebhookServiceTest {
             pushResult.setVia("Github");
             pushResult.setCommit("abc123");
             pushResult.setFileChanges(List.of("main.tf"));
-            when(gitHubWebhookService.parseGitHubPayload(eq(payload), any(), any())).thenReturn(pushResult);
+            when(gitHubWebhookService.parseGitHubPayload(eq(payload), any())).thenReturn(pushResult);
 
             // ws1 has no webhook (should be skipped with warning)
             Workspace ws1 = workspaceWithSource("https://github.com/owner/repo");
@@ -429,7 +429,7 @@ class RepoWebhookServiceTest {
             WebhookEvent event2 = new WebhookEvent();
             event2.setEvent(WebhookEventType.PUSH);
             event2.setBranch("main");
-            event2.setPath(".*");
+            event2.setPath("*");
             event2.setTemplateId("template-2");
             wh2.setEvents(List.of(event2));
             ws2.setWebhook(wh2);
@@ -461,7 +461,7 @@ class RepoWebhookServiceTest {
             WebhookResult invalidResult = new WebhookResult();
             invalidResult.setEvent("unknown");
             invalidResult.setValid(false);
-            when(gitHubWebhookService.parseGitHubPayload(eq(payload), any(), any())).thenReturn(invalidResult);
+            when(gitHubWebhookService.parseGitHubPayload(eq(payload), any())).thenReturn(invalidResult);
 
             subject.processV2Webhook(rw.getId().toString(), payload, headers);
 
@@ -488,7 +488,7 @@ class RepoWebhookServiceTest {
             WebhookResult pingResult = new WebhookResult();
             pingResult.setEvent("ping");
             pingResult.setValid(true);
-            when(gitHubWebhookService.parseGitHubPayload(eq(payload), any(), any())).thenReturn(pingResult);
+            when(gitHubWebhookService.parseGitHubPayload(eq(payload), any())).thenReturn(pingResult);
 
             // Should not throw — valid signature
             subject.processV2Webhook(rw.getId().toString(), payload, headers);

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
@@ -1,0 +1,526 @@
+package io.terrakube.api.plugin.vcs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import io.terrakube.api.plugin.scheduler.ScheduleJobService;
+import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
+import io.terrakube.api.repository.JobRepository;
+import io.terrakube.api.repository.RepoWebhookRepository;
+import io.terrakube.api.repository.WebhookEventRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.webhook.RepoWebhook;
+import io.terrakube.api.rs.webhook.Webhook;
+import io.terrakube.api.rs.webhook.WebhookEvent;
+import io.terrakube.api.rs.webhook.WebhookEventType;
+import io.terrakube.api.rs.workspace.Workspace;
+
+@ExtendWith(MockitoExtension.class)
+class RepoWebhookServiceTest {
+
+    RepoWebhookRepository repoWebhookRepository;
+    WorkspaceRepository workspaceRepository;
+    WebhookEventRepository webhookEventRepository;
+    GitHubWebhookService gitHubWebhookService;
+    JobRepository jobRepository;
+    ScheduleJobService scheduleJobService;
+
+    RepoWebhookService subject;
+
+    @BeforeEach
+    void setup() {
+        repoWebhookRepository = mock(RepoWebhookRepository.class);
+        workspaceRepository = mock(WorkspaceRepository.class);
+        webhookEventRepository = mock(WebhookEventRepository.class);
+        gitHubWebhookService = mock(GitHubWebhookService.class);
+        jobRepository = mock(JobRepository.class);
+        scheduleJobService = mock(ScheduleJobService.class);
+
+        subject = new RepoWebhookService(
+                repoWebhookRepository,
+                workspaceRepository,
+                webhookEventRepository,
+                gitHubWebhookService,
+                jobRepository,
+                scheduleJobService);
+    }
+
+    private Workspace workspaceWithSource(String source) {
+        Workspace ws = new Workspace();
+        ws.setSource(source);
+        Vcs vcs = new Vcs();
+        ws.setVcs(vcs);
+        Organization org = new Organization();
+        ws.setOrganization(org);
+        ws.setName("test-workspace");
+        return ws;
+    }
+
+    private RepoWebhook repoWebhookWith(String url, String secret) {
+        RepoWebhook rw = new RepoWebhook();
+        rw.setId(UUID.randomUUID());
+        rw.setRepositoryUrl(url);
+        rw.setWebhookSecret(secret);
+        rw.setVcs(new Vcs());
+        return rw;
+    }
+
+    private String computeHmac(String secret, String payload) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        SecretKeySpec keySpec = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        mac.init(keySpec);
+        byte[] hash = mac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+        StringBuilder hex = new StringBuilder(2 * hash.length);
+        for (byte b : hash) {
+            String h = Integer.toHexString(0xff & b);
+            if (h.length() == 1) hex.append('0');
+            hex.append(h);
+        }
+        return "sha256=" + hex;
+    }
+
+    @Nested
+    class GetOrCreateRepoWebhook {
+
+        @Test
+        void returnsExistingWhenFound() {
+            Workspace ws = workspaceWithSource("https://github.com/owner/repo");
+            RepoWebhook existing = repoWebhookWith("https://github.com/owner/repo", "secret");
+            when(repoWebhookRepository.findByRepositoryUrl("https://github.com/owner/repo"))
+                    .thenReturn(Optional.of(existing));
+
+            RepoWebhook result = subject.getOrCreateRepoWebhook(ws);
+
+            assertThat(result).isSameAs(existing);
+            verify(repoWebhookRepository, never()).save(any());
+        }
+
+        @Test
+        void createsNewWhenNotFound() {
+            Workspace ws = workspaceWithSource("https://github.com/owner/repo");
+            when(repoWebhookRepository.findByRepositoryUrl("https://github.com/owner/repo"))
+                    .thenReturn(Optional.empty());
+            when(repoWebhookRepository.save(any(RepoWebhook.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            RepoWebhook result = subject.getOrCreateRepoWebhook(ws);
+
+            assertThat(result.getRepositoryUrl()).isEqualTo("https://github.com/owner/repo");
+            assertThat(result.getWebhookSecret()).isNotNull().hasSize(36); // UUID format
+            verify(repoWebhookRepository).save(any(RepoWebhook.class));
+        }
+
+        @Test
+        void handlesRaceConditionOnConcurrentInsert() {
+            Workspace ws = workspaceWithSource("https://github.com/owner/repo");
+            RepoWebhook existing = repoWebhookWith("https://github.com/owner/repo", "secret");
+            when(repoWebhookRepository.findByRepositoryUrl("https://github.com/owner/repo"))
+                    .thenReturn(Optional.empty())
+                    .thenReturn(Optional.of(existing));
+            when(repoWebhookRepository.save(any(RepoWebhook.class)))
+                    .thenThrow(new DataIntegrityViolationException("Duplicate"));
+
+            RepoWebhook result = subject.getOrCreateRepoWebhook(ws);
+
+            assertThat(result).isSameAs(existing);
+        }
+
+        @Test
+        void throwsWhenRaceConditionRetryAlsoFails() {
+            Workspace ws = workspaceWithSource("https://github.com/owner/repo");
+            when(repoWebhookRepository.findByRepositoryUrl("https://github.com/owner/repo"))
+                    .thenReturn(Optional.empty());
+            when(repoWebhookRepository.save(any(RepoWebhook.class)))
+                    .thenThrow(new DataIntegrityViolationException("Duplicate"));
+
+            assertThatThrownBy(() -> subject.getOrCreateRepoWebhook(ws))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Failed to create or find RepoWebhook");
+        }
+
+        @Test
+        void normalizesUrl() {
+            Workspace ws = workspaceWithSource("https://GitHub.com/Owner/Repo.git");
+            when(repoWebhookRepository.findByRepositoryUrl("https://github.com/owner/repo"))
+                    .thenReturn(Optional.empty());
+            when(repoWebhookRepository.save(any(RepoWebhook.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            RepoWebhook result = subject.getOrCreateRepoWebhook(ws);
+
+            assertThat(result.getRepositoryUrl()).isEqualTo("https://github.com/owner/repo");
+        }
+    }
+
+    @Nested
+    class CreateOrUpdateSharedWebhook {
+
+        @Test
+        void aggregatesEventTypesAcrossWorkspaces() {
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", "secret");
+
+            Workspace ws1 = workspaceWithSource("https://github.com/owner/repo");
+            Webhook wh1 = new Webhook();
+            WebhookEvent pushEvent = new WebhookEvent();
+            pushEvent.setEvent(WebhookEventType.PUSH);
+            wh1.setEvents(List.of(pushEvent));
+            ws1.setWebhook(wh1);
+
+            Workspace ws2 = workspaceWithSource("https://github.com/owner/repo");
+            Webhook wh2 = new Webhook();
+            WebhookEvent prEvent = new WebhookEvent();
+            prEvent.setEvent(WebhookEventType.PULL_REQUEST);
+            wh2.setEvents(List.of(prEvent));
+            ws2.setWebhook(wh2);
+
+            when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(rw.getRepositoryUrl()))
+                    .thenReturn(List.of(ws1, ws2));
+            when(gitHubWebhookService.createOrUpdateRepoWebhook(eq(rw), any()))
+                    .thenReturn("12345");
+
+            subject.createOrUpdateSharedWebhook(rw);
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Set<WebhookEventType>> captor = ArgumentCaptor.forClass(Set.class);
+            verify(gitHubWebhookService).createOrUpdateRepoWebhook(eq(rw), captor.capture());
+            assertThat(captor.getValue()).containsExactlyInAnyOrder(WebhookEventType.PUSH, WebhookEventType.PULL_REQUEST);
+            assertThat(rw.getRemoteHookId()).isEqualTo("12345");
+            verify(repoWebhookRepository).save(rw);
+        }
+
+        @Test
+        void skipsWhenNoEventTypes() {
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", "secret");
+
+            Workspace ws = workspaceWithSource("https://github.com/owner/repo");
+            Webhook wh = new Webhook();
+            wh.setEvents(Collections.emptyList());
+            ws.setWebhook(wh);
+
+            when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(rw.getRepositoryUrl()))
+                    .thenReturn(List.of(ws));
+
+            subject.createOrUpdateSharedWebhook(rw);
+
+            verify(gitHubWebhookService, never()).createOrUpdateRepoWebhook(any(), any());
+        }
+    }
+
+    @Nested
+    class CleanupIfOrphan {
+
+        @Test
+        void deletesWhenNoWorkspacesRemain() {
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", "secret");
+            when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(rw.getRepositoryUrl()))
+                    .thenReturn(Collections.emptyList());
+
+            subject.cleanupIfOrphan(rw);
+
+            verify(gitHubWebhookService).deleteRepoWebhook(rw);
+            verify(repoWebhookRepository).delete(rw);
+        }
+
+        @Test
+        void updatesWhenWorkspacesStillExist() {
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", "secret");
+            Workspace ws = workspaceWithSource("https://github.com/owner/repo");
+            Webhook wh = new Webhook();
+            WebhookEvent event = new WebhookEvent();
+            event.setEvent(WebhookEventType.PUSH);
+            wh.setEvents(List.of(event));
+            ws.setWebhook(wh);
+
+            when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(rw.getRepositoryUrl()))
+                    .thenReturn(List.of(ws));
+            when(gitHubWebhookService.createOrUpdateRepoWebhook(eq(rw), any())).thenReturn("12345");
+
+            subject.cleanupIfOrphan(rw);
+
+            verify(gitHubWebhookService, never()).deleteRepoWebhook(any());
+            verify(repoWebhookRepository, never()).delete(any());
+            verify(gitHubWebhookService).createOrUpdateRepoWebhook(eq(rw), any());
+        }
+    }
+
+    @Nested
+    class ProcessV2Webhook {
+
+        @Test
+        void throwsOnInvalidUuid() {
+            assertThatThrownBy(() -> subject.processV2Webhook("not-a-uuid", "{}", Map.of()))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void throwsOnNotFound() {
+            UUID id = UUID.randomUUID();
+            when(repoWebhookRepository.findById(id)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> subject.processV2Webhook(id.toString(), "{}", Map.of()))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Repo webhook not found");
+        }
+
+        @Test
+        void throwsSecurityExceptionOnHmacFailure() {
+            String secret = "test-secret";
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            Map<String, String> headers = Map.of("x-hub-signature-256", "sha256=invalid");
+
+            assertThatThrownBy(() -> subject.processV2Webhook(rw.getId().toString(), "{}", headers))
+                    .isInstanceOf(SecurityException.class)
+                    .hasMessageContaining("HMAC signature verification failed");
+
+            verify(jobRepository, never()).save(any());
+        }
+
+        @Test
+        void throwsWhenSignatureHeaderMissing() {
+            String secret = "test-secret";
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            assertThatThrownBy(() -> subject.processV2Webhook(rw.getId().toString(), "{}", Map.of()))
+                    .isInstanceOf(SecurityException.class);
+        }
+
+        @Test
+        void handlesValidPingEvent() throws Exception {
+            String secret = "test-secret";
+            String payload = "{\"zen\":\"test\"}";
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            String sig = computeHmac(secret, payload);
+            Map<String, String> headers = Map.of(
+                    "x-hub-signature-256", sig,
+                    "x-github-event", "ping");
+
+            WebhookResult pingResult = new WebhookResult();
+            pingResult.setEvent("ping");
+            pingResult.setValid(true);
+            when(gitHubWebhookService.parseGitHubPayload(eq(payload), any(), any())).thenReturn(pingResult);
+
+            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+
+            verify(jobRepository, never()).save(any());
+            verify(workspaceRepository, never()).findByNormalizedSourceWithMigratedWebhook(any());
+        }
+
+        @Test
+        void fansOutToMultipleWorkspaces() throws Exception {
+            String secret = "test-secret";
+            String payload = "{\"ref\":\"refs/heads/main\"}";
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            String sig = computeHmac(secret, payload);
+            Map<String, String> headers = Map.of(
+                    "x-hub-signature-256", sig,
+                    "x-github-event", "push");
+
+            WebhookResult pushResult = new WebhookResult();
+            pushResult.setEvent("push");
+            pushResult.setValid(true);
+            pushResult.setBranch("main");
+            pushResult.setCreatedBy("user@test.com");
+            pushResult.setVia("Github");
+            pushResult.setCommit("abc123");
+            pushResult.setFileChanges(List.of("main.tf"));
+            when(gitHubWebhookService.parseGitHubPayload(eq(payload), any(), any())).thenReturn(pushResult);
+
+            // Create two workspaces with matching webhook events
+            Workspace ws1 = workspaceWithSource("https://github.com/owner/repo");
+            ws1.setName("ws1");
+            Webhook wh1 = new Webhook();
+            WebhookEvent event1 = new WebhookEvent();
+            event1.setEvent(WebhookEventType.PUSH);
+            event1.setBranch("main");
+            event1.setPath(".*");
+            event1.setTemplateId("template-1");
+            wh1.setEvents(List.of(event1));
+            ws1.setWebhook(wh1);
+
+            Workspace ws2 = workspaceWithSource("https://github.com/owner/repo");
+            ws2.setName("ws2");
+            Webhook wh2 = new Webhook();
+            WebhookEvent event2 = new WebhookEvent();
+            event2.setEvent(WebhookEventType.PUSH);
+            event2.setBranch("main");
+            event2.setPath(".*");
+            event2.setTemplateId("template-2");
+            wh2.setEvents(List.of(event2));
+            ws2.setWebhook(wh2);
+
+            when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(rw.getRepositoryUrl()))
+                    .thenReturn(List.of(ws1, ws2));
+            when(webhookEventRepository.findByWebhookAndEventOrderByPriorityAsc(wh1, WebhookEventType.PUSH))
+                    .thenReturn(List.of(event1));
+            when(webhookEventRepository.findByWebhookAndEventOrderByPriorityAsc(wh2, WebhookEventType.PUSH))
+                    .thenReturn(List.of(event2));
+            when(jobRepository.save(any(Job.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+
+            verify(jobRepository, times(2)).save(any(Job.class));
+        }
+
+        @Test
+        void continuesProcessingWhenOneWorkspaceFails() throws Exception {
+            String secret = "test-secret";
+            String payload = "{\"ref\":\"refs/heads/main\"}";
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            String sig = computeHmac(secret, payload);
+            Map<String, String> headers = Map.of(
+                    "x-hub-signature-256", sig,
+                    "x-github-event", "push");
+
+            WebhookResult pushResult = new WebhookResult();
+            pushResult.setEvent("push");
+            pushResult.setValid(true);
+            pushResult.setBranch("main");
+            pushResult.setCreatedBy("user@test.com");
+            pushResult.setVia("Github");
+            pushResult.setCommit("abc123");
+            pushResult.setFileChanges(List.of("main.tf"));
+            when(gitHubWebhookService.parseGitHubPayload(eq(payload), any(), any())).thenReturn(pushResult);
+
+            // ws1 has no webhook (should be skipped with warning)
+            Workspace ws1 = workspaceWithSource("https://github.com/owner/repo");
+            ws1.setName("ws1-no-webhook");
+
+            // ws2 has a valid webhook
+            Workspace ws2 = workspaceWithSource("https://github.com/owner/repo");
+            ws2.setName("ws2");
+            Webhook wh2 = new Webhook();
+            WebhookEvent event2 = new WebhookEvent();
+            event2.setEvent(WebhookEventType.PUSH);
+            event2.setBranch("main");
+            event2.setPath(".*");
+            event2.setTemplateId("template-2");
+            wh2.setEvents(List.of(event2));
+            ws2.setWebhook(wh2);
+
+            when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(rw.getRepositoryUrl()))
+                    .thenReturn(List.of(ws1, ws2));
+            when(webhookEventRepository.findByWebhookAndEventOrderByPriorityAsc(wh2, WebhookEventType.PUSH))
+                    .thenReturn(List.of(event2));
+            when(jobRepository.save(any(Job.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+
+            // ws1 skipped, ws2 should still create a job
+            verify(jobRepository, times(1)).save(any(Job.class));
+        }
+
+        @Test
+        void skipsInvalidWebhookResult() throws Exception {
+            String secret = "test-secret";
+            String payload = "{}";
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            String sig = computeHmac(secret, payload);
+            Map<String, String> headers = Map.of(
+                    "x-hub-signature-256", sig,
+                    "x-github-event", "unknown");
+
+            WebhookResult invalidResult = new WebhookResult();
+            invalidResult.setEvent("unknown");
+            invalidResult.setValid(false);
+            when(gitHubWebhookService.parseGitHubPayload(eq(payload), any(), any())).thenReturn(invalidResult);
+
+            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+
+            verify(workspaceRepository, never()).findByNormalizedSourceWithMigratedWebhook(any());
+            verify(jobRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    class VerifyHmacSignature {
+
+        @Test
+        void acceptsValidSignature() throws Exception {
+            String secret = "my-webhook-secret";
+            String payload = "{\"action\":\"push\"}";
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            String sig = computeHmac(secret, payload);
+            Map<String, String> headers = Map.of(
+                    "x-hub-signature-256", sig,
+                    "x-github-event", "ping");
+
+            WebhookResult pingResult = new WebhookResult();
+            pingResult.setEvent("ping");
+            pingResult.setValid(true);
+            when(gitHubWebhookService.parseGitHubPayload(eq(payload), any(), any())).thenReturn(pingResult);
+
+            // Should not throw — valid signature
+            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+        }
+
+        @Test
+        void rejectsTamperedPayload() throws Exception {
+            String secret = "my-webhook-secret";
+            String payload = "{\"action\":\"push\"}";
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            // Compute sig for different payload
+            String sig = computeHmac(secret, "{\"action\":\"different\"}");
+            Map<String, String> headers = Map.of("x-hub-signature-256", sig);
+
+            assertThatThrownBy(() -> subject.processV2Webhook(rw.getId().toString(), payload, headers))
+                    .isInstanceOf(SecurityException.class);
+        }
+
+        @Test
+        void rejectsWrongSecret() throws Exception {
+            String secret = "correct-secret";
+            String payload = "{}";
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            String sig = computeHmac("wrong-secret", payload);
+            Map<String, String> headers = Map.of("x-hub-signature-256", sig);
+
+            assertThatThrownBy(() -> subject.processV2Webhook(rw.getId().toString(), payload, headers))
+                    .isInstanceOf(SecurityException.class);
+        }
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookEventMatcherTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookEventMatcherTest.java
@@ -30,8 +30,8 @@ class WebhookEventMatcherTest {
     }
 
     @Test
-    void checkBranch_regexMatch_returnsTrue() {
-        assertThat(WebhookEventMatcher.checkBranch("main-branch", eventWithBranch("main.*"))).isTrue();
+    void checkBranch_globMatch_returnsTrue() {
+        assertThat(WebhookEventMatcher.checkBranch("main-branch", eventWithBranch("main*"))).isTrue();
     }
 
     @Test
@@ -41,7 +41,7 @@ class WebhookEventMatcherTest {
 
     @Test
     void checkBranch_commaSeparatedList_matchesAny() {
-        WebhookEvent event = eventWithBranch("main, develop, release/.*");
+        WebhookEvent event = eventWithBranch("main, develop, release/*");
         assertThat(WebhookEventMatcher.checkBranch("develop", event)).isTrue();
         assertThat(WebhookEventMatcher.checkBranch("release/1.0", event)).isTrue();
         assertThat(WebhookEventMatcher.checkBranch("feature/foo", event)).isFalse();
@@ -52,18 +52,47 @@ class WebhookEventMatcherTest {
     @Test
     void checkFileChanges_fileMatchesPattern_returnsTrue() {
         assertThat(WebhookEventMatcher.checkFileChanges(
-                List.of("src/main/App.java"), eventWithPath("src/main/.*"))).isTrue();
+                List.of("src/main/App.java"), eventWithPath("src/main/*"))).isTrue();
     }
 
     @Test
     void checkFileChanges_noFileMatches_returnsFalse() {
         assertThat(WebhookEventMatcher.checkFileChanges(
-                List.of("docs/README.md"), eventWithPath("src/.*"))).isFalse();
+                List.of("docs/README.md"), eventWithPath("src/*"))).isFalse();
     }
 
     @Test
     void checkFileChanges_multiplePatterns_oneMatches_returnsTrue() {
         assertThat(WebhookEventMatcher.checkFileChanges(
-                List.of("terraform/main.tf"), eventWithPath("src/.*,terraform/.*"))).isTrue();
+                List.of("terraform/main.tf"), eventWithPath("src/*,terraform/*"))).isTrue();
+    }
+
+    // --- glob matching tests ---
+
+    @Test
+    void globMatch_questionMark_matchesSingleChar() {
+        assertThat(WebhookEventMatcher.globMatch("main", "mai?")).isTrue();
+        assertThat(WebhookEventMatcher.globMatch("main", "ma??")).isTrue();
+        assertThat(WebhookEventMatcher.globMatch("main", "m?")).isFalse();
+    }
+
+    @Test
+    void globMatch_escapesRegexSpecialChars() {
+        assertThat(WebhookEventMatcher.globMatch("file.txt", "file.txt")).isTrue();
+        assertThat(WebhookEventMatcher.globMatch("fileatxt", "file.txt")).isFalse();
+    }
+
+    @Test
+    void globMatch_invalidPattern_returnsFalse() {
+        assertThat(WebhookEventMatcher.globMatch("test", null)).isFalse();
+    }
+
+    // --- globToSafeRegex prevents ReDoS ---
+
+    @Test
+    void globToSafeRegex_escapesNestedQuantifiers() {
+        String regex = WebhookEventMatcher.globToSafeRegex("(a+)+$");
+        // Nested quantifiers should be escaped, not treated as regex
+        assertThat(regex).isEqualTo("\\(a\\+\\)\\+\\$");
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookEventMatcherTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookEventMatcherTest.java
@@ -1,0 +1,69 @@
+package io.terrakube.api.plugin.vcs;
+
+import java.util.List;
+
+import io.terrakube.api.rs.webhook.WebhookEvent;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WebhookEventMatcherTest {
+
+    private WebhookEvent eventWithBranch(String branch) {
+        WebhookEvent event = new WebhookEvent();
+        event.setBranch(branch);
+        return event;
+    }
+
+    private WebhookEvent eventWithPath(String path) {
+        WebhookEvent event = new WebhookEvent();
+        event.setPath(path);
+        return event;
+    }
+
+    // --- checkBranch tests ---
+
+    @Test
+    void checkBranch_exactMatch_returnsTrue() {
+        assertThat(WebhookEventMatcher.checkBranch("main", eventWithBranch("main"))).isTrue();
+    }
+
+    @Test
+    void checkBranch_regexMatch_returnsTrue() {
+        assertThat(WebhookEventMatcher.checkBranch("main-branch", eventWithBranch("main.*"))).isTrue();
+    }
+
+    @Test
+    void checkBranch_noMatch_returnsFalse() {
+        assertThat(WebhookEventMatcher.checkBranch("develop", eventWithBranch("main"))).isFalse();
+    }
+
+    @Test
+    void checkBranch_commaSeparatedList_matchesAny() {
+        WebhookEvent event = eventWithBranch("main, develop, release/.*");
+        assertThat(WebhookEventMatcher.checkBranch("develop", event)).isTrue();
+        assertThat(WebhookEventMatcher.checkBranch("release/1.0", event)).isTrue();
+        assertThat(WebhookEventMatcher.checkBranch("feature/foo", event)).isFalse();
+    }
+
+    // --- checkFileChanges tests ---
+
+    @Test
+    void checkFileChanges_fileMatchesPattern_returnsTrue() {
+        assertThat(WebhookEventMatcher.checkFileChanges(
+                List.of("src/main/App.java"), eventWithPath("src/main/.*"))).isTrue();
+    }
+
+    @Test
+    void checkFileChanges_noFileMatches_returnsFalse() {
+        assertThat(WebhookEventMatcher.checkFileChanges(
+                List.of("docs/README.md"), eventWithPath("src/.*"))).isFalse();
+    }
+
+    @Test
+    void checkFileChanges_multiplePatterns_oneMatches_returnsTrue() {
+        assertThat(WebhookEventMatcher.checkFileChanges(
+                List.of("terraform/main.tf"), eventWithPath("src/.*,terraform/.*"))).isTrue();
+    }
+}

--- a/ui/src/domain/Workspaces/Settings/Webhook.tsx
+++ b/ui/src/domain/Workspaces/Settings/Webhook.tsx
@@ -56,6 +56,7 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
   ]);
   const workspaceId = workspace.id;
   const [remoteHookId, setRemoteHookId] = useState("");
+  const [migratedV2, setMigratedV2] = useState(false);
   const webhookId = workspace.relationships.webhook?.data?.id;
 
   useEffect(() => {
@@ -77,6 +78,7 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
     ])
       .then(([webhookRes, eventsRes]) => {
         setRemoteHookId(webhookRes.data.data.attributes.remoteHookId);
+        setMigratedV2(webhookRes.data.data.attributes.migratedV2 || false);
 
         let i = 1;
         const events = eventsRes.data.data
@@ -277,6 +279,62 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
       message.success("Webhook saved successfully");
     });
   };
+  const handleMigrateV2 = () => {
+    if (!webhookId) return;
+    setWaiting(true);
+    axiosInstance
+      .patch(`organization/${organizationId}/workspace/${workspaceId}/webhook/${webhookId}`, {
+        data: {
+          type: "webhook",
+          id: webhookId,
+          attributes: {
+            migratedV2: true,
+          },
+        },
+      })
+      .then((response) => {
+        if (response.status === 200) {
+          setMigratedV2(true);
+          message.success("Migrated to shared webhook successfully");
+        } else {
+          message.error("Failed to migrate to shared webhook");
+        }
+        setWaiting(false);
+      })
+      .catch(() => {
+        message.error("Failed to migrate to shared webhook");
+        setWaiting(false);
+      });
+  };
+
+  const handleRevertV2 = () => {
+    if (!webhookId) return;
+    setWaiting(true);
+    axiosInstance
+      .patch(`organization/${organizationId}/workspace/${workspaceId}/webhook/${webhookId}`, {
+        data: {
+          type: "webhook",
+          id: webhookId,
+          attributes: {
+            migratedV2: false,
+          },
+        },
+      })
+      .then((response) => {
+        if (response.status === 200) {
+          setMigratedV2(false);
+          message.success("Reverted to per-workspace webhook");
+        } else {
+          message.error("Failed to revert webhook");
+        }
+        setWaiting(false);
+      })
+      .catch(() => {
+        message.error("Failed to revert webhook");
+        setWaiting(false);
+      });
+  };
+
   const columns = [
     {
       title: "Priority",
@@ -415,8 +473,47 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
             </Col>
             <Col span={12}>
               <Form.Item hidden={!webhookEnabled} label={renderVCSLogo(vcsProvider!)}>
-                {remoteHookId}
+                {migratedV2 ? <Typography.Text type="success">Shared</Typography.Text> : remoteHookId}
               </Form.Item>
+            </Col>
+          </Row>
+          <Row hidden={!webhookEnabled || vcsProvider !== "GITHUB"}>
+            <Col span={24} style={{ marginBottom: 16 }}>
+              {migratedV2 ? (
+                <Space>
+                  <Typography.Text type="success">Shared repo webhook active</Typography.Text>
+                  <Popconfirm
+                    title="Revert to per-workspace webhook?"
+                    description="This will create a new per-workspace webhook on your next save."
+                    onConfirm={handleRevertV2}
+                    okText="Yes"
+                    cancelText="No"
+                    disabled={!manageWorkspace}
+                  >
+                    <Button type="default" size="small" disabled={!manageWorkspace}>
+                      Revert
+                    </Button>
+                  </Popconfirm>
+                </Space>
+              ) : (
+                <Space>
+                  <Typography.Text type="secondary">
+                    Consolidate webhooks across workspaces sharing this repository
+                  </Typography.Text>
+                  <Popconfirm
+                    title="Migrate to shared webhook?"
+                    description="This will replace the per-workspace webhook with a single shared webhook for this repository."
+                    onConfirm={handleMigrateV2}
+                    okText="Yes"
+                    cancelText="No"
+                    disabled={!manageWorkspace}
+                  >
+                    <Button type="default" size="small" disabled={!manageWorkspace}>
+                      Migrate to Shared Webhook
+                    </Button>
+                  </Popconfirm>
+                </Space>
+              )}
             </Col>
           </Row>
           <Row hidden={!webhookEnabled}>

--- a/ui/src/domain/types.ts
+++ b/ui/src/domain/types.ts
@@ -357,6 +357,7 @@ export type Webhook = {
 };
 export type WebhookAttributes = {
   remoteHookId: string;
+  migratedV2: boolean;
 };
 export enum WebhookEventType {
   PUSH = "PUSH",


### PR DESCRIPTION
## Summary
- Adds shared repo-level webhook infrastructure (v2) that consolidates per-workspace webhooks into a single webhook per repository, reducing GitHub API usage and simplifying webhook management
- Normalizes repository URLs for deduplication and migrates workspaces to shared webhooks via an Elide lifecycle hook
- Includes security hardening: uniform error responses, UUID validation, glob-based pattern matching (ReDoS prevention), per-workspace VCS credential isolation, configurable `insecure_ssl`, and constant-time HMAC comparison for v1

## Changes
- **New entities**: `RepoWebhook` for shared webhook state, with Liquibase migration
- **New services**: `RepoWebhookService` (fan-out processing), `WebhookEventMatcher` (glob matching), `RepoUrlNormalizer`
- **GitHub integration**: `createOrUpdateRepoWebhook`, `deleteRepoWebhook`, `fetchPrFileChanges` on `GitHubWebhookService`
- **Security**: v2 endpoint at `/webhook/v2/{id}` with HMAC-SHA256 verification, CSRF exemption, and `permitAll` (same posture as v1)
- **UI**: Webhook settings page updated to show migration status
- **Config**: `io.terrakube.webhook.insecure-ssl` property (default `1`, recommended `0` for production)

## Test plan
- [x] Unit tests for `RepoUrlNormalizer`, `WebhookEventMatcher`, `RepoWebhookService` (41 tests passing)
- [ ] Integration test: push to shared repo triggers jobs in multiple workspaces
- [ ] Integration test: PR event fetches file changes per-workspace with correct VCS credentials
- [ ] Verify v1 webhooks continue to function unchanged
- [ ] Verify `insecure_ssl=0` enforces TLS verification on GitHub webhook delivery