### PR TITLE
feat(executor): integrate TerrakubeClient in SetupWorkspaceImpl and PlanStructuredOutputService

### DIFF
--- a/api/src/main/java/io/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/io/terrakube/api/rs/job/Job.java
@@ -71,7 +71,8 @@ public class Job extends GenericAuditFields {
     @Column(name = "tcl")
     private String tcl;
 
-    @Exclude
+    @CreatePermission(expression = "user is a super service")
+    @UpdatePermission(expression = "user is a super service")
     @Column(name = "override_source")
     private String overrideSource;
 

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -19,7 +19,7 @@
 		<msal4j.version>1.24.1</msal4j.version>
 		<commons-text.version>1.15.0</commons-text.version>
 		<terraform-spring-boot-starter.version>1.4.0</terraform-spring-boot-starter.version>
-		<terrakube-client-starter.version>1.5.1</terrakube-client-starter.version>
+		<terrakube-client-starter.version>1.6.0</terrakube-client-starter.version>
 		<commons-io.version>2.22.0</commons-io.version>
 		<commons-codec>1.22.0</commons-codec>
 		<azure-storage-blob.version>12.33.2</azure-storage-blob.version>

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/PlanStructuredOutputService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/PlanStructuredOutputService.java
@@ -2,6 +2,7 @@ package io.terrakube.executor.service.terraform;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.terrakube.client.TerrakubeClient;
 import io.terrakube.terraform.TerraformClient;
 import io.terrakube.terraform.TerraformProcessData;
 import lombok.extern.slf4j.Slf4j;
@@ -42,16 +43,19 @@ public class PlanStructuredOutputService {
     private final ObjectMapper objectMapper;
     private final String terrakubeApiUrl;
     TerraformClient terraformClient;
+    TerrakubeClient terrakubeClient;
 
     public PlanStructuredOutputService(
             WorkspaceSecurity workspaceSecurity,
             ObjectMapper objectMapper,
             @Value("${io.terrakube.api.url}") String terrakubeApiUrl,
-            TerraformClient terraformClient) {
+            TerraformClient terraformClient,
+            TerrakubeClient terrakubeClient) {
         this.workspaceSecurity = workspaceSecurity;
         this.objectMapper = objectMapper;
         this.terrakubeApiUrl = terrakubeApiUrl;
         this.terraformClient = terraformClient;
+        this.terrakubeClient = terrakubeClient;
     }
 
     public void publishPlanSummary(TerraformJob terraformJob, File terraformWorkingDir) {
@@ -62,9 +66,9 @@ public class PlanStructuredOutputService {
             }
 
             List<Map<String, Object>> changes = buildChangesFromPlanJson(planJson);
-            Map<String, Object> context = getCurrentContext(terraformJob.getJobId());
+            Map<String, Object> context = getCurrentContext(terraformJob.getOrganizationId(), terraformJob.getJobId());
             Map<String, Object> updatedContext = updateContext(context, terraformJob.getStepId(), changes);
-            saveContext(terraformJob.getJobId(), updatedContext);
+            saveContext(terraformJob.getOrganizationId(), terraformJob.getJobId(), updatedContext);
         } catch (InterruptedException e) {
             log.error("Interrupted while publishing plan summary", e);
             Thread.currentThread().interrupt();
@@ -156,13 +160,19 @@ public class PlanStructuredOutputService {
         return updatedContext;
     }
 
-    private Map<String, Object> getCurrentContext(String jobId) {
+    private Map<String, Object> getCurrentContext(String organizationId, String jobId) {
         HttpURLConnection connection = null;
         try {
-            connection = buildConnection(terrakubeApiUrl + "/context/v1/" + jobId, "GET");
+            io.terrakube.client.model.organization.job.Job jobInfo = terrakubeClient.getJobById(organizationId, jobId).getData();
+            if (jobInfo.getAttributes().getStatus().equals("running")) {
+                log.info("Job {} exists, Terrakube should be able to get the context", jobId);
+            } else {
+                throw new IllegalStateException("Job is not running, cannot get context");
+            }
+            connection = buildConnection(terrakubeApiUrl + "/context/v1/" + jobInfo.getId(), "GET");
             int statusCode = connection.getResponseCode();
             if (statusCode >= 400) {
-                log.warn("Unable to read context for job {}. Response status: {}", jobId, statusCode);
+                log.warn("Unable to read context for job {}. Response status: {}", jobInfo.getId(), statusCode);
                 return new HashMap<>();
             }
 
@@ -183,10 +193,16 @@ public class PlanStructuredOutputService {
         }
     }
 
-    private void saveContext(String jobId, Map<String, Object> context) {
+    private void saveContext(String organizationId, String jobId, Map<String, Object> context) {
         HttpURLConnection connection = null;
         try {
-            connection = buildConnection(terrakubeApiUrl + "/context/v1/" + jobId, "POST");
+            io.terrakube.client.model.organization.job.Job jobInfo = terrakubeClient.getJobById(organizationId, jobId).getData();
+            if (jobInfo.getAttributes().getStatus().equals("running")) {
+                log.info("Job {} exists, Terrakube should be able to save the context", jobId);
+            } else {
+                throw new IllegalStateException("Job is not running, cannot get context");
+            }
+            connection = buildConnection(terrakubeApiUrl + "/context/v1/" + jobInfo.getId(), "POST");
             connection.setDoOutput(true);
             byte[] data = objectMapper.writeValueAsBytes(context);
             try (OutputStream os = connection.getOutputStream()) {
@@ -212,7 +228,7 @@ public class PlanStructuredOutputService {
         connection.setRequestMethod(method);
         connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
         connection.setReadTimeout(READ_TIMEOUT_MS);
-        connection.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(5));
+        connection.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(1));
         connection.setRequestProperty("Content-Type", "application/json");
         connection.setUseCaches(false);
         return connection;

--- a/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -1,9 +1,7 @@
 package io.terrakube.executor.service.workspace;
 
 import java.io.*;
-import java.net.InetSocketAddress;
-import java.net.URL;
-import java.net.URLConnection;
+import java.net.*;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -20,6 +18,7 @@ import com.azure.core.http.ProxyOptions;
 import com.azure.core.http.netty.NettyAsyncHttpClientBuilder;
 import com.azure.identity.DefaultAzureCredential;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import io.terrakube.client.TerrakubeClient;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
@@ -58,15 +57,17 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
     boolean enableRegistrySecurity;
     TerraformExecutor terraformExecutor;
     String apiUrl;
+    TerrakubeClient terrakubeClient;
 
     public SetupWorkspaceImpl(WorkspaceSecurity workspaceSecurity,
-            @Value("${io.terrakube.client.enableSecurity}") boolean enableRegistrySecurity,
-            TerraformExecutor terraformExecutor,
-            @Value("${io.terrakube.api.url}") String apiUrl) {
+                              @Value("${io.terrakube.client.enableSecurity}") boolean enableRegistrySecurity,
+                              TerraformExecutor terraformExecutor,
+                              @Value("${io.terrakube.api.url}") String apiUrl, TerrakubeClient terrakubeClient) {
         this.workspaceSecurity = workspaceSecurity;
         this.enableRegistrySecurity = enableRegistrySecurity;
         this.terraformExecutor = terraformExecutor;
         this.apiUrl = apiUrl;
+        this.terrakubeClient = terrakubeClient;
     }
 
     @Override
@@ -77,7 +78,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
             if (!terraformJob.getBranch().equals("remote-content")) {
                 downloadWorkspaceGit(workspaceCloneFolder, terraformJob);
             } else {
-                downloadWorkspaceTarGz(workspaceCloneFolder, terraformJob.getSource());
+                downloadWorkspaceTarGz(workspaceCloneFolder, terraformJob.getOrganizationId(), terraformJob.getJobId());
             }
             if (terraformJob.getModuleSshKey() != null && !terraformJob.getModuleSshKey().isEmpty()) {
                 generateSshFolder(workspaceCloneFolder, terraformJob.getModuleSshKey(), SSH_DIRECTORY_FILE_MODULE);
@@ -187,10 +188,11 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
                 gitCloneFolder.getPath());
     }
 
-    private void downloadWorkspaceTarGz(File tarGzFolder, String source) throws IOException {
+    private void downloadWorkspaceTarGz(File tarGzFolder, String organizationId, String jobId) throws IOException, URISyntaxException {
+        String source = terrakubeClient.getJobById(organizationId, jobId).getData().getAttributes().getOverrideSource();
+        log.info("Download workspace from source: {}", source);
         File terraformTarGz = new File(tarGzFolder.getPath() + "/terraformContent.tar.gz");
-        String resolvedSource = resolveRemoteContentSource(source);
-        URL url = new URL(resolvedSource);
+        URL url = new URI(source).toURL();
         URLConnection urlConnection = url.openConnection();
         urlConnection.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(1));
 
@@ -199,30 +201,6 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
         }
 
         extractTarGZ(new FileInputStream(terraformTarGz), tarGzFolder.getPath());
-    }
-
-    private String resolveRemoteContentSource(String source) {
-        if (source == null || source.isBlank()) {
-            return source;
-        }
-
-        try {
-            URL sourceUrl = new URL(source);
-            if (!sourceUrl.getProtocol().startsWith("http")) {
-                return source;
-            }
-
-            URL terrakubeApiUrl = new URL(apiUrl);
-            String resolvedSource = new URL(terrakubeApiUrl, sourceUrl.getFile()).toString();
-            if (!resolvedSource.equals(source)) {
-                log.info("Resolved remote content source from {} to {}", source, resolvedSource);
-            }
-            return resolvedSource;
-        } catch (IOException e) {
-            log.warn("Unable to resolve remote content source {}, using original value. {}",
-                    source, e.getMessage());
-            return source;
-        }
     }
 
     public void extractTarGZ(InputStream in, String destinationFilePath) throws IOException {

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/PlanStructuredOutputServiceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/PlanStructuredOutputServiceTest.java
@@ -1,6 +1,7 @@
 package io.terrakube.executor.service.terraform;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.terrakube.client.TerrakubeClient;
 import io.terrakube.executor.service.workspace.security.WorkspaceSecurity;
 import io.terrakube.terraform.TerraformClient;
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,8 @@ class PlanStructuredOutputServiceTest {
 
     private PlanStructuredOutputService subject() {
         WorkspaceSecurity workspaceSecurity = Mockito.mock(WorkspaceSecurity.class);
-        return new PlanStructuredOutputService(workspaceSecurity, new ObjectMapper(), "http://terrakube-api", new TerraformClient());
+        TerrakubeClient terrakubeClient = Mockito.mock(TerrakubeClient.class);
+        return new PlanStructuredOutputService(workspaceSecurity, new ObjectMapper(), "http://terrakube-api", new TerraformClient(), terrakubeClient);
     }
 
     @Test

--- a/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
@@ -9,6 +9,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
+import io.terrakube.client.TerrakubeClient;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.tools.tar.TarEntry;
@@ -17,6 +18,7 @@ import org.eclipse.jgit.api.errors.InvalidRemoteException;
 import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.mockito.Mockito;
 
 import io.terrakube.executor.service.mode.TerraformJob;
@@ -68,16 +70,23 @@ public class SetupWorkspaceTest {
         return job;
     }
 
-    private SetupWorkspace standardSetupWorkspaceImpl() {
+    private SetupWorkspace standardSetupWorkspaceImpl(TerraformJob job) {
         WorkspaceSecurity security = Mockito.mock(WorkspaceSecurity.class);
         TerraformExecutor executor = Mockito.mock(TerraformExecutor.class);
-        return new SetupWorkspaceImpl(security, false, executor, "https://terrakube-api.example.com");
+        TerrakubeClient client = Mockito.mock(TerrakubeClient.class, Answers.RETURNS_DEEP_STUBS);
+
+        if (job != null && "remote-content".equals(job.getBranch())) {
+            Mockito.when(client.getJobById(job.getOrganizationId(), job.getJobId()).getData().getAttributes().getOverrideSource())
+                    .thenReturn(job.getSource());
+        }
+
+        return new SetupWorkspaceImpl(security, false, executor, "https://terrakube-api.example.com", client);
     }
 
     @Test
     public void downloadsAndChecksOutGitRepository() throws Exception {
-        SetupWorkspace setup = standardSetupWorkspaceImpl();
         TerraformJob job = successfulGitJob();
+        SetupWorkspace setup = standardSetupWorkspaceImpl(job);
         File workspaceDir = setup.prepareWorkspace(job);
         File terrformDir = FileUtils.getFile(workspaceDir, job.getFolder(), "main.tf");
         Assert.assertTrue(terrformDir.exists());
@@ -85,8 +94,8 @@ public class SetupWorkspaceTest {
 
     @Test
     public void injectsCommitHashInfo() throws Exception {
-        SetupWorkspace setup = standardSetupWorkspaceImpl();
         TerraformJob job = successfulGitJob();
+        SetupWorkspace setup = standardSetupWorkspaceImpl(job);
         File workspaceDir = setup.prepareWorkspace(job);
         File terrformDir = FileUtils.getFile(workspaceDir, "commitHash.info");
         Assert.assertTrue(terrformDir.exists());
@@ -94,8 +103,8 @@ public class SetupWorkspaceTest {
 
     @Test
     public void failsWhenAskedToCheckoutABadCommit() throws Exception {
-        SetupWorkspace setup = standardSetupWorkspaceImpl();
         TerraformJob job = successfulGitJob();
+        SetupWorkspace setup = standardSetupWorkspaceImpl(job);
         job.setCommitId("nonsense");
         WorkspaceException e = Assert.assertThrows(WorkspaceException.class, () -> setup.prepareWorkspace(job));
         Assert.assertEquals(RefNotFoundException.class, e.getCause().getClass());
@@ -103,8 +112,8 @@ public class SetupWorkspaceTest {
 
     @Test
     public void reportsFailureOnBadRepository() {
-        SetupWorkspace setup = standardSetupWorkspaceImpl();
         TerraformJob job = successfulGitJob();
+        SetupWorkspace setup = standardSetupWorkspaceImpl(job);
         job.setSource("nonsense");
         WorkspaceException e = Assert.assertThrows(WorkspaceException.class, () -> setup.prepareWorkspace(job));
         Assert.assertEquals(InvalidRemoteException.class, e.getCause().getClass());
@@ -112,8 +121,8 @@ public class SetupWorkspaceTest {
 
     @Test
     public void downloadsAndUnpacksTarGz() throws Exception {
-        SetupWorkspace setup = standardSetupWorkspaceImpl();
         TerraformJob job = successfulTarGzJob();
+        SetupWorkspace setup = standardSetupWorkspaceImpl(job);
         File workspaceDir = setup.prepareWorkspace(job);
         File terrformDir = FileUtils.getFile(workspaceDir, "main.tf");
         Assert.assertTrue(terrformDir.exists());
@@ -121,17 +130,17 @@ public class SetupWorkspaceTest {
 
     @Test
     public void reportsFailureonBadTarGz() throws Exception {
-        SetupWorkspace setup = standardSetupWorkspaceImpl();
         TerraformJob job = successfulTarGzJob();
         job.setSource("file:/nonsense");
+        SetupWorkspace setup = standardSetupWorkspaceImpl(job);
         WorkspaceException e = Assert.assertThrows(WorkspaceException.class, () -> setup.prepareWorkspace(job));
         Assert.assertEquals(FileNotFoundException.class, e.getCause().getClass());
     }
 
     @Test
     public void injectsAwsCredentialsWhenAsked() throws Exception {
-        SetupWorkspace setup = standardSetupWorkspaceImpl();
         TerraformJob job = successfulTarGzJob();
+        SetupWorkspace setup = standardSetupWorkspaceImpl(job);
         job.getEnvironmentVariables().put("ENABLE_DYNAMIC_CREDENTIALS_AWS", "true");
         job.getEnvironmentVariables().put("TERRAKUBE_AWS_CREDENTIALS_FILE", "ze-secret");
         File workspaceDir = setup.prepareWorkspace(job);


### PR DESCRIPTION
- Added TerrakubeClient as a dependency to streamline context management and remote content handling.
- Updated related methods to use organization and job IDs for API interactions.
- Adjusted tests to account for new client dependency.
- Bumped TerrakubeClient version to 1.6.0 in `pom.xml`.
- Fix code to not construct the URL's path from user-controlled data to solve sonarcloud security issues.