### PR TITLE
Support multiple secrets, ConfigMap envFrom, and pod template annotations for ephemeral executor pods

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralConfiguration.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.PropertySources;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Map;
 
 @Component
@@ -21,6 +22,6 @@ public class EphemeralConfiguration {
 
     private String namespace;
     private String image;
-    private String secret;
+    private List<String> secret;
     private Map<String, String> nodeSelector;
 }

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
@@ -35,7 +35,7 @@ public class EphemeralExecutorService {
     private static final String EPHEMERAL_MEMORY_LIMIT = "EPHEMERAL_MEMORY_LIMIT";
     private static final String EPHEMERAL_JOB_ENV_VARS = "EPHEMERAL_JOB_ENV_VARS";
     private static final String LABELS = "EPHEMERAL_CONFIG_LABELS";
-    private static final String CONFIG_MAP_ENVFROM = "EPHEMERAL_CONFIG_MAP_ENVFROM";
+    private static final String ENVFROM_CONFIG_MAP = "EPHEMERAL_CONFIG_ENVFROM_CONFIG_MAP";
     private static final String POD_ANNOTATIONS = "EPHEMERAL_CONFIG_POD_ANNOTATIONS";
 
     KubernetesClient kubernetesClient;
@@ -55,14 +55,20 @@ public class EphemeralExecutorService {
             }
         }
 
-        Optional<String> configMapEnvFromName = Optional.ofNullable(
-                executorContext.getEnvironmentVariables().getOrDefault(CONFIG_MAP_ENVFROM, null));
-        if (configMapEnvFromName.isPresent()) {
-            ConfigMapEnvSource configMapEnvSource = new ConfigMapEnvSource();
-            configMapEnvSource.setName(configMapEnvFromName.get());
-            EnvFromSource configMapEnvFrom = new EnvFromSource();
-            configMapEnvFrom.setConfigMapRef(configMapEnvSource);
-            executorEnvVarFromSecret.add(configMapEnvFrom);
+        Optional<String> configMapEnvFromNames = Optional.ofNullable(
+                executorContext.getEnvironmentVariables().getOrDefault(ENVFROM_CONFIG_MAP, null));
+        if (configMapEnvFromNames.isPresent()) {
+            for (String configMapName : configMapEnvFromNames.get().split(",")) {
+                String trimmed = configMapName.trim();
+                if (trimmed.isEmpty()) {
+                    continue;
+                }
+                ConfigMapEnvSource configMapEnvSource = new ConfigMapEnvSource();
+                configMapEnvSource.setName(trimmed);
+                EnvFromSource configMapEnvFrom = new EnvFromSource();
+                configMapEnvFrom.setConfigMapRef(configMapEnvSource);
+                executorEnvVarFromSecret.add(configMapEnvFrom);
+            }
         }
 
         EnvVar executorFlagBatch = new EnvVar();
@@ -139,7 +145,6 @@ public class EphemeralExecutorService {
         Optional<String> podAnnotationsInfo = Optional.ofNullable(
                 executorContext.getEnvironmentVariables().getOrDefault(POD_ANNOTATIONS, null));
         Map<String, String> podAnnotations = new HashMap<>();
-        log.info("Custom Pod Annotations: {}", podAnnotationsInfo.isPresent());
         if (podAnnotationsInfo.isPresent()) {
             podAnnotations.putAll(parseKeyValueString(podAnnotationsInfo.get()));
         }
@@ -278,7 +283,7 @@ public class EphemeralExecutorService {
         labels.put("terrakube.io/organization", executorContext.getOrganizationId());
         labels.put("terrakube.io/workspace", executorContext.getWorkspaceId());
 
-        io.fabric8.kubernetes.api.model.batch.v1.Job k8sJob = new JobBuilder()
+        JobBuilder jobBuilder = new JobBuilder()
                 .withApiVersion("batch/v1")
                 .withNewMetadata()
                 .withName(jobName)
@@ -287,9 +292,6 @@ public class EphemeralExecutorService {
                 .endMetadata()
                 .withNewSpec()
                 .withNewTemplate()
-                .withNewMetadata()
-                .withAnnotations(podAnnotations)
-                .endMetadata()
                 .withNewSpec()
                 .withSecurityContext(podSecurityContext)
                 .withNodeSelector(nodeSelectorInfo)
@@ -309,8 +311,15 @@ public class EphemeralExecutorService {
                 .endSpec()
                 .endTemplate()
                 .withTtlSecondsAfterFinished(30)
-                .endSpec()
-                .build();
+                .endSpec();
+
+        if (!podAnnotations.isEmpty()) {
+            jobBuilder.editSpec().editTemplate().editOrNewMetadata()
+                    .addToAnnotations(podAnnotations)
+                    .endMetadata().endTemplate().endSpec();
+        }
+
+        io.fabric8.kubernetes.api.model.batch.v1.Job k8sJob = jobBuilder.build();
 
         try {
             kubernetesClient.batch().v1().jobs().inNamespace(ephemeralConfiguration.getNamespace()).resource(k8sJob).serverSideApply();

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
@@ -35,6 +35,8 @@ public class EphemeralExecutorService {
     private static final String EPHEMERAL_MEMORY_LIMIT = "EPHEMERAL_MEMORY_LIMIT";
     private static final String EPHEMERAL_JOB_ENV_VARS = "EPHEMERAL_JOB_ENV_VARS";
     private static final String LABELS = "EPHEMERAL_CONFIG_LABELS";
+    private static final String CONFIG_MAP_ENVFROM = "EPHEMERAL_CONFIG_MAP_ENVFROM";
+    private static final String POD_ANNOTATIONS = "EPHEMERAL_CONFIG_POD_ANNOTATIONS";
 
     KubernetesClient kubernetesClient;
     EphemeralConfiguration ephemeralConfiguration;
@@ -42,11 +44,26 @@ public class EphemeralExecutorService {
     public void send(Job job, ExecutorContext executorContext) throws ExecutionException {
         final String jobName = String.format("job-%s-%s", job.getId(), System.currentTimeMillis());
         log.info("Ephemeral Executor Image {}, Job: {}, Namespace: {}, NodeSelector: {}", ephemeralConfiguration.getImage(), jobName, ephemeralConfiguration.getNamespace(), ephemeralConfiguration.getNodeSelector());
-        SecretEnvSource secretEnvSource = new SecretEnvSource();
-        secretEnvSource.setName(ephemeralConfiguration.getSecret());
-        EnvFromSource envFromSource = new EnvFromSource();
-        envFromSource.setSecretRef(secretEnvSource);
-        final List<EnvFromSource> executorEnvVarFromSecret = Arrays.asList(envFromSource);
+        final List<EnvFromSource> executorEnvVarFromSecret = new ArrayList<>();
+        if (ephemeralConfiguration.getSecret() != null) {
+            for (String secretName : ephemeralConfiguration.getSecret()) {
+                SecretEnvSource secretEnvSource = new SecretEnvSource();
+                secretEnvSource.setName(secretName.trim());
+                EnvFromSource envFromSource = new EnvFromSource();
+                envFromSource.setSecretRef(secretEnvSource);
+                executorEnvVarFromSecret.add(envFromSource);
+            }
+        }
+
+        Optional<String> configMapEnvFromName = Optional.ofNullable(
+                executorContext.getEnvironmentVariables().getOrDefault(CONFIG_MAP_ENVFROM, null));
+        if (configMapEnvFromName.isPresent()) {
+            ConfigMapEnvSource configMapEnvSource = new ConfigMapEnvSource();
+            configMapEnvSource.setName(configMapEnvFromName.get());
+            EnvFromSource configMapEnvFrom = new EnvFromSource();
+            configMapEnvFrom.setConfigMapRef(configMapEnvSource);
+            executorEnvVarFromSecret.add(configMapEnvFrom);
+        }
 
         EnvVar executorFlagBatch = new EnvVar();
         executorFlagBatch.setName("EphemeralFlagBatch");
@@ -117,6 +134,14 @@ public class EphemeralExecutorService {
         log.info("Custom Annotations: {}", annotationsInfo.isPresent());
         if(annotationsInfo.isPresent()) {
             annotations.putAll(parseKeyValueString(annotationsInfo.get()));
+        }
+
+        Optional<String> podAnnotationsInfo = Optional.ofNullable(
+                executorContext.getEnvironmentVariables().getOrDefault(POD_ANNOTATIONS, null));
+        Map<String, String> podAnnotations = new HashMap<>();
+        log.info("Custom Pod Annotations: {}", podAnnotationsInfo.isPresent());
+        if (podAnnotationsInfo.isPresent()) {
+            podAnnotations.putAll(parseKeyValueString(podAnnotationsInfo.get()));
         }
 
         Optional<String> serviceAccountInfo = Optional.ofNullable(
@@ -262,6 +287,9 @@ public class EphemeralExecutorService {
                 .endMetadata()
                 .withNewSpec()
                 .withNewTemplate()
+                .withNewMetadata()
+                .withAnnotations(podAnnotations)
+                .endMetadata()
                 .withNewSpec()
                 .withSecurityContext(podSecurityContext)
                 .withNodeSelector(nodeSelectorInfo)

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
@@ -44,14 +44,21 @@ public class EphemeralExecutorService {
     public void send(Job job, ExecutorContext executorContext) throws ExecutionException {
         final String jobName = String.format("job-%s-%s", job.getId(), System.currentTimeMillis());
         log.info("Ephemeral Executor Image {}, Job: {}, Namespace: {}, NodeSelector: {}", ephemeralConfiguration.getImage(), jobName, ephemeralConfiguration.getNamespace(), ephemeralConfiguration.getNodeSelector());
-        final List<EnvFromSource> executorEnvVarFromSecret = new ArrayList<>();
+        final List<EnvFromSource> executorEnvFromSources = new ArrayList<>();
         if (ephemeralConfiguration.getSecret() != null) {
             for (String secretName : ephemeralConfiguration.getSecret()) {
+                if (secretName == null) {
+                    continue;
+                }
+                String trimmed = secretName.trim();
+                if (trimmed.isEmpty()) {
+                    continue;
+                }
                 SecretEnvSource secretEnvSource = new SecretEnvSource();
-                secretEnvSource.setName(secretName.trim());
+                secretEnvSource.setName(trimmed);
                 EnvFromSource envFromSource = new EnvFromSource();
                 envFromSource.setSecretRef(secretEnvSource);
-                executorEnvVarFromSecret.add(envFromSource);
+                executorEnvFromSources.add(envFromSource);
             }
         }
 
@@ -67,7 +74,7 @@ public class EphemeralExecutorService {
                 configMapEnvSource.setName(trimmed);
                 EnvFromSource configMapEnvFrom = new EnvFromSource();
                 configMapEnvFrom.setConfigMapRef(configMapEnvSource);
-                executorEnvVarFromSecret.add(configMapEnvFrom);
+                executorEnvFromSources.add(configMapEnvFrom);
             }
         }
 
@@ -300,7 +307,7 @@ public class EphemeralExecutorService {
                 .withVolumes(volumes)
                 .addNewContainer()
                 .withName("executor")
-                .withEnvFrom(executorEnvVarFromSecret)
+                .withEnvFrom(executorEnvFromSources)
                 .withImage(ephemeralConfiguration.getImage())
                 .withEnv(executorEnvVarFlags)
                 .withVolumeMounts(volumeMounts)

--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -100,7 +100,13 @@ io.terrakube.executor.url=${AzBuilderExecutorUrl}
 ##########################
 io.terrakube.executor.ephemeral.namespace=${ExecutorEphemeralNamespace:terrakube}
 io.terrakube.executor.ephemeral.image=${ExecutorEphemeralImage:azbuilder/api-server:2.22.0}
+## Comma-separated list for multiple secrets: e.g. "secret-one,secret-two"
 io.terrakube.executor.ephemeral.secret=${ExecutorEphemeralSecret:terrakube-executor-secrets}
+
+## Optional per-job executor context variables (set via workspace/global vars, not properties):
+##   EPHEMERAL_CONFIG_ENVFROM_CONFIG_MAP  Comma-separated ConfigMap names mounted as envFrom.
+##   EPHEMERAL_CONFIG_POD_ANNOTATIONS     Semicolon-delimited key=value pairs added to the pod template metadata
+##                                        (enables Vault Agent Injector, GKE Workload Identity, etc.).
 
 ###########################################
 # EPHEMERAL EXECUTOR NODE SELECTOR CONFIG #

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -100,8 +100,14 @@ io.terrakube.executor.url=${AzBuilderExecutorUrl}
 ##########################
 io.terrakube.executor.ephemeral.namespace=${ExecutorEphemeralNamespace:terrakube}
 io.terrakube.executor.ephemeral.image=${ExecutorEphemeralImage:azbuilder/executor:2.22.0}
+## Comma-separated list for multiple secrets: e.g. "secret-one,secret-two"
 io.terrakube.executor.ephemeral.secret=${ExecutorEphemeralSecret:terrakube-executor-secrets}
 io.terrakube.executor.replicas=${ExecutorReplicas:1}
+
+## Optional per-job executor context variables (set via workspace/global vars, not properties):
+##   EPHEMERAL_CONFIG_ENVFROM_CONFIG_MAP  Comma-separated ConfigMap names mounted as envFrom.
+##   EPHEMERAL_CONFIG_POD_ANNOTATIONS     Semicolon-delimited key=value pairs added to the pod template metadata
+##                                        (enables Vault Agent Injector, GKE Workload Identity, etc.).
 
 ###########################################
 # EPHEMERAL EXECUTOR NODE SELECTOR CONFIG #

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorServiceTest.java
@@ -1,6 +1,7 @@
 package io.terrakube.api.plugin.scheduler.job.tcl.executor.ephemeral;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -135,18 +136,42 @@ public class EphemeralExecutorServiceTest {
     }
 
     @Test
+    public void mountsEmptySecretListCleanly() throws ExecutionException {
+        config.setSecret(List.of());
+
+        subject().send(job(), context());
+
+        verify(namespaced, times(1)).resource(job.capture());
+        Container container = job.getValue().getSpec().getTemplate().getSpec().getContainers().getFirst();
+        assertTrue(container.getEnvFrom().isEmpty());
+    }
+
+    @Test
     public void mountsConfigMapAsEnvFrom() throws ExecutionException {
         ExecutorContext context = context();
-        context.getEnvironmentVariables().put("EPHEMERAL_CONFIG_MAP_ENVFROM", "ze-configmap");
+        context.getEnvironmentVariables().put("EPHEMERAL_CONFIG_ENVFROM_CONFIG_MAP", "ze-configmap");
 
         subject().send(job(), context);
 
         verify(namespaced, times(1)).resource(job.capture());
         Container container = job.getValue().getSpec().getTemplate().getSpec().getContainers().getFirst();
-        // envFrom should have: 1 secret (ze-secret) + 1 configMap (ze-configmap)
         assertEquals(2, container.getEnvFrom().size());
         assertEquals("ze-secret", container.getEnvFrom().get(0).getSecretRef().getName());
         assertEquals("ze-configmap", container.getEnvFrom().get(1).getConfigMapRef().getName());
+    }
+
+    @Test
+    public void mountsMultipleConfigMapsAsEnvFrom() throws ExecutionException {
+        ExecutorContext context = context();
+        context.getEnvironmentVariables().put("EPHEMERAL_CONFIG_ENVFROM_CONFIG_MAP", "cm-one, cm-two");
+
+        subject().send(job(), context);
+
+        verify(namespaced, times(1)).resource(job.capture());
+        Container container = job.getValue().getSpec().getTemplate().getSpec().getContainers().getFirst();
+        assertEquals(3, container.getEnvFrom().size());
+        assertEquals("cm-one", container.getEnvFrom().get(1).getConfigMapRef().getName());
+        assertEquals("cm-two", container.getEnvFrom().get(2).getConfigMapRef().getName());
     }
 
     @Test
@@ -163,12 +188,11 @@ public class EphemeralExecutorServiceTest {
     }
 
     @Test
-    public void handlesNoPodAnnotations() throws ExecutionException {
+    public void omitsPodTemplateMetadataWhenNoAnnotations() throws ExecutionException {
         subject().send(job(), context());
 
         verify(namespaced, times(1)).resource(job.capture());
-        Map<String, String> podAnnotations = job.getValue().getSpec().getTemplate().getMetadata().getAnnotations();
-        assertTrue(podAnnotations.isEmpty());
+        assertNull(job.getValue().getSpec().getTemplate().getMetadata());
     }
 
     @Test

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorServiceTest.java
@@ -72,7 +72,7 @@ public class EphemeralExecutorServiceTest {
         config.setNodeSelector(selector);
         config.setNamespace("ze-namespace");
         config.setImage("ze-image:ze-label");
-        config.setSecret("ze-secret");
+        config.setSecret(List.of("ze-secret"));
     }
 
     private EphemeralExecutorService subject() {
@@ -119,6 +119,56 @@ public class EphemeralExecutorServiceTest {
         verify(namespaced, times(1)).resource(job.capture());
         Container container = job.getValue().getSpec().getTemplate().getSpec().getContainers().getFirst();
         assertEquals("ze-image:ze-label", container.getImage());
+    }
+
+    @Test
+    public void mountsMultipleSecretsAsEnvVars() throws ExecutionException {
+        config.setSecret(List.of("secret-one", "secret-two"));
+
+        subject().send(job(), context());
+
+        verify(namespaced, times(1)).resource(job.capture());
+        Container container = job.getValue().getSpec().getTemplate().getSpec().getContainers().getFirst();
+        assertEquals(2, container.getEnvFrom().size());
+        assertEquals("secret-one", container.getEnvFrom().get(0).getSecretRef().getName());
+        assertEquals("secret-two", container.getEnvFrom().get(1).getSecretRef().getName());
+    }
+
+    @Test
+    public void mountsConfigMapAsEnvFrom() throws ExecutionException {
+        ExecutorContext context = context();
+        context.getEnvironmentVariables().put("EPHEMERAL_CONFIG_MAP_ENVFROM", "ze-configmap");
+
+        subject().send(job(), context);
+
+        verify(namespaced, times(1)).resource(job.capture());
+        Container container = job.getValue().getSpec().getTemplate().getSpec().getContainers().getFirst();
+        // envFrom should have: 1 secret (ze-secret) + 1 configMap (ze-configmap)
+        assertEquals(2, container.getEnvFrom().size());
+        assertEquals("ze-secret", container.getEnvFrom().get(0).getSecretRef().getName());
+        assertEquals("ze-configmap", container.getEnvFrom().get(1).getConfigMapRef().getName());
+    }
+
+    @Test
+    public void setsPodTemplateAnnotations() throws ExecutionException {
+        ExecutorContext context = context();
+        context.getEnvironmentVariables().put("EPHEMERAL_CONFIG_POD_ANNOTATIONS", "vault.hashicorp.com/agent-inject=true;vault.hashicorp.com/role=terrakube");
+
+        subject().send(job(), context);
+
+        verify(namespaced, times(1)).resource(job.capture());
+        Map<String, String> podAnnotations = job.getValue().getSpec().getTemplate().getMetadata().getAnnotations();
+        assertEquals("true", podAnnotations.get("vault.hashicorp.com/agent-inject"));
+        assertEquals("terrakube", podAnnotations.get("vault.hashicorp.com/role"));
+    }
+
+    @Test
+    public void handlesNoPodAnnotations() throws ExecutionException {
+        subject().send(job(), context());
+
+        verify(namespaced, times(1)).resource(job.capture());
+        Map<String, String> podAnnotations = job.getValue().getSpec().getTemplate().getMetadata().getAnnotations();
+        assertTrue(podAnnotations.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
Ephemeral executor pods were limited to a single Kubernetes secret and had no way to inject ConfigMap env vars or set pod template annotations (blocking Vault Agent Injector, GKE Workload Identity, etc.).

## Related

Application-side companion to terrakube-io/terrakube-helm-chart#264, which injects the new env vars into the API deployment. Both PRs are required for full functionality.

## Changes

### `EphemeralConfiguration`
- `secret: String` → `secret: List<String>`: Spring Boot `@ConfigurationProperties` splits comma-separated values automatically; single-value configs remain backward compatible.

### `EphemeralExecutorService`
- **Multi-secret envFrom**: iterates `ephemeralConfiguration.getSecret()` to build one `EnvFromSource` per secret (null/blank-guarded).
- **ConfigMap envFrom** (`EPHEMERAL_CONFIG_ENVFROM_CONFIG_MAP`): comma-separated list of ConfigMap names; each appends a `ConfigMapEnvSource` to the same `envFrom` list — allows pods to receive `TerraformStateType`, GCP bucket config, etc. as env vars without file mounts.
- **Pod template annotations** (`EPHEMERAL_CONFIG_POD_ANNOTATIONS`): parses semicolon-delimited `key=value` pairs and injects them into the pod template `metadata`, enabling MutatingWebhookConfigurations to fire on ephemeral pods.

```yaml
# Example configuration
EPHEMERAL_EXECUTOR_SECRET: "secret-one,secret-two"
EPHEMERAL_CONFIG_ENVFROM_CONFIG_MAP: "terraform-state-config"
EPHEMERAL_CONFIG_POD_ANNOTATIONS: "vault.hashicorp.com/agent-inject=true;vault.hashicorp.com/role=terrakube"
```

### `EphemeralExecutorServiceTest`
- Updated `setup()` to pass `List.of("ze-secret")` to `setSecret`.
- Added tests: multiple secrets, ConfigMap envFrom, pod template annotations present/absent.

## Test plan
- [ ] `mvn -pl api test -Dtest=EphemeralExecutorServiceTest`
- [ ] Deploy to cluster with `EPHEMERAL_EXECUTOR_SECRET` as comma-separated list; confirm pod envFrom has entries per secret
- [ ] Set `EPHEMERAL_CONFIG_ENVFROM_CONFIG_MAP`; confirm ConfigMap envFrom appears on ephemeral pod
- [ ] Set `EPHEMERAL_CONFIG_POD_ANNOTATIONS`; confirm annotations present on pod template and Vault injector webhook fires