### PR TITLE
fix(ui): accept hyphenated SSH host and stop crashing on unknown SSH provider (#3169)

### DIFF
--- a/ui/src/domain/Modules/Create.tsx
+++ b/ui/src/domain/Modules/Create.tsx
@@ -391,7 +391,7 @@ export const CreateModule = () => {
                   {
                     required: true,
                     pattern: new RegExp(
-                      "((git|ssh|http(s)?)|(git@[\\w\\.]+))(:(//)?)([\\w\\.@\\:/\\-~]+)(\\.git)?(/)?"
+                      "((git|ssh|http(s)?)|(git@[\\w\\.\\-]+))(:(//)?)([\\w\\.@\\:/\\-~]+)(\\.git)?(/)?"
                     ),
                   },
                 ]}

--- a/ui/src/domain/Workspaces/Create.tsx
+++ b/ui/src/domain/Workspaces/Create.tsx
@@ -632,7 +632,7 @@ export const CreateWorkspace = () => {
                   {
                     required: true,
                     pattern: new RegExp(
-                      "(empty)|(((git|ssh|http(s)?)|(git@[\\w\\.]+))(:(//)?)([\\w\\.@\\:/\\-~]+)(\\.git)?(/)?)"
+                      "(empty)|(((git|ssh|http(s)?)|(git@[\\w\\.\\-]+))(:(//)?)([\\w\\.@\\:/\\-~]+)(\\.git)?(/)?)"
                     ),
                   },
                 ]}

--- a/ui/src/modules/workspaces/utils/formatSshUrl.spec.ts
+++ b/ui/src/modules/workspaces/utils/formatSshUrl.spec.ts
@@ -35,4 +35,15 @@ describe("formatSshUrl", () => {
     const result = formatSshUrl("git@gitlab.com:org-name/project-name/repo-name.git");
     expect(result).toBe("https://gitlab.com/org-name/project-name/repo-name");
   });
+
+  test("self-hosted SSH url with hyphenated host is formatted correctly", () => {
+    // Regression test for issue #3168: a host containing a hyphen (here a
+    // self-hosted GitHub instance) used to round-trip through the function as
+    // "https://github-test.com:terrakube-io/terrakube-docker-compose", which
+    // crashed `new URL(...)` because "terrakube-io" parses as a port. The host
+    // does not match any of the four hardcoded provider blocks, so the colon
+    // has to be normalized in the generic git@ rewrite step.
+    const result = formatSshUrl("git@github-test.com:terrakube-io/terrakube-docker-compose.git");
+    expect(result).toBe("https://github-test.com/terrakube-io/terrakube-docker-compose");
+  });
 });

--- a/ui/src/modules/workspaces/utils/formatSshUrl.ts
+++ b/ui/src/modules/workspaces/utils/formatSshUrl.ts
@@ -4,11 +4,22 @@ export default function (source: string): string {
   }
 
   if (source.startsWith("git@")) {
-    source = source.replace("git@", "https://");
+    // Convert "git@host:path" -> "https://host/path" in one step. The previous
+    // two-step rewrite ("git@" -> "https://") left the colon between host and
+    // path intact, producing "https://host:path", which is only well-formed
+    // for the four hardcoded providers below (each one runs a host-specific
+    // ".com:"/".org:" -> "/" replacement). For any other host -- including
+    // self-hosted git over SSH and hosts that contain a hyphen (e.g.
+    // github-test.com) -- that left "https://github-test.com:terrakube" and
+    // `new URL(...)` interpreted "terrakube" as a port, which crashed the
+    // organization page (issue #3168, bug 2).
+    source = source.replace(/^git@([^:]+):/, "https://$1/");
   }
 
   if (source.includes("dev.azure.com")) {
-    source = source.replace(":v3", "").replace("ssh.", "");
+    // ":v3" handles HTTPS-shaped DevOps URLs that still carry the v3 segment;
+    // "/v3" handles the SSH form after the regex above rewrote the colon.
+    source = source.replace(":v3", "").replace("/v3", "").replace("ssh.", "");
     source = stripUserFromHost(source);
     source = source.replace("/_git", "");
   }


### PR DESCRIPTION


Closes #3168.

The repo URL form on the workspace and module create flows rejected valid SSH URLs like git@github-test.com:org/repo.git because the host part of the validation regex (git@[\w\.]+) excluded the hyphen. Once such a URL made it into the database, the organization page also crashed with "URL constructor: https://github-test.com:terrakube-io/... is not a valid URL" -- formatSshUrl rewrote git@ to https:// but only replaced the host:path colon with a slash for the four hardcoded providers (github.com, ghe.com, dev.azure.com, bitbucket.org, gitlab.com). Self-hosted hosts and hyphenated hosts left the colon intact, and the rest of the path was parsed as a port number.

Two changes:

1. Both validation regexes (workspace Create.tsx, module Create.tsx) now accept "-" inside the host: "git@[\w\.\-]+".

2. formatSshUrl now converts "git@host:path" to "https://host/path" in a single step (regex /^git@([^:]+):/ -> "https://$1/") so unknown hosts work the same as the four hardcoded ones. The DevOps branch picks up "/v3" in addition to ":v3" because the SSH form ("git@ssh.dev.azure. com:v3/...") now lands as ".../v3/..." after the host rewrite. All existing test cases (DevOps SSH/HTTPS, GitHub SSH, BitBucket SSH/HTTPS, GitLab SSH/HTTPS) still produce the same expected output.

Adds a regression test against the exact URL from the issue.

The unit tests run via jest+ts-jest can't be executed cleanly in this clone because the project's tsconfig.test.json uses options ("baseUrl", "moduleResolution=node10") that the bundled TypeScript 6.0.3 flags as deprecated and treats as errors. That is independent of this change. I verified the new behavior by porting formatSshUrl to a standalone Node script and confirming all 7 existing assertions plus the new hyphenated-host case match the expected outputs.