### PR TITLE
fix(executor): update dynamic credentials file paths for AWS and GCP environment variables (#3173)

### DIFF
--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -588,6 +588,16 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             log.info("File terrakube_env does not exist");
         }
 
+        if (terraformJob.getEnvironmentVariables().containsKey("AWS_WEB_IDENTITY_TOKEN_FILE")) {
+            log.info("AWS_WEB_IDENTITY_TOKEN_FILE updating location to: {}", workingDirectory.getAbsolutePath() + "/terrakube_config_dynamic_credentials_aws.txt");
+            terraformJob.getEnvironmentVariables().put("AWS_WEB_IDENTITY_TOKEN_FILE", workingDirectory.getAbsolutePath() + "/terrakube_config_dynamic_credentials_aws.txt");
+        }
+
+        if (terraformJob.getEnvironmentVariables().containsKey("GOOGLE_APPLICATION_CREDENTIALS")) {
+            log.info("GOOGLE_APPLICATION_CREDENTIALS updating location to: {}", workingDirectory.getAbsolutePath() + "/terrakube_config_dynamic_credentials_gcp.json");
+            terraformJob.getEnvironmentVariables().put("GOOGLE_APPLICATION_CREDENTIALS", workingDirectory.getAbsolutePath() + "/terrakube_config_dynamic_credentials_gcp.json");
+        }
+
         return terraformJob.getEnvironmentVariables();
     }
 }

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -3,7 +3,11 @@ FROM node:alpine AS builder
 WORKDIR /app
 COPY package.json .
 COPY yarn.lock .
-RUN yarn
+# Install Yarn (not included in recent node:alpine images)
+RUN npm install -g yarn
+
+# Install dependencies using the exact versions from yarn.lock
+RUN yarn install --frozen-lockfile
 COPY . .
 
 # Increase Node.js memory limit to prevent out of memory errors


### PR DESCRIPTION


* fix(executor): update dynamic credentials file paths for AWS and GCP environment variables

- Adjusted `AWS_WEB_IDENTITY_TOKEN_FILE` and `GOOGLE_APPLICATION_CREDENTIALS` paths to use working directory for better configuration management.

* update Dockerfile to install Yarn