### PR TITLE
feat(ui): add project management pages

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeService.java
@@ -1696,7 +1696,7 @@ public class RemoteTfeService {
             organization.getProject().forEach(project -> {
                 ProjectModel projectData = new ProjectModel();
                 projectData.setId(project.getId().toString());
-                projectData.setType("project");
+                projectData.setType("projects");
                 projectData.setAttributes(new HashMap<>());
                 projectData.getAttributes().put("name", project.getName());
                 projectData.setRelationships(new io.terrakube.api.plugin.state.model.project.Relationships());

--- a/ui/src/domain/Home/App.tsx
+++ b/ui/src/domain/Home/App.tsx
@@ -35,6 +35,8 @@ const CreateOrganization = lazy(() =>
 );
 const OrganizationsPickerPage = lazy(() => import("@/modules/organizations/OrganizationsPickerPage"));
 const OrganizationsDetailPage = lazy(() => import("@/modules/organizations/OrganizationDetailsPage"));
+const ProjectsPage = lazy(() => import("@/modules/projects/ProjectsPage"));
+const ProjectDetailPage = lazy(() => import("@/modules/projects/ProjectDetailPage"));
 
 // Workspaces
 const CreateWorkspace = lazy(() =>
@@ -82,6 +84,16 @@ const CreateOrganizationRoute = () => {
 const OrganizationsDetailRoute = () => {
   const { organizationName, setOrganizationName } = useAppRouteContext();
   return <OrganizationsDetailPage setOrganizationName={setOrganizationName} organizationName={organizationName} />;
+};
+
+const OrganizationsProjectsRoute = () => {
+  const { organizationName, setOrganizationName } = useAppRouteContext();
+  return <ProjectsPage setOrganizationName={setOrganizationName} organizationName={organizationName} />;
+};
+
+const OrganizationsProjectDetailRoute = () => {
+  const { organizationName, setOrganizationName } = useAppRouteContext();
+  return <ProjectDetailPage setOrganizationName={setOrganizationName} organizationName={organizationName} />;
 };
 
 const WorkspaceDetailsRoute = ({ selectedTab }: { selectedTab?: string }) => {
@@ -243,6 +255,14 @@ const App = () => {
         {
           path: "/organizations/:id/workspaces",
           element: <OrganizationsDetailRoute />,
+        },
+        {
+          path: "/organizations/:id/projects",
+          element: <OrganizationsProjectsRoute />,
+        },
+        {
+          path: "/organizations/:orgid/projects/:id",
+          element: <OrganizationsProjectDetailRoute />,
         },
         {
           path: "/workspaces/create",

--- a/ui/src/domain/Home/MainMenu.tsx
+++ b/ui/src/domain/Home/MainMenu.tsx
@@ -1,4 +1,4 @@
-import { AppstoreOutlined, CloudOutlined, SettingOutlined } from "@ant-design/icons";
+import { AppstoreOutlined, CloudOutlined, ProjectOutlined, SettingOutlined } from "@ant-design/icons";
 import { Menu } from "antd";
 import "antd/dist/reset.css";
 import { useEffect, useState } from "react";
@@ -103,6 +103,8 @@ export const MainMenu = ({ organizationName, setOrganizationName, themeMode }: P
       setDefaultSelected(["registry"]);
     } else if (location.pathname.includes("settings")) {
       setDefaultSelected(["settings"]);
+    } else if (location.pathname.includes("projects")) {
+      setDefaultSelected(["projects"]);
     } else {
       setDefaultSelected(["workspaces"]);
     }
@@ -131,6 +133,12 @@ export const MainMenu = ({ organizationName, setOrganizationName, themeMode }: P
   const items = [
     ...(orgIdFromUrl
       ? [
+          {
+            label: "Projects",
+            key: "projects",
+            icon: <ProjectOutlined />,
+            onClick: () => handleSectionNavigation("projects"),
+          },
           {
             label: "Workspaces",
             key: "workspaces",

--- a/ui/src/domain/Workspaces/Create.tsx
+++ b/ui/src/domain/Workspaces/Create.tsx
@@ -24,8 +24,10 @@ import { Link, useNavigate } from "react-router-dom";
 import { v7 as uuid } from "uuid";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "../../config/actionTypes";
 import axiosInstance from "../../config/axiosConfig";
-import { SshKey, Template, TofuRelease, VcsModel, VcsType, VcsTypeExtended } from "../types";
+import { ProjectModel, SshKey, Template, TofuRelease, VcsModel, VcsType, VcsTypeExtended } from "../types";
 import { compareVersions } from "./Workspaces";
+import projectService from "@/modules/projects/projectService";
+import workspaceService from "@/modules/workspaces/workspaceService";
 const { Content } = Layout;
 const { Step } = Steps;
 
@@ -54,6 +56,7 @@ type CreateWorkspaceForm = {
   iacType: string;
   defaultTemplate: string;
   sshKey?: string;
+  project?: string;
 };
 
 export const CreateWorkspace = () => {
@@ -81,6 +84,7 @@ export const CreateWorkspace = () => {
     id: "terraform",
     name: "Terraform",
   });
+  const [projectList, setProjectList] = useState<ProjectModel[]>([]);
   const gitlabItems = [
     {
       label: "Gitlab.com",
@@ -149,13 +153,14 @@ export const CreateWorkspace = () => {
 
     const versionsApi = `${new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin}/${iacType.id}/index.json`;
 
-    // Parallel load: versions, SSH keys, templates, and VCS
+    // Parallel load: versions, SSH keys, templates, VCS, and projects
     Promise.all([
       axiosInstance.get(versionsApi),
       axiosInstance.get(`organization/${organizationId}/ssh`),
       axiosInstance.get(`organization/${organizationId}/template`),
       axiosInstance.get(`organization/${organizationId}/vcs`),
-    ]).then(([versionsRes, sshRes, templatesRes, vcsRes]) => {
+      projectService.listProjects(organizationId!),
+    ]).then(([versionsRes, sshRes, templatesRes, vcsRes, projectsRes]) => {
       // Process versions
       const tfVersions: string[] = [];
       if (iacType.id === "tofu") {
@@ -184,6 +189,10 @@ export const CreateWorkspace = () => {
 
       // Set VCS
       setVCS(vcsRes.data.data);
+
+      // Set projects
+      if (!projectsRes.isError) setProjectList(projectsRes.data);
+
       setLoading(false);
     });
   }, []);
@@ -304,7 +313,7 @@ export const CreateWorkspace = () => {
     });
   };
 
-  const onFinish = (values: CreateWorkspaceForm) => {
+  const onFinish = async (values: CreateWorkspaceForm) => {
     const workspace_lid = uuid();
     const body = {
       "atomic:operations": [
@@ -348,42 +357,44 @@ export const CreateWorkspace = () => {
       };
     }
 
-    axiosInstance
-      .post(`/operations`, body, {
+    try {
+      const response = await axiosInstance.post(`/operations`, body, {
         headers: {
           "Content-Type": 'application/vnd.api+json;ext="https://jsonapi.org/ext/atomic"',
           Accept: 'application/vnd.api+json;ext="https://jsonapi.org/ext/atomic"',
         },
-      })
-      .then((response) => {
-        if (response.status === 200) {
-          navigate(`/organizations/${organizationId}/workspaces/${response.data["atomic:results"][0].data.id}`);
-        }
-      })
-      .catch((error) => {
-        if (error.response) {
-          if (error.response.status === 403) {
-            message.error(
-              <span>
-                You are not authorized to create workspaces. <br /> Please contact your administrator and request the{" "}
-                <b>Manage Workspaces</b> permission. <br /> For more information, visit the{" "}
-                <a
-                  target="_blank"
-                  href="https://docs.terrakube.io/user-guide/organizations/team-management"
-                  rel="noreferrer"
-                >
-                  Terrakube documentation
-                </a>
-                .
-              </span>
-            );
-          } else {
-            message.error(
-              <span>An error occurred while submitting the workspace. Please contact your system administrator.</span>
-            );
-          }
-        }
       });
+      if (response.status === 200) {
+        const workspaceId = response.data["atomic:results"][0].data.id;
+        if (values.project && values.project !== "none") {
+          await workspaceService.assignWorkspaceToProject(organizationId!, workspaceId, values.project);
+        }
+        navigate(`/organizations/${organizationId}/workspaces/${workspaceId}`);
+      }
+    } catch (error: any) {
+      if (error.response) {
+        if (error.response.status === 403) {
+          message.error(
+            <span>
+              You are not authorized to create workspaces. <br /> Please contact your administrator and request the{" "}
+              <b>Manage Workspaces</b> permission. <br /> For more information, visit the{" "}
+              <a
+                target="_blank"
+                href="https://docs.terrakube.io/user-guide/organizations/team-management"
+                rel="noreferrer"
+              >
+                Terrakube documentation
+              </a>
+              .
+            </span>
+          );
+        } else {
+          message.error(
+            <span>An error occurred while submitting the workspace. Please contact your system administrator.</span>
+          );
+        }
+      }
+    }
   };
 
   const handleChange = (currentVal: number) => {
@@ -720,6 +731,18 @@ export const CreateWorkspace = () => {
                   {sshKeys.map(function (sshKey) {
                     return <Option key={sshKey?.id}>{sshKey?.attributes?.name}</Option>;
                   })}
+                </Select>
+              </Form.Item>
+              <Form.Item
+                name="project"
+                label="Project"
+                extra="Optional. Assigning a project lets you group and filter workspaces."
+              >
+                <Select placeholder="(No project)" style={{ width: 250 }}>
+                  <Option key="none">(No project)</Option>
+                  {projectList.map((p) => (
+                    <Option key={p.id}>{p.name}</Option>
+                  ))}
                 </Select>
               </Form.Item>
               <Form.Item>

--- a/ui/src/domain/Workspaces/Details.tsx
+++ b/ui/src/domain/Workspaces/Details.tsx
@@ -138,6 +138,8 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
   const [currentStateId, setCurrentStateId] = useState("");
   const [actions, setActions] = useState<Action[]>([]);
   const [contextState, setContextState] = useState({});
+  const [projectName, setProjectName] = useState<string | null>(null);
+  const [projectId, setProjectId] = useState<string | null>(null);
   const {
     token: { colorBgContainer },
   } = theme.useToken();
@@ -371,7 +373,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
         setTemplates(template.data.data);
         axiosInstance
           .get(
-            `organization/${organizationId}/workspace/${id}?include=job,variable,history,schedule,vcs,agent,organization,webhook,reference`
+            `organization/${organizationId}/workspace/${id}?include=job,variable,history,schedule,vcs,agent,organization,webhook,reference,project`
           )
           .then(async (response) => {
             if (_loadPermissionSet) loadPermissionSet();
@@ -411,6 +413,15 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
               const organizationName = organization.attributes.name;
               setOrganizationName(organizationName);
               sessionStorage.setItem(ORGANIZATION_NAME, organizationName);
+            }
+
+            const proj = response.data.included?.find((item: any) => item.type === "project");
+            if (proj) {
+              setProjectName(proj.attributes?.name ?? null);
+              setProjectId(proj.id ?? null);
+            } else {
+              setProjectName(null);
+              setProjectId(null);
             }
             setOrganizationNameLocal(sessionStorage.getItem(ORGANIZATION_NAME)!);
             setWorkspaceName(response.data.data.attributes.name);
@@ -767,6 +778,15 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
                         <span>
                           <ThunderboltOutlined /> Execution Mode: {executionMode}{" "}
                         </span>
+                        <Divider />
+                        <h4>Project</h4>
+                        {projectName && projectId ? (
+                          <Link to={`/organizations/${organizationId}/projects/${projectId}`}>
+                            {projectName}
+                          </Link>
+                        ) : (
+                          <Typography.Text type="secondary">No project</Typography.Text>
+                        )}
                         <Divider />
                         <h4>Tags</h4>
                         <Tags organizationId={organizationId} workspaceId={id!} manageWorkspace={manageWorkspace} />

--- a/ui/src/domain/Workspaces/Settings/General.tsx
+++ b/ui/src/domain/Workspaces/Settings/General.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from "react";
 import axiosInstance from "../../../config/axiosConfig";
 import { Agent, Template, TofuRelease, Workspace } from "../../types";
 import { atomicHeader, compareVersions, genericHeader, getIaCIconById, getIaCNameById, iacTypes } from "../Workspaces";
+import projectService from "@/modules/projects/projectService";
+import { ProjectModel } from "@/domain/types";
 
 const { Text } = Typography;
 
@@ -22,6 +24,7 @@ type UpdateWorkspaceForm = {
   branch: string;
   defaultTemplate?: string;
   executorAgent?: string;
+  project?: string;
 };
 
 export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace }: Props) => {
@@ -31,6 +34,7 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace 
   const [selectedIac, setSelectedIac] = useState("");
   const [terraformVersions, setTerraformVersions] = useState<string[]>([]);
   const [agentList, setAgentList] = useState<Agent[]>([]);
+  const [projectList, setProjectList] = useState<ProjectModel[]>([]);
   const [waiting, setWaiting] = useState(false);
 
   const loadVersions = (iacType: string) => {
@@ -55,24 +59,27 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace 
     const iacType = workspaceData.attributes?.iacType;
     const versionsApi = `${new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin}/${iacType}/index.json`;
 
-    // Parallel load: versions and agent list
-    Promise.all([axiosInstance.get(versionsApi), axiosInstance.get(`organization/${organizationId}/agent`)]).then(
-      ([versionsRes, agentsRes]) => {
-        const tfVersions: string[] = [];
-        if (iacType === "tofu") {
-          versionsRes.data.forEach((release: TofuRelease) => {
-            if (!release.tag_name.includes("-")) tfVersions.push(release.tag_name.replace("v", ""));
-          });
-        } else {
-          for (const version in versionsRes.data.versions) {
-            if (!version.includes("-")) tfVersions.push(version);
-          }
+    // Parallel load: versions, agent list, and projects
+    Promise.all([
+      axiosInstance.get(versionsApi),
+      axiosInstance.get(`organization/${organizationId}/agent`),
+      projectService.listProjects(organizationId),
+    ]).then(([versionsRes, agentsRes, projectsRes]) => {
+      const tfVersions: string[] = [];
+      if (iacType === "tofu") {
+        versionsRes.data.forEach((release: TofuRelease) => {
+          if (!release.tag_name.includes("-")) tfVersions.push(release.tag_name.replace("v", ""));
+        });
+      } else {
+        for (const version in versionsRes.data.versions) {
+          if (!version.includes("-")) tfVersions.push(version);
         }
-        setTerraformVersions(tfVersions.sort(compareVersions).reverse());
-        setAgentList(agentsRes.data.data);
-        setWaiting(false);
       }
-    );
+      setTerraformVersions(tfVersions.sort(compareVersions).reverse());
+      setAgentList(agentsRes.data.data);
+      if (!projectsRes.isError) setProjectList(projectsRes.data);
+      setWaiting(false);
+    });
   }, [organizationId, workspaceData.attributes?.iacType]);
 
   const handleIacChange = (iac: string) => {
@@ -143,6 +150,21 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace 
           console.log("Workspace agent update failed");
         }
       });
+
+    const bodyProject =
+      values.project && values.project !== "none"
+        ? { data: { type: "project", id: values.project } }
+        : { data: null };
+
+    axiosInstance
+      .patch(`/organization/${organizationId}/workspace/${id}/relationships/project`, bodyProject, genericHeader)
+      .then((response) => {
+        if (response.status === 204) {
+          console.log("Workspace project updated successfully");
+        } else {
+          console.log("Workspace project update failed");
+        }
+      });
   };
 
   return (
@@ -168,6 +190,7 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace 
               workspaceData.relationships.agent?.data?.id == null
                 ? "default"
                 : workspaceData.relationships.agent.data?.id,
+            project: workspaceData.relationships.project?.data?.id ?? "none",
           }}
           layout="vertical"
           name="form-settings"
@@ -313,6 +336,26 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace 
               {orgTemplates.map(function (template) {
                 return <Option key={template?.id}>{template?.attributes?.name}</Option>;
               })}
+            </Select>
+          </Form.Item>
+
+          <Divider />
+
+          {/* Section 5: Project */}
+          <h2>Project</h2>
+          <Text type="secondary">Assign this workspace to a project for easier organization and filtering.</Text>
+
+          <Form.Item
+            name="project"
+            label="Project"
+            extra="Optional. Assigning a project lets you group and filter workspaces."
+            style={{ marginTop: 16 }}
+          >
+            <Select placeholder="No project" disabled={!manageWorkspace}>
+              <Option key="none">(No project)</Option>
+              {projectList.map((p) => (
+                <Option key={p.id}>{p.name}</Option>
+              ))}
             </Select>
           </Form.Item>
 

--- a/ui/src/domain/types.ts
+++ b/ui/src/domain/types.ts
@@ -344,6 +344,24 @@ export type FlatSchedule = {
   id: string;
 } & ScheduleAttributes;
 
+// Projects
+export type Project = {
+  id: string;
+  attributes: ProjectAttributes;
+  relationships: { organization: RelationshipItem };
+};
+
+export type ProjectAttributes = {
+  name: string;
+  description?: string;
+} & AuditFieldBase;
+
+export type ProjectModel = {
+  id: string;
+  name: string;
+  description?: string;
+};
+
 // Workspaces
 export type Workspace = {
   id: string;
@@ -352,6 +370,7 @@ export type Workspace = {
     organization: RelationshipItem;
     webhook?: RelationshipItem;
     agent?: RelationshipItem;
+    project?: RelationshipItem;
     history?: RelationshipArray;
   };
 };

--- a/ui/src/modules/layout/PageWrapper/PageWrapper.tsx
+++ b/ui/src/modules/layout/PageWrapper/PageWrapper.tsx
@@ -46,7 +46,7 @@ export default function PageWrapper({
           className="page-wrapper-crumbs"
           items={breadcrumbs.map((bc) => ({
             key: bc.path,
-            label: <NavLink to={bc.path}>{bc.label}</NavLink>,
+            title: <NavLink to={bc.path}>{bc.label}</NavLink>,
           }))}
         />
       )}

--- a/ui/src/modules/organizations/OrganizationDetailsPage.tsx
+++ b/ui/src/modules/organizations/OrganizationDetailsPage.tsx
@@ -36,6 +36,13 @@ export default function OrganizationsDetailPage({ organizationName, setOrganizat
     [filteredWorkspaces, sortOption]
   );
 
+  const projects = useMemo(() => {
+    const seen = new Set<string>();
+    return workspaces
+      .filter((ws) => ws.projectId && !seen.has(ws.projectId) && seen.add(ws.projectId!))
+      .map((ws) => ({ id: ws.projectId!, name: ws.projectName! }));
+  }, [workspaces]);
+
   const handleSortChange = (option: WorkspaceSortOption) => {
     setSortOption(option);
     setStoredWorkspaceSortOption(option);
@@ -92,6 +99,7 @@ export default function OrganizationsDetailPage({ organizationName, setOrganizat
             onTagsLoaded={(t) => setTags(t)}
             sortOption={sortOption}
             onSortChange={handleSortChange}
+            projects={projects}
           />
         )}
         <List

--- a/ui/src/modules/permissions/useOrgPermissions.ts
+++ b/ui/src/modules/permissions/useOrgPermissions.ts
@@ -73,8 +73,7 @@ export function useOrgPermissions() {
           managePermission: response.data.managePermission ?? false,
         });
       })
-      .catch((err) => {
-        console.error("Failed to load org permissions:", err);
+      .catch(() => {
         // Keep default (all false) on error — user sees read-only UI
       })
       .finally(() => {

--- a/ui/src/modules/projects/ProjectDetailPage.tsx
+++ b/ui/src/modules/projects/ProjectDetailPage.tsx
@@ -1,0 +1,294 @@
+import { DeleteOutlined } from "@ant-design/icons";
+import { Button, Form, Input, Layout, Menu, Popconfirm, Space, Spin, Typography, message, theme } from "antd";
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import PageWrapper from "@/modules/layout/PageWrapper/PageWrapper";
+import projectService from "./projectService";
+import ProjectWorkspaces from "./ProjectWorkspaces";
+import workspaceService from "@/modules/workspaces/workspaceService";
+import useApiRequest from "@/modules/api/useApiRequest";
+import { ProjectModel } from "@/domain/types";
+import { ORGANIZATION_NAME } from "../../config/actionTypes";
+import type { MenuProps } from "antd";
+
+const { Content, Sider } = Layout;
+type MenuItem = Required<MenuProps>["items"][number];
+
+type Props = {
+  organizationName: string;
+  setOrganizationName: React.Dispatch<React.SetStateAction<string>>;
+};
+
+type ProjectForm = {
+  name: string;
+  description?: string;
+};
+
+type GeneralProps = {
+  orgid: string;
+  projectId: string;
+  project: ProjectModel | null;
+  assignedWorkspacesCount: number;
+};
+
+function ProjectGeneralSettings({ orgid, projectId, project, assignedWorkspacesCount }: GeneralProps) {
+  const [waiting, setWaiting] = useState(false);
+  const [form] = Form.useForm<ProjectForm>();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (project) {
+      form.setFieldsValue({ name: project.name, description: project.description });
+    }
+  }, [project, form]);
+
+  const onFinish = async (values: ProjectForm) => {
+    setWaiting(true);
+    try {
+      await projectService.updateProject(orgid, projectId, values);
+      message.success("Project updated successfully");
+    } catch (err: any) {
+      if (err?.response?.status === 403) {
+        message.error(
+          <span>
+            You are not authorized to update projects. <br /> Please contact your administrator and request the{" "}
+            <b>Manage Workspaces</b> permission. <br /> For more information, visit the{" "}
+            <a
+              target="_blank"
+              href="https://docs.terrakube.io/user-guide/organizations/team-management"
+              rel="noreferrer"
+            >
+              Terrakube documentation
+            </a>
+            .
+          </span>
+        );
+      } else {
+        message.error(err?.message ?? "Project update failed");
+      }
+    } finally {
+      setWaiting(false);
+    }
+  };
+
+  const onDelete = async () => {
+    try {
+      await projectService.deleteProject(orgid, projectId);
+      message.success("Project deleted successfully");
+      navigate(`/organizations/${orgid}/projects`);
+    } catch (err: any) {
+      const statusCode = err?.response?.status;
+      if (statusCode === 403) {
+        message.error(
+          <span>
+            You are not authorized to delete projects. <br /> Please contact your administrator and request the{" "}
+            <b>Manage Workspaces</b> permission. <br /> For more information, visit the{" "}
+            <a
+              target="_blank"
+              href="https://docs.terrakube.io/user-guide/organizations/team-management"
+              rel="noreferrer"
+            >
+              Terrakube documentation
+            </a>
+            .
+          </span>
+        );
+      } else if (statusCode === 423) {
+        message.error(
+          "Cannot delete project: Workspaces are still associated with this project. Please remove all workspaces first and try again."
+        );
+      } else {
+        message.error(err?.message ?? "Project deletion failed");
+      }
+    }
+  };
+
+  return (
+    <div style={{ width: "100%" }}>
+      <h1>General Settings</h1>
+      <p>Adjust the name and description for this project.</p>
+      <Spin spinning={waiting}>
+        <Form form={form} layout="vertical" name="project-general-settings" onFinish={onFinish} requiredMark={false}>
+          <Form.Item name="name" label="Name" rules={[{ required: true, message: "Name is required" }]}>
+            <Input />
+          </Form.Item>
+          <Form.Item name="description" label="Description" extra="Optional">
+            <Input.TextArea rows={5} placeholder="Project description" />
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" htmlType="submit">
+              Save settings
+            </Button>
+          </Form.Item>
+        </Form>
+      </Spin>
+
+      <div style={{ marginTop: "40px" }}>
+        <Typography.Text type="secondary">
+          Deleting this project permanently removes all of its settings and history from Terrakube.
+        </Typography.Text>
+        <h3 style={{ marginBottom: "16px", marginTop: "24px" }}>Delete this Project</h3>
+        <div style={{ marginBottom: "16px" }}>
+          <Typography.Text type="secondary">
+            <Typography.Text strong>Warning!</Typography.Text> This action cannot be undone.
+          </Typography.Text>
+          {assignedWorkspacesCount > 0 && (
+            <div style={{ marginTop: "8px" }}>
+              <Typography.Text type="warning">
+                This project has {assignedWorkspacesCount} workspace{assignedWorkspacesCount > 1 ? "s" : ""} assigned.
+                Please remove all workspaces before deleting this project.
+              </Typography.Text>
+            </div>
+          )}
+        </div>
+        <Popconfirm
+          title={
+            <p>
+              Project will be permanently deleted
+              <br />
+              from this organization.
+              <br />
+              Are you sure?
+            </p>
+          }
+          onConfirm={onDelete}
+          okText="Yes"
+          cancelText="No"
+          placement="bottom"
+          disabled={assignedWorkspacesCount > 0}
+        >
+          <Button
+            type="primary"
+            danger
+            style={{ width: "fit-content", padding: "8px 24px", height: "auto" }}
+            disabled={assignedWorkspacesCount > 0}
+          >
+            <Space>
+              <DeleteOutlined />
+              Delete Project
+            </Space>
+          </Button>
+        </Popconfirm>
+      </div>
+    </div>
+  );
+}
+
+export default function ProjectDetailPage({ organizationName, setOrganizationName }: Props) {
+  const { orgid, id } = useParams();
+  const [project, setProject] = useState<ProjectModel | null>(null);
+  const [activeKey, setActiveKey] = useState("general");
+  const [assignedWorkspacesCount, setAssignedWorkspacesCount] = useState(0);
+  const { token } = theme.useToken();
+
+  const { loading, execute, error } = useApiRequest({
+    action: () => projectService.getProject(orgid!, id!),
+    onReturn: (data) => {
+      setProject(data);
+      const stored = sessionStorage.getItem(ORGANIZATION_NAME);
+      if (stored) setOrganizationName(stored);
+    },
+  });
+
+  useEffect(() => {
+    execute();
+  }, [id]);
+
+  useEffect(() => {
+    async function loadWorkspaces() {
+      try {
+        const result = await workspaceService.listWorkspaces(orgid!);
+        if (!result.isError) {
+          const assignedCount = result.data.workspaces.filter((ws) => ws.projectId === id).length;
+          setAssignedWorkspacesCount(assignedCount);
+        }
+      } catch {
+        // Silently fail if workspaces cannot be loaded
+      }
+    }
+
+    if (orgid && id) {
+      loadWorkspaces();
+    }
+  }, [orgid, id]);
+
+  // Reload workspace count when switching tabs
+  const handleTabChange = (key: string) => {
+    setActiveKey(key);
+    if (key === "general" && orgid && id) {
+      // Reload workspace count when returning to general tab
+      workspaceService.listWorkspaces(orgid).then((result) => {
+        if (!result.isError) {
+          const assignedCount = result.data.workspaces.filter((ws) => ws.projectId === id).length;
+          setAssignedWorkspacesCount(assignedCount);
+        }
+      });
+    }
+  };
+
+  const menuItems: MenuItem[] = [
+    {
+      type: "group",
+      label: "Project Settings",
+      key: "project-settings",
+      children: [
+        { key: "general", label: "General" },
+        { key: "workspaces", label: "Workspaces" },
+      ],
+    },
+  ];
+
+  const renderContent = () => {
+    switch (activeKey) {
+      case "workspaces":
+        return <ProjectWorkspaces orgid={orgid!} projectId={id!} />;
+      case "general":
+      default:
+        return (
+          <ProjectGeneralSettings
+            orgid={orgid!}
+            projectId={id!}
+            project={project}
+            assignedWorkspacesCount={assignedWorkspacesCount}
+          />
+        );
+    }
+  };
+
+  return (
+    <PageWrapper
+      title={project?.name ?? "Project"}
+      subTitle={`Project in the ${organizationName} organization`}
+      loadingText="Loading project..."
+      loading={loading}
+      error={error}
+      breadcrumbs={[
+        { label: organizationName, path: "/" },
+        { label: "Projects", path: `/organizations/${orgid}/projects` },
+        { label: project?.name ?? "Project", path: `/organizations/${orgid}/projects/${id}` },
+      ]}
+      fluid
+    >
+      <Layout style={{ background: token.colorBgContainer }}>
+        <Sider
+          width={200}
+          style={{
+            background: token.colorBgContainer,
+            borderRight: `1px solid ${token.colorBorderSecondary}`,
+            height: "100%",
+            overflow: "auto",
+          }}
+        >
+          <Menu
+            mode="inline"
+            selectedKeys={[activeKey]}
+            style={{ height: "100%" }}
+            items={menuItems}
+            onClick={(e) => handleTabChange(e.key)}
+          />
+        </Sider>
+        <Content style={{ padding: "0 24px", minHeight: 280, maxWidth: 900 }}>{renderContent()}</Content>
+      </Layout>
+    </PageWrapper>
+  );
+}

--- a/ui/src/modules/projects/ProjectWorkspaces.tsx
+++ b/ui/src/modules/projects/ProjectWorkspaces.tsx
@@ -1,0 +1,182 @@
+import { PlusOutlined } from "@ant-design/icons";
+import { Button, Modal, Popconfirm, Select, Table, Typography, message } from "antd";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import WorkspaceStatusTag from "@/modules/workspaces/components/WorkspaceStatusTag";
+import { WorkspaceListItem } from "@/modules/workspaces/types";
+import workspaceService from "@/modules/workspaces/workspaceService";
+
+type Props = {
+  orgid: string;
+  projectId: string;
+};
+
+export default function ProjectWorkspaces({ orgid, projectId }: Props) {
+  const [allWorkspaces, setAllWorkspaces] = useState<WorkspaceListItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | undefined>();
+  const [assigning, setAssigning] = useState(false);
+
+  const assignedWorkspaces = allWorkspaces.filter((ws) => ws.projectId === projectId);
+  const unassignedWorkspaces = allWorkspaces.filter((ws) => !ws.projectId);
+
+  async function loadWorkspaces() {
+    setLoading(true);
+    try {
+      const result = await workspaceService.listWorkspaces(orgid);
+      if (!result.isError) {
+        setAllWorkspaces(result.data.workspaces);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadWorkspaces();
+  }, [orgid, projectId]);
+
+  const handleAssign = async () => {
+    if (!selectedWorkspaceId) return;
+    setAssigning(true);
+    try {
+      await workspaceService.assignWorkspaceToProject(orgid, selectedWorkspaceId, projectId);
+      message.success("Workspace added to project");
+      setModalOpen(false);
+      setSelectedWorkspaceId(undefined);
+      await loadWorkspaces();
+    } catch (err: any) {
+      if (err?.response?.status === 403) {
+        message.error(
+          <span>
+            You are not authorized to assign workspaces to projects. <br /> Please contact your administrator and request the{" "}
+            <b>Manage Workspaces</b> permission. <br /> For more information, visit the{" "}
+            <a
+              target="_blank"
+              href="https://docs.terrakube.io/user-guide/organizations/team-management"
+              rel="noreferrer"
+            >
+              Terrakube documentation
+            </a>
+            .
+          </span>
+        );
+      } else {
+        message.error("Failed to add workspace to project");
+      }
+    } finally {
+      setAssigning(false);
+    }
+  };
+
+  const handleRemove = async (workspaceId: string) => {
+    try {
+      await workspaceService.removeWorkspaceFromProject(orgid, workspaceId);
+      message.success("Workspace removed from project");
+      await loadWorkspaces();
+    } catch (err: any) {
+      if (err?.response?.status === 403) {
+        message.error(
+          <span>
+            You are not authorized to remove workspaces from projects. <br /> Please contact your administrator and request the{" "}
+            <b>Manage Workspaces</b> permission. <br /> For more information, visit the{" "}
+            <a
+              target="_blank"
+              href="https://docs.terrakube.io/user-guide/organizations/team-management"
+              rel="noreferrer"
+            >
+              Terrakube documentation
+            </a>
+            .
+          </span>
+        );
+      } else {
+        message.error("Failed to remove workspace from project");
+      }
+    }
+  };
+
+  const columns = [
+    {
+      title: "Name",
+      dataIndex: "name",
+      key: "name",
+      render: (name: string, record: WorkspaceListItem) => (
+        <Link to={`/organizations/${orgid}/workspaces/${record.id}`}>{name}</Link>
+      ),
+    },
+    {
+      title: "Status",
+      dataIndex: "lastStatus",
+      key: "lastStatus",
+      render: (status: WorkspaceListItem["lastStatus"]) => <WorkspaceStatusTag status={status} />,
+    },
+    {
+      title: "Repository",
+      dataIndex: "normalizedSource",
+      key: "normalizedSource",
+      render: (src: string | undefined) => (
+        <Typography.Text type="secondary">{src || "—"}</Typography.Text>
+      ),
+    },
+    {
+      title: "",
+      key: "actions",
+      render: (_: unknown, record: WorkspaceListItem) => (
+        <Popconfirm
+          title="Remove workspace from this project?"
+          onConfirm={() => handleRemove(record.id)}
+          okText="Yes"
+          cancelText="No"
+          placement="left"
+        >
+          <Button danger size="small">Remove</Button>
+        </Popconfirm>
+      ),
+    },
+  ];
+
+  return (
+    <div style={{ width: "100%" }}>
+      <h1>Workspaces</h1>
+      <p>Manage which workspaces belong to this project.</p>
+      <Button
+        type="primary"
+        icon={<PlusOutlined />}
+        style={{ marginBottom: 16 }}
+        onClick={() => setModalOpen(true)}
+        disabled={unassignedWorkspaces.length === 0}
+      >
+        Add Workspace
+      </Button>
+      <Table
+        rowKey="id"
+        loading={loading}
+        dataSource={assignedWorkspaces}
+        columns={columns}
+        pagination={{ pageSize: 10, showSizeChanger: true }}
+        locale={{ emptyText: "No workspaces assigned to this project yet." }}
+      />
+      <Modal
+        title="Add workspace to project"
+        open={modalOpen}
+        onOk={handleAssign}
+        onCancel={() => { setModalOpen(false); setSelectedWorkspaceId(undefined); }}
+        confirmLoading={assigning}
+        okText="Add"
+        okButtonProps={{ disabled: !selectedWorkspaceId }}
+      >
+        <Select
+          showSearch
+          placeholder="Search workspaces..."
+          optionFilterProp="label"
+          style={{ width: "100%", marginTop: 8 }}
+          value={selectedWorkspaceId}
+          onChange={setSelectedWorkspaceId}
+          options={unassignedWorkspaces.map((ws) => ({ label: ws.name, value: ws.id }))}
+        />
+      </Modal>
+    </div>
+  );
+}

--- a/ui/src/modules/projects/ProjectWorkspaces.tsx
+++ b/ui/src/modules/projects/ProjectWorkspaces.tsx
@@ -50,8 +50,8 @@ export default function ProjectWorkspaces({ orgid, projectId }: Props) {
       if (err?.response?.status === 403) {
         message.error(
           <span>
-            You are not authorized to assign workspaces to projects. <br /> Please contact your administrator and request the{" "}
-            <b>Manage Workspaces</b> permission. <br /> For more information, visit the{" "}
+            You are not authorized to assign workspaces to projects. <br /> Please contact your administrator and
+            request the <b>Manage Workspaces</b> permission. <br /> For more information, visit the{" "}
             <a
               target="_blank"
               href="https://docs.terrakube.io/user-guide/organizations/team-management"
@@ -79,8 +79,8 @@ export default function ProjectWorkspaces({ orgid, projectId }: Props) {
       if (err?.response?.status === 403) {
         message.error(
           <span>
-            You are not authorized to remove workspaces from projects. <br /> Please contact your administrator and request the{" "}
-            <b>Manage Workspaces</b> permission. <br /> For more information, visit the{" "}
+            You are not authorized to remove workspaces from projects. <br /> Please contact your administrator and
+            request the <b>Manage Workspaces</b> permission. <br /> For more information, visit the{" "}
             <a
               target="_blank"
               href="https://docs.terrakube.io/user-guide/organizations/team-management"
@@ -116,9 +116,7 @@ export default function ProjectWorkspaces({ orgid, projectId }: Props) {
       title: "Repository",
       dataIndex: "normalizedSource",
       key: "normalizedSource",
-      render: (src: string | undefined) => (
-        <Typography.Text type="secondary">{src || "—"}</Typography.Text>
-      ),
+      render: (src: string | undefined) => <Typography.Text type="secondary">{src || "—"}</Typography.Text>,
     },
     {
       title: "",
@@ -131,7 +129,9 @@ export default function ProjectWorkspaces({ orgid, projectId }: Props) {
           cancelText="No"
           placement="left"
         >
-          <Button danger size="small">Remove</Button>
+          <Button danger size="small">
+            Remove
+          </Button>
         </Popconfirm>
       ),
     },
@@ -162,7 +162,10 @@ export default function ProjectWorkspaces({ orgid, projectId }: Props) {
         title="Add workspace to project"
         open={modalOpen}
         onOk={handleAssign}
-        onCancel={() => { setModalOpen(false); setSelectedWorkspaceId(undefined); }}
+        onCancel={() => {
+          setModalOpen(false);
+          setSelectedWorkspaceId(undefined);
+        }}
         confirmLoading={assigning}
         okText="Add"
         okButtonProps={{ disabled: !selectedWorkspaceId }}

--- a/ui/src/modules/projects/ProjectsPage.tsx
+++ b/ui/src/modules/projects/ProjectsPage.tsx
@@ -83,7 +83,11 @@ export default function ProjectsPage({ organizationName, setOrganizationName }: 
       dataIndex: "name",
       key: "name",
       render: (_: any, record: ProjectModel) => (
-        <Button type="link" style={{ padding: 0 }} onClick={() => navigate(`/organizations/${id}/projects/${record.id}`)}>
+        <Button
+          type="link"
+          style={{ padding: 0 }}
+          onClick={() => navigate(`/organizations/${id}/projects/${record.id}`)}
+        >
           {record.name}
         </Button>
       ),

--- a/ui/src/modules/projects/ProjectsPage.tsx
+++ b/ui/src/modules/projects/ProjectsPage.tsx
@@ -1,0 +1,141 @@
+import { Button, Form, Input, Modal, Table, message } from "antd";
+import { PlusOutlined } from "@ant-design/icons";
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import PageWrapper from "@/modules/layout/PageWrapper/PageWrapper";
+import projectService from "./projectService";
+import useApiRequest from "@/modules/api/useApiRequest";
+import { ProjectModel } from "@/domain/types";
+import { ORGANIZATION_NAME } from "../../config/actionTypes";
+
+type Props = {
+  organizationName: string;
+  setOrganizationName: React.Dispatch<React.SetStateAction<string>>;
+};
+
+type ProjectForm = {
+  name: string;
+  description?: string;
+};
+
+export default function ProjectsPage({ organizationName, setOrganizationName }: Props) {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [projects, setProjects] = useState<ProjectModel[]>([]);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [form] = Form.useForm<ProjectForm>();
+
+  const { loading, execute, error } = useApiRequest({
+    action: () => projectService.listProjects(id!),
+    onReturn: (data) => {
+      setProjects(data);
+      const stored = sessionStorage.getItem(ORGANIZATION_NAME);
+      if (stored) setOrganizationName(stored);
+    },
+  });
+
+  useEffect(() => {
+    execute();
+  }, []);
+
+  const openCreate = () => {
+    form.resetFields();
+    setModalOpen(true);
+  };
+
+  const handleOk = async () => {
+    try {
+      const values = await form.validateFields();
+      setSubmitting(true);
+      await projectService.createProject(id!, values);
+      message.success("Project created");
+      setModalOpen(false);
+      execute();
+    } catch (err: any) {
+      if (err?.errorFields) return;
+      if (err?.response?.status === 403) {
+        message.error(
+          <span>
+            You are not authorized to create projects. <br /> Please contact your administrator and request the{" "}
+            <b>Manage Workspaces</b> permission. <br /> For more information, visit the{" "}
+            <a
+              target="_blank"
+              href="https://docs.terrakube.io/user-guide/organizations/team-management"
+              rel="noreferrer"
+            >
+              Terrakube documentation
+            </a>
+            .
+          </span>
+        );
+      } else {
+        message.error(err?.message ?? "An error occurred");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const columns = [
+    {
+      title: "Name",
+      dataIndex: "name",
+      key: "name",
+      render: (_: any, record: ProjectModel) => (
+        <Button type="link" style={{ padding: 0 }} onClick={() => navigate(`/organizations/${id}/projects/${record.id}`)}>
+          {record.name}
+        </Button>
+      ),
+    },
+    {
+      title: "Description",
+      dataIndex: "description",
+      key: "description",
+    },
+  ];
+
+  return (
+    <PageWrapper
+      title="Projects"
+      subTitle={`Projects in the ${organizationName} organization`}
+      loadingText="Loading projects..."
+      loading={loading}
+      error={error}
+      breadcrumbs={[
+        { label: organizationName, path: "/" },
+        { label: "Projects", path: `/organizations/${id}/projects` },
+      ]}
+      fluid
+      actions={
+        <Button icon={<PlusOutlined />} type="primary" onClick={openCreate}>
+          New project
+        </Button>
+      }
+    >
+      <Table
+        dataSource={projects}
+        columns={columns}
+        rowKey="id"
+        pagination={{ showSizeChanger: true, defaultPageSize: 10 }}
+      />
+      <Modal
+        title="New project"
+        open={modalOpen}
+        onOk={handleOk}
+        onCancel={() => setModalOpen(false)}
+        confirmLoading={submitting}
+        okText="Create"
+      >
+        <Form form={form} layout="vertical">
+          <Form.Item name="name" label="Name" rules={[{ required: true, message: "Name is required" }]}>
+            <Input />
+          </Form.Item>
+          <Form.Item name="description" label="Description">
+            <Input.TextArea rows={3} />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </PageWrapper>
+  );
+}

--- a/ui/src/modules/projects/projectService.ts
+++ b/ui/src/modules/projects/projectService.ts
@@ -38,8 +38,7 @@ async function listProjects(organizationId: string): Promise<ApiResponse<Project
     };
   }
 
-  const edges =
-    tempData.data?.organization?.edges?.[0]?.node?.project?.edges ?? [];
+  const edges = tempData.data?.organization?.edges?.[0]?.node?.project?.edges ?? [];
 
   return {
     isError: false,
@@ -124,8 +123,7 @@ async function getProject(organizationId: string, projectId: string): Promise<Ap
     };
   }
 
-  const node =
-    tempData.data?.organization?.edges?.[0]?.node?.project?.edges?.[0]?.node;
+  const node = tempData.data?.organization?.edges?.[0]?.node?.project?.edges?.[0]?.node;
 
   return {
     isError: false,

--- a/ui/src/modules/projects/projectService.ts
+++ b/ui/src/modules/projects/projectService.ts
@@ -1,0 +1,153 @@
+import axiosInstance from "@/config/axiosConfig";
+import { apiPost } from "@/modules/api/apiWrapper";
+import { ApiResponse } from "@/modules/api/types";
+import { ProjectModel } from "@/domain/types";
+
+async function listProjects(organizationId: string): Promise<ApiResponse<ProjectModel[]>> {
+  const body = {
+    query: `{
+      organization(ids: ["${organizationId}"]) {
+        edges {
+          node {
+            project {
+              edges {
+                node {
+                  id
+                  name
+                  description
+                }
+              }
+            }
+          }
+        }
+      }
+    }`,
+  };
+
+  const tempData = await apiPost<unknown, any>("/graphql/api/v1", body, {
+    dataWrapped: true,
+    contentType: "application/json",
+  });
+
+  if (tempData.isError) {
+    return {
+      isError: true,
+      responseCode: tempData.responseCode,
+      error: tempData.error,
+      data: [],
+    };
+  }
+
+  const edges =
+    tempData.data?.organization?.edges?.[0]?.node?.project?.edges ?? [];
+
+  return {
+    isError: false,
+    responseCode: tempData.responseCode,
+    data: edges.map((edge: any) => ({
+      id: edge.node.id,
+      name: edge.node.name,
+      description: edge.node.description,
+    })),
+  };
+}
+
+async function createProject(organizationId: string, data: { name: string; description?: string }): Promise<void> {
+  const body = {
+    data: {
+      type: "project",
+      attributes: {
+        name: data.name,
+        description: data.description ?? "",
+      },
+    },
+  };
+
+  await axiosInstance.post(`organization/${organizationId}/project`, body, {
+    headers: { "Content-Type": "application/vnd.api+json" },
+  });
+}
+
+async function updateProject(
+  organizationId: string,
+  projectId: string,
+  data: { name: string; description?: string }
+): Promise<void> {
+  const body = {
+    data: {
+      id: projectId,
+      type: "project",
+      attributes: {
+        name: data.name,
+        description: data.description ?? "",
+      },
+    },
+  };
+
+  await axiosInstance.patch(`organization/${organizationId}/project/${projectId}`, body, {
+    headers: { "Content-Type": "application/vnd.api+json" },
+  });
+}
+
+async function getProject(organizationId: string, projectId: string): Promise<ApiResponse<ProjectModel>> {
+  const body = {
+    query: `{
+      organization(ids: ["${organizationId}"]) {
+        edges {
+          node {
+            project(ids: ["${projectId}"]) {
+              edges {
+                node {
+                  id
+                  name
+                  description
+                }
+              }
+            }
+          }
+        }
+      }
+    }`,
+  };
+
+  const tempData = await apiPost<unknown, any>("/graphql/api/v1", body, {
+    dataWrapped: true,
+    contentType: "application/json",
+  });
+
+  if (tempData.isError) {
+    return {
+      isError: true,
+      responseCode: tempData.responseCode,
+      error: tempData.error,
+      data: { id: "", name: "" },
+    };
+  }
+
+  const node =
+    tempData.data?.organization?.edges?.[0]?.node?.project?.edges?.[0]?.node;
+
+  return {
+    isError: false,
+    responseCode: tempData.responseCode,
+    data: {
+      id: node?.id ?? "",
+      name: node?.name ?? "",
+      description: node?.description,
+    },
+  };
+}
+
+async function deleteProject(organizationId: string, projectId: string): Promise<void> {
+  await axiosInstance.delete(`organization/${organizationId}/project/${projectId}`);
+}
+
+const methods = {
+  listProjects,
+  getProject,
+  createProject,
+  updateProject,
+  deleteProject,
+};
+
+export default methods;

--- a/ui/src/modules/workspaces/components/WorkspaceCard.tsx
+++ b/ui/src/modules/workspaces/components/WorkspaceCard.tsx
@@ -1,5 +1,5 @@
-import { ClockCircleOutlined } from "@ant-design/icons";
-import { Card, Space, Row, Col, Typography, Flex } from "antd";
+import { ClockCircleOutlined, FolderOutlined } from "@ant-design/icons";
+import { Card, Space, Row, Col, Tag, Typography, Flex } from "antd";
 import { DateTime } from "luxon";
 import { IconContext } from "react-icons";
 import { BiTerminal } from "react-icons/bi";
@@ -31,6 +31,9 @@ export default function WorkspaceCard({ item, tags }: Props) {
             <Row justify="start">
               <Col span={24}>
                 <Flex justify="end" wrap gap="small">
+                  {item.projectName && (
+                    <Tag icon={<FolderOutlined />} color="blue">{item.projectName}</Tag>
+                  )}
                   <WorkspaceCardTags tags={tags} item={item} />
                 </Flex>
               </Col>

--- a/ui/src/modules/workspaces/components/WorkspaceCard.tsx
+++ b/ui/src/modules/workspaces/components/WorkspaceCard.tsx
@@ -32,7 +32,9 @@ export default function WorkspaceCard({ item, tags }: Props) {
               <Col span={24}>
                 <Flex justify="end" wrap gap="small">
                   {item.projectName && (
-                    <Tag icon={<FolderOutlined />} color="blue">{item.projectName}</Tag>
+                    <Tag icon={<FolderOutlined />} color="blue">
+                      {item.projectName}
+                    </Tag>
                   )}
                   <WorkspaceCardTags tags={tags} item={item} />
                 </Flex>

--- a/ui/src/modules/workspaces/components/WorkspaceFilter.tsx
+++ b/ui/src/modules/workspaces/components/WorkspaceFilter.tsx
@@ -27,6 +27,7 @@ type Props = {
   onTagsLoaded: (tags: TagModel[]) => void;
   sortOption: WorkspaceSortOption;
   onSortChange: (option: WorkspaceSortOption) => void;
+  projects?: { id: string; name: string }[];
 };
 
 enum Additional {
@@ -41,10 +42,12 @@ export default function WorkspaceFilter({
   onTagsLoaded,
   sortOption,
   onSortChange,
+  projects = [],
 }: Props) {
   const [statusFilter, setStatusFilter] = useState<string>(sessionStorage.getItem("filterValue") || "All");
   const [searchFilter, setSearchFilter] = useState(sessionStorage.getItem("searchValue") || "");
   const [tagsFilter, setTagsFilter] = useState<string[]>((sessionStorage.getItem("selectedTags") as any) || []);
+  const [projectFilter, setProjectFilter] = useState<string | null>(sessionStorage.getItem("projectFilter") || null);
   const [tags, setTags] = useState<TagModel[]>([]);
 
   const { execute } = useApiRequest({
@@ -87,12 +90,18 @@ export default function WorkspaceFilter({
       }
     });
 
+    filteredWorkspaces = filteredWorkspaces.filter((workspace) => {
+      if (!projectFilter) return true;
+      if (projectFilter === "__unassigned__") return !workspace.projectId;
+      return workspace.projectId === projectFilter;
+    });
+
     onFiltered(filteredWorkspaces);
   }
 
   useEffect(() => {
     filterItems();
-  }, [statusFilter, tagsFilter]);
+  }, [statusFilter, tagsFilter, projectFilter]);
   useEffect(() => {
     execute();
   }, []);
@@ -237,6 +246,23 @@ export default function WorkspaceFilter({
         </div>
 
         <div className="workspace-filter-right">
+          {projects.length > 0 && (
+            <Select
+              allowClear
+              placeholder="Project"
+              value={projectFilter || undefined}
+              onChange={(val) => {
+                const next = val ?? null;
+                setProjectFilter(next);
+                sessionStorage.setItem("projectFilter", next ?? "");
+              }}
+              options={[
+                { label: "(Unassigned)", value: "__unassigned__" },
+                ...projects.map((p) => ({ label: p.name, value: p.id })),
+              ]}
+              style={{ minWidth: 140 }}
+            />
+          )}
           <Popover
             content={tagsContent}
             trigger="click"

--- a/ui/src/modules/workspaces/types.ts
+++ b/ui/src/modules/workspaces/types.ts
@@ -12,6 +12,8 @@ export type WorkspaceListItem = {
   normalizedSource?: string;
   terraformVersion?: string;
   tags?: string[];
+  projectId?: string;
+  projectName?: string;
 };
 
 export type ListWorkspacesResponse = {

--- a/ui/src/modules/workspaces/workspaceService.ts
+++ b/ui/src/modules/workspaces/workspaceService.ts
@@ -1,3 +1,4 @@
+import axiosInstance from "@/config/axiosConfig";
 import { apiPost } from "@/modules/api/apiWrapper";
 import { ApiResponse } from "@/modules/api/types";
 import { ListWorkspacesResponse, WorkspaceListItem } from "@/modules/workspaces/types";
@@ -24,12 +25,20 @@ async function listWorkspaces(organizationId: string): Promise<ApiResponse<ListW
                       lastJobStatus
                       lastJobDate
                       workspaceTag {
-                        edges { 
+                        edges {
                           node {
                             id
                             tagId
                           }
-                        } 
+                        }
+                      }
+                      project {
+                        edges {
+                          node {
+                            id
+                            name
+                          }
+                        }
                       }
                     }
                   }
@@ -76,6 +85,8 @@ async function listWorkspaces(organizationId: string): Promise<ApiResponse<ListW
       normalizedSource: formatSshUrl(element.node.source),
       terraformVersion: element.node.terraformVersion,
       tags: element.node?.workspaceTag?.edges?.map((e: any) => e.node.tagId),
+      projectId: element.node?.project?.edges?.[0]?.node?.id,
+      projectName: element.node?.project?.edges?.[0]?.node?.name,
     };
     return ws;
   });
@@ -93,8 +104,26 @@ async function listWorkspaces(organizationId: string): Promise<ApiResponse<ListW
   };
 }
 
+async function assignWorkspaceToProject(orgId: string, workspaceId: string, projectId: string): Promise<void> {
+  await axiosInstance.patch(
+    `organization/${orgId}/workspace/${workspaceId}/relationships/project`,
+    { data: { type: "project", id: projectId } },
+    { headers: { "Content-Type": "application/vnd.api+json" } }
+  );
+}
+
+async function removeWorkspaceFromProject(orgId: string, workspaceId: string): Promise<void> {
+  await axiosInstance.patch(
+    `organization/${orgId}/workspace/${workspaceId}/relationships/project`,
+    { data: null },
+    { headers: { "Content-Type": "application/vnd.api+json" } }
+  );
+}
+
 const methods = {
   listWorkspaces,
+  assignWorkspaceToProject,
+  removeWorkspaceFromProject,
 };
 
 export default methods;


### PR DESCRIPTION
## Summary

Closes #650

Adds **Project management** to the UI, allowing users to group and organize Workspaces under Projects within an Organization. Users can list, create, edit, and delete Projects, and assign Workspaces to Projects for filtering.

Also fixes a bug where `terraform init` with a `workspaces { project = "..." }` block failed to locate the configured project.

---

## Changes

### New pages / components

| File | Description |
|---|---|
| `ProjectsPage.tsx` | List and create Projects within an Organization (includes 403 error handling) |
| `ProjectDetailPage.tsx` | Edit Project settings (name, description), delete Projects, and manage assigned Workspaces (includes 403 error handling) |
| `ProjectWorkspaces.tsx` | List, add, and remove Workspaces assigned to a Project (includes 403 error handling) |
| `projectService.ts` | Project CRUD operations (GraphQL reads + JSON:API REST writes) |

### Modified files

| File | Change |
|---|---|
| `App.tsx` | Add routes for `/organizations/:id/projects` and `/:orgid/projects/:id` |
| `MainMenu.tsx` | Add "Projects" menu item with `ProjectOutlined` icon to the sidebar |
| `Create.tsx` | Add optional Project selector when creating a Workspace |
| `Details.tsx` | Show the assigned Project name (with link) in the Workspace detail sidebar |
| `Workspaces/Settings/General.tsx` | Add "Project" section — a dropdown to assign/unassign a Project |
| `WorkspaceCard.tsx` | Display the assigned Project name as a badge on each Workspace card |
| `WorkspaceFilter.tsx` | Add Project filter (includes an "Unassigned" option); persist selection to sessionStorage |
| `OrganizationDetailsPage.tsx` | Derive unique Project list from Workspaces and pass it to `WorkspaceFilter` |
| `workspaceService.ts` | Add `assignWorkspaceToProject` / `removeWorkspaceFromProject` (`PATCH /workspace/:id/relationships/project`); include `project` in GraphQL query |
| `types.ts` (workspaces) | Add `projectId` / `projectName` to `WorkspaceListItem` |
| `types.ts` (domain) | Define `ProjectModel` type |
| `PageWrapper.tsx` | Ant Design v5 compatibility: replace Breadcrumb `label` with `title` |
| `RemoteTfeService.java` | Fix: JSON:API type corrected from `"project"` → `"projects"` in project listing response (see below) |

---

## Error handling

All Project management operations handle authorization errors (403 Forbidden). When a user lacks the required "Manage Workspaces" permission, they see a message that includes:

- A note that administrator contact is required
- Instructions on how to request the necessary permission
- A link to the Terrakube documentation

Project deletion is also guarded: if a Project still has Workspaces assigned, a helpful error is shown rather than allowing deletion.

---

## Design notes

### `RemoteTfeService.java` fix

When using the Terraform `cloud` block with a `workspaces { project = "..." }` configuration and running `terraform init`, Terraform CLI looked up the project by name in the response but found no match, producing:

```
Error: Error loading state: Attempted to find configured project abc but was unable to.
```

The root cause was that the JSON:API `type` field in the project listing response was `"project"` instead of the correct plural form `"projects"`. Terraform CLI uses the type field to identify resource objects in the response, so the mismatch caused the lookup to silently fail.

```diff
- "type": "project"
+ "type": "projects"
```

### `PageWrapper.tsx` change

```diff
- label: <NavLink to={bc.path}>{bc.label}</NavLink>,
+ title: <NavLink to={bc.path}>{bc.label}</NavLink>,
```

In Ant Design v5, the `Breadcrumb` component's `items` prop replaced `label` with `title`. Without this fix, the breadcrumb on the Project detail page does not render.

### Project membership is optional

Workspace–Project assignment is intentionally optional:

- The Create Workspace wizard and the General settings tab both include a `(No project)` option.
- Workspaces can also be removed from a Project via the Project detail page.
- Unassigning sends `{ data: null }` to the relationship endpoint.

**Future consideration (out of scope):** If per-Project access control is introduced later, Workspaces with no Project assignment could become a gap in permission management. Whether to make assignment required should be revisited when Project-level permissions are added.

---

## Testing

1. Navigate to `/organizations/:id/projects` — verify Project list, create, and 403 handling.
2. Open a Project detail page — verify edit (name/description), delete, and Workspace add/remove.
3. On the Workspaces list page — verify the Project filter works, including the "Unassigned" option.
4. Confirm the Project name badge appears on Workspace cards.
5. In Workspace Settings > General — verify Project assignment and unassignment save correctly.
6. In the Create Workspace wizard — verify the optional Project dropdown works.
7. In the Workspace detail view — verify the assigned Project name is shown as a link.
8. Confirm the breadcrumb renders correctly on the Project detail page.
9. Test authorization errors: verify that operations by a user without "Manage Workspaces" permission show appropriate error messages with documentation links.
10. Test Project deletion constraint: verify that attempting to delete a Project with assigned Workspaces shows a helpful error message.

## Screenshots

<img width="1147" height="476" alt="image" src="https://github.com/user-attachments/assets/19f5b28f-f280-4531-a4ce-4b81b762fac0" />

<img width="1066" height="804" alt="image" src="https://github.com/user-attachments/assets/6be06090-230d-4c02-801a-da9194cc045f" />

<img width="1093" height="653" alt="image" src="https://github.com/user-attachments/assets/d540770a-9e3c-4e3f-852a-92c9822c59c1" />
