### PR TITLE
fix(ui): Add pull requests read permission to GitHub App setup instructions

### DIFF
--- a/ui/src/domain/Settings/AddVCS.tsx
+++ b/ui/src/domain/Settings/AddVCS.tsx
@@ -594,12 +594,15 @@ export const AddVCS = ({ setMode, loadVCS }: Props) => {
                     <b>Webhook:</b> <b>untick</b> Active
                   </li>
                   <li>
-                    <b>Repository permissions:</b> Commit statuses: Read and write (Only if webhook to be used on VCS
-                    workflow workspaces)
+                    <b>Repository permissions:</b>
                     <br />
-                    Content: Read-only
+                    Commit statuses: Read and write (Only if webhook to be used on VCS workflow workspaces)
+                    <br />
+                    Contents: Read-only
                     <br />
                     Metadata: Read-only
+                    <br />
+                    Pull requests: Read-only (Only if webhook to be used on VCS workflow workspaces)
                     <br />
                     Webhooks: Read and write (Only if webhook to be used on VCS workflow workspaces)
                   </li>


### PR DESCRIPTION
## Description

This PR adds the "Pull requests: Read-only" permission to the Repository permissions list in the GitHub App setup instructions within AddVCS.tsx.
This change resolves a 403 Forbidden error that occurred when fetching pull request file changes via the GitHub API.

In addition, this PR includes minor documentation and formatting improvements related to the same setup instructions.

## Background

The issue was identified in GitHubWebhookService.java, specifically in the [getPrFileChanges](https://github.com/terrakube-io/terrakube/blob/2.29.1/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java#L259) method, where `callGitHubApi()` was returning a 403 error when attempting to retrieve files changed in a pull request.

Although the linked code is from an older version (2.29.1), the same issue persists in the current codebase, as the method still relies on this API call without the necessary permissions being documented.

## Changes

Updated the Repository permissions section in AddVCS.tsx to include:

* Pull requests: Read-only

This ensures users configure their GitHub App with the required permissions to avoid 403 errors during PR-related webhook processing.

Also applied minor wording and formatting adjustments for clarity.

## Impact

No breaking changes; this is an additive update to the setup instructions.
Users setting up new GitHub Apps will now be guided to include this permission, preventing runtime errors.
Existing apps without this permission may need to be updated manually.

## Testing

Verified that the change aligns with GitHub API documentation for pull request file access.
Recommend testing by triggering a PR webhook event and confirming that `getPrFileChanges` succeeds without 403 errors.

## Screenshot

<img width="974" height="475" alt="image" src="https://github.com/user-attachments/assets/48852c1a-69de-46d4-b3e1-c7e14c377dd0" />
