### PR TITLE
feat(security): add JWT-based authentication and security configuration for executor

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorService.java
@@ -3,8 +3,13 @@ package io.terrakube.api.plugin.scheduler.job.tcl.executor.persistent;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
-import java.util.Optional;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
 
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -24,6 +29,8 @@ import io.terrakube.api.rs.job.Job;
 import lombok.extern.slf4j.Slf4j;
 import reactor.netty.http.client.HttpClient;
 
+import javax.crypto.SecretKey;
+
 @Slf4j
 @Service
 public class PersistentExecutorService {
@@ -37,14 +44,19 @@ public class PersistentExecutorService {
     @Autowired
     private WebClient.Builder webClientBuilder;
 
+    @Value("${io.terrakube.token.internal}")
+    private String base64KeyInternal;
+
     // Manual all-args constructor because Lombok will not copy @Value
     public PersistentExecutorService(
         @Value("${io.terrakube.executor.url}") String executorUrl,
         @Autowired GlobalVarRepository globalVarRepository,
-        @Autowired WebClient.Builder webClientBuilder) {
+        @Autowired WebClient.Builder webClientBuilder,
+        @Value("${io.terrakube.token.internal}") String internalJwtSecret) {
             this.executorUrl = executorUrl;
             this.globalVarRepository = globalVarRepository;
             this.webClientBuilder = webClientBuilder;
+            this.base64KeyInternal = internalJwtSecret;
     }
 
     private static final int CONNECT_TIMEOUT_MS = 10_000;
@@ -72,6 +84,7 @@ public class PersistentExecutorService {
             response = webClient.post()
                     .uri(executorUrlForRequest)
                     .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + generateSystemToken())
                     .bodyValue(executorContext)
                     .retrieve()
                     .toEntity(ExecutorContext.class)
@@ -119,5 +132,21 @@ public class PersistentExecutorService {
             log.info("No default executor found, using default executor url {}", this.executorUrl);
             return this.executorUrl;
         }
+    }
+
+    public String generateSystemToken() {
+        return Jwts.builder()
+                .issuer("TERRAKUBE_INTERNAL")
+                .subject(String.format("%s (Token)", "Terrakube Internal"))
+                .audience().add("TERRAKUBE_INTERNAL").and()
+                .id(UUID.randomUUID().toString())
+                .claim("email", "internal@terrakube.io")
+                .claim("email_verified", true)
+                .claim("name", "Terrakube Api")
+                .issuedAt(Date.from(Instant.now()))
+                .expiration(Date.from(
+                        Instant.now().plus(10, ChronoUnit.SECONDS)
+                        )
+                ).signWith(Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(this.base64KeyInternal))).compact();
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorServiceTest.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.Optional;
 
 import io.terrakube.api.helpers.FailUnkownMethod;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -78,7 +79,7 @@ public class PersistentExecutorServiceTest {
                 "http://default-executor/",
                 globalVarRepository,
                 webClientBuilder,
-                "ze-executor");
+                RandomStringUtils.randomAlphanumeric(32));
     }
 
     private Job jobOnDefaultExecutor() {

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -69,17 +70,20 @@ public class PersistentExecutorServiceTest {
         doReturn(requestBodyUriSpec).when(webClient).post();
         doReturn(requestBodySpec).when(requestBodyUriSpec).uri(anyString());
         doReturn(requestBodySpec).when(requestBodySpec).contentType(any(MediaType.class));
+        doReturn(requestBodySpec).when(requestBodySpec).header(anyString(), anyString());
         doReturn(requestHeadersSpec).when(requestBodySpec).bodyValue(any(ExecutorContext.class));
         doReturn(responseSpec).when(requestHeadersSpec).retrieve();
         doReturn(Mono.just(responseEntity)).when(responseSpec).toEntity(ExecutorContext.class);
     }
 
     private PersistentExecutorService subject() {
-        return new PersistentExecutorService(
+        PersistentExecutorService persistentExecutorService = spy(new PersistentExecutorService(
                 "http://default-executor/",
                 globalVarRepository,
                 webClientBuilder,
-                RandomStringUtils.randomAlphanumeric(32));
+                RandomStringUtils.randomAlphanumeric(32)));
+        doReturn(RandomStringUtils.randomAlphanumeric(64)).when(persistentExecutorService).generateSystemToken();
+        return persistentExecutorService;
     }
 
     private Job jobOnDefaultExecutor() {

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorServiceTest.java
@@ -12,6 +12,7 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Optional;
 
+import io.terrakube.api.helpers.FailUnkownMethod;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -24,7 +25,6 @@ import org.springframework.web.reactive.function.client.WebClient.RequestBodyUri
 import org.springframework.web.reactive.function.client.WebClient.RequestHeadersSpec;
 import org.springframework.web.reactive.function.client.WebClient.ResponseSpec;
 
-import io.terrakube.api.helpers.FailUnkownMethod;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutionException;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorContext;
 import io.terrakube.api.repository.GlobalVarRepository;
@@ -75,10 +75,10 @@ public class PersistentExecutorServiceTest {
 
     private PersistentExecutorService subject() {
         return new PersistentExecutorService(
-            "http://default-executor/",
-            globalVarRepository,
-            webClientBuilder
-        );
+                "http://default-executor/",
+                globalVarRepository,
+                webClientBuilder,
+                "ze-executor");
     }
 
     private Job jobOnDefaultExecutor() {

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -57,6 +57,14 @@
         </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-redis</artifactId>
 		</dependency>
 		<dependency>

--- a/executor/src/main/java/io/terrakube/executor/configuration/security/ExecutorManagerResolver.java
+++ b/executor/src/main/java/io/terrakube/executor/configuration/security/ExecutorManagerResolver.java
@@ -1,0 +1,46 @@
+package io.terrakube.executor.configuration.security;
+
+import io.jsonwebtoken.io.Decoders;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationManagerResolver;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.*;
+
+@Builder
+@Getter
+@Setter
+@Slf4j
+public class ExecutorManagerResolver implements AuthenticationManagerResolver<HttpServletRequest> {
+
+    private String internalJwtSecret;
+
+    @Override
+    public AuthenticationManager resolve(HttpServletRequest request) {
+        ProviderManager providerManager = null;
+        try {
+            log.info("Authenticating executor request");
+            providerManager = new ProviderManager(new JwtAuthenticationProvider(getJwtEncoder()));
+        } catch (Exception ex) {
+            log.error(ex.getMessage());
+        }
+        return providerManager;
+    }
+
+    private JwtDecoder getJwtEncoder() {
+        SecretKey jwtSecretKey = new SecretKeySpec(Decoders.BASE64URL.decode(internalJwtSecret), "HMACSHA256");
+        return NimbusJwtDecoder.withSecretKey(jwtSecretKey).macAlgorithm(MacAlgorithm.HS256).build();
+    }
+
+}

--- a/executor/src/main/java/io/terrakube/executor/configuration/security/SecurityAdapter.java
+++ b/executor/src/main/java/io/terrakube/executor/configuration/security/SecurityAdapter.java
@@ -1,0 +1,39 @@
+package io.terrakube.executor.configuration.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.AuthenticationManagerResolver;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Slf4j
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true, securedEnabled = true, jsr250Enabled = true)
+public class SecurityAdapter {
+
+    @Bean
+    @Order(1)
+    public SecurityFilterChain filterChain(HttpSecurity http, @Value("${io.terrakube.client.secretKey}") String internalJwtSecret) throws Exception {
+        http.cors(Customizer.withDefaults())
+                .authorizeHttpRequests(authz -> {
+                    authz.anyRequest().authenticated();
+                })
+                .oauth2ResourceServer(oauth2 -> {
+                    AuthenticationManagerResolver<HttpServletRequest> authenticationManagerResolver = ExecutorManagerResolver
+                            .builder()
+                            .internalJwtSecret(internalJwtSecret)
+                            .build();
+                    oauth2.authenticationManagerResolver(authenticationManagerResolver);
+                });
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
- Introduced `ExecutorManagerResolver` to handle JWT authentication.
- Added `SecurityAdapter` for configuring security filters and authentication manager.
- Updated `PersistentExecutorService` to include token generation for internal service communication.
- Added necessary Spring Security dependencies in `pom.xml`.