### PR TITLE
fix(ui): add dark mode support for missing CSS files

### DIFF
--- a/ui/src/domain/Home/App.css
+++ b/ui/src/domain/Home/App.css
@@ -50,6 +50,10 @@
   margin-bottom: 15px;
 }
 
+[data-theme="dark"] .popup-text {
+  color: var(--tk-text-secondary);
+}
+
 .paragraph {
   margin: 0;
 }

--- a/ui/src/domain/Jobs/StructuredPlanOutput.css
+++ b/ui/src/domain/Jobs/StructuredPlanOutput.css
@@ -650,3 +650,311 @@
     text-align: left;
   }
 }
+
+/* ==========================================================================
+   Dark Mode Overrides
+   ========================================================================== */
+
+[data-theme="dark"] .structured-plan-shell {
+  background: var(--tk-bg-container);
+  border-color: var(--tk-border-primary);
+}
+
+[data-theme="dark"] .structured-plan-summaryArea {
+  border-bottom-color: var(--tk-border-primary);
+}
+
+[data-theme="dark"] .structured-plan-summaryEmpty {
+  background: var(--tk-fill-primary);
+  border-color: var(--tk-border-primary);
+  color: var(--tk-text-secondary);
+}
+
+[data-theme="dark"] .structured-plan-summaryMeta {
+  color: var(--tk-text-secondary);
+}
+
+[data-theme="dark"] .structured-plan-toolbar {
+  border-bottom-color: var(--tk-border-primary);
+}
+
+[data-theme="dark"] .structured-plan-searchInput {
+  background: var(--tk-bg-base);
+  border-color: var(--tk-border-primary);
+  color: var(--tk-text-primary);
+}
+
+[data-theme="dark"] .structured-plan-searchInput:focus {
+  border-color: #58a6ff;
+  box-shadow: 0 0 0 2px rgba(88, 166, 255, 0.2);
+}
+
+[data-theme="dark"] .structured-plan-searchInput::placeholder {
+  color: var(--tk-text-tertiary);
+}
+
+[data-theme="dark"] .structured-plan-selectWrap {
+  background: var(--tk-bg-base);
+  border-color: var(--tk-border-primary);
+  color: var(--tk-text-secondary);
+}
+
+[data-theme="dark"] .structured-plan-selectWrap:focus-within {
+  border-color: #58a6ff;
+  box-shadow: 0 0 0 2px rgba(88, 166, 255, 0.2);
+}
+
+[data-theme="dark"] .structured-plan-selectIcon,
+[data-theme="dark"] .structured-plan-selectChevron {
+  color: var(--tk-text-tertiary);
+}
+
+[data-theme="dark"] .structured-plan-select {
+  color: var(--tk-text-primary);
+}
+
+[data-theme="dark"] .structured-plan-checkbox {
+  color: var(--tk-text-secondary);
+}
+
+[data-theme="dark"] .structured-plan-toolbarMeta {
+  color: var(--tk-text-secondary);
+}
+
+[data-theme="dark"] .structured-plan-toolbarButton {
+  background: var(--tk-bg-elevated);
+  border-color: var(--tk-border-primary);
+  color: var(--tk-text-primary);
+}
+
+[data-theme="dark"] .structured-plan-toolbarButton:hover {
+  background: var(--tk-fill-primary);
+}
+
+[data-theme="dark"] .structured-plan-row {
+  border-bottom-color: var(--tk-border-secondary);
+}
+
+[data-theme="dark"] .structured-plan-rowToggle:hover {
+  background: var(--tk-fill-primary);
+}
+
+[data-theme="dark"] .structured-plan-rowToggle:focus-visible {
+  background: var(--tk-fill-primary);
+  box-shadow: inset 0 0 0 2px rgba(88, 166, 255, 0.2);
+}
+
+[data-theme="dark"] .structured-plan-chevron {
+  color: var(--tk-text-secondary);
+}
+
+/* Action icons — dark mode: darker pastel variants */
+[data-theme="dark"] .structured-plan-actionIcon--create {
+  background: rgba(46, 160, 67, 0.15);
+  border-color: rgba(46, 160, 67, 0.3);
+  color: #3fb950;
+}
+
+[data-theme="dark"] .structured-plan-actionIcon--update {
+  background: rgba(56, 139, 253, 0.15);
+  border-color: rgba(56, 139, 253, 0.3);
+  color: #58a6ff;
+}
+
+[data-theme="dark"] .structured-plan-actionIcon--replace {
+  background: var(--tk-fill-primary);
+  border-color: var(--tk-border-primary);
+  color: var(--tk-text-secondary);
+}
+
+[data-theme="dark"] .structured-plan-actionIcon--delete {
+  background: rgba(248, 81, 73, 0.15);
+  border-color: rgba(248, 81, 73, 0.3);
+  color: #f85149;
+}
+
+[data-theme="dark"] .structured-plan-actionIcon--read,
+[data-theme="dark"] .structured-plan-actionIcon--unknown {
+  background: var(--tk-fill-primary);
+  border-color: var(--tk-border-primary);
+  color: var(--tk-text-tertiary);
+}
+
+[data-theme="dark"] .structured-plan-providerBadge {
+  background: var(--tk-fill-primary);
+  border-color: var(--tk-border-primary);
+  color: var(--tk-text-secondary);
+}
+
+[data-theme="dark"] .structured-plan-address {
+  color: var(--tk-text-primary);
+}
+
+[data-theme="dark"] .structured-plan-copyButton {
+  border-left-color: var(--tk-border-secondary);
+  color: var(--tk-text-tertiary);
+}
+
+[data-theme="dark"] .structured-plan-copyButton:hover {
+  background: var(--tk-fill-primary);
+  color: var(--tk-text-primary);
+}
+
+[data-theme="dark"] .structured-plan-rowBody {
+  background: var(--tk-bg-container);
+}
+
+[data-theme="dark"] .structured-plan-rowBodyInner {
+  border-left-color: var(--tk-border-primary);
+}
+
+[data-theme="dark"] .structured-plan-rowCounts {
+  color: var(--tk-text-secondary);
+}
+
+[data-theme="dark"] .structured-plan-diffGroupLabel {
+  color: var(--tk-text-primary);
+}
+
+[data-theme="dark"] .structured-plan-diffGroupChildren {
+  border-left-color: var(--tk-border-primary);
+}
+
+[data-theme="dark"] .structured-plan-hiddenCount {
+  color: var(--tk-text-tertiary);
+}
+
+/* Diff rows — dark mode */
+[data-theme="dark"] .structured-plan-diffRow {
+  background: var(--tk-bg-elevated);
+  border-color: var(--tk-border-primary);
+}
+
+[data-theme="dark"] .structured-plan-diffRow--added {
+  background: rgba(46, 160, 67, 0.08);
+  border-color: rgba(46, 160, 67, 0.25);
+}
+
+[data-theme="dark"] .structured-plan-diffRow--removed {
+  background: rgba(248, 81, 73, 0.08);
+  border-color: rgba(248, 81, 73, 0.25);
+}
+
+[data-theme="dark"] .structured-plan-diffRow--changed {
+  background: rgba(56, 139, 253, 0.08);
+  border-color: rgba(56, 139, 253, 0.25);
+}
+
+[data-theme="dark"] .structured-plan-diffRow--unknown {
+  background: rgba(210, 153, 34, 0.08);
+  border-color: rgba(210, 153, 34, 0.25);
+}
+
+[data-theme="dark"] .structured-plan-diffRow--sensitive {
+  background: rgba(163, 113, 247, 0.08);
+  border-color: rgba(163, 113, 247, 0.25);
+}
+
+[data-theme="dark"] .structured-plan-diffLabel {
+  color: var(--tk-text-primary);
+}
+
+/* Diff markers — dark mode */
+[data-theme="dark"] .structured-plan-diffMarker--added {
+  background: rgba(46, 160, 67, 0.2);
+  color: #3fb950;
+}
+
+[data-theme="dark"] .structured-plan-diffMarker--removed {
+  background: rgba(248, 81, 73, 0.2);
+  color: #f85149;
+}
+
+[data-theme="dark"] .structured-plan-diffMarker--changed {
+  background: rgba(56, 139, 253, 0.2);
+  color: #58a6ff;
+}
+
+[data-theme="dark"] .structured-plan-diffMarker--unknown {
+  background: rgba(210, 153, 34, 0.2);
+  color: #e3b341;
+}
+
+[data-theme="dark"] .structured-plan-diffMarker--sensitive {
+  background: rgba(163, 113, 247, 0.2);
+  color: #d2a8ff;
+}
+
+[data-theme="dark"] .structured-plan-diffArrow {
+  color: var(--tk-text-tertiary);
+}
+
+/* Value tokens — dark mode */
+[data-theme="dark"] .structured-plan-valueToken {
+  background: var(--tk-bg-elevated);
+  border-color: var(--tk-border-primary);
+  color: var(--tk-text-primary);
+}
+
+[data-theme="dark"] .structured-plan-valueToken--added {
+  border-color: rgba(46, 160, 67, 0.35);
+  color: #3fb950;
+}
+
+[data-theme="dark"] .structured-plan-valueToken--removed {
+  border-color: rgba(248, 81, 73, 0.35);
+  color: #f85149;
+}
+
+[data-theme="dark"] .structured-plan-valueToken--changed {
+  border-color: rgba(56, 139, 253, 0.35);
+  color: #58a6ff;
+}
+
+[data-theme="dark"] .structured-plan-valueToken--unknown {
+  border-color: rgba(210, 153, 34, 0.35);
+  color: #e3b341;
+}
+
+[data-theme="dark"] .structured-plan-valueToken--sensitive {
+  border-color: rgba(163, 113, 247, 0.35);
+  color: #d2a8ff;
+}
+
+/* Action pills — dark mode */
+[data-theme="dark"] .structured-plan-actionPill--create {
+  background: rgba(46, 160, 67, 0.15);
+  border-color: rgba(46, 160, 67, 0.3);
+  color: #3fb950;
+}
+
+[data-theme="dark"] .structured-plan-actionPill--update {
+  background: rgba(56, 139, 253, 0.15);
+  border-color: rgba(56, 139, 253, 0.3);
+  color: #58a6ff;
+}
+
+[data-theme="dark"] .structured-plan-actionPill--replace {
+  background: var(--tk-fill-primary);
+  border-color: var(--tk-border-primary);
+  color: var(--tk-text-secondary);
+}
+
+[data-theme="dark"] .structured-plan-actionPill--delete {
+  background: rgba(248, 81, 73, 0.15);
+  border-color: rgba(248, 81, 73, 0.3);
+  color: #f85149;
+}
+
+[data-theme="dark"] .structured-plan-actionPill--read,
+[data-theme="dark"] .structured-plan-actionPill--unknown {
+  background: var(--tk-fill-primary);
+  border-color: var(--tk-border-primary);
+  color: var(--tk-text-tertiary);
+}
+
+[data-theme="dark"] .structured-plan-metaPill {
+  background: var(--tk-fill-primary);
+  border-color: var(--tk-border-primary);
+  color: var(--tk-text-secondary);
+}

--- a/ui/src/domain/Jobs/StructuredPlanOutput.css
+++ b/ui/src/domain/Jobs/StructuredPlanOutput.css
@@ -658,6 +658,7 @@
 [data-theme="dark"] .structured-plan-shell {
   background: var(--tk-bg-container);
   border-color: var(--tk-border-primary);
+  color: var(--tk-text-primary);
 }
 
 [data-theme="dark"] .structured-plan-summaryArea {

--- a/ui/src/modules/user/components/PatSection/PatSection.css
+++ b/ui/src/modules/user/components/PatSection/PatSection.css
@@ -43,3 +43,7 @@
     max-width: 350px;
   }
 }
+
+[data-theme="dark"] .pat-section .breadcrumb {
+  color: var(--tk-text-secondary);
+}

--- a/ui/src/modules/user/components/ThemeSection/ThemeSection.css
+++ b/ui/src/modules/user/components/ThemeSection/ThemeSection.css
@@ -31,3 +31,7 @@
 .ant-select-item-option-content .color-option {
   padding: 0;
 }
+
+[data-theme="dark"] .color-box {
+  border-color: rgba(255, 255, 255, 0.12);
+}


### PR DESCRIPTION
## Summary

Several CSS files were using hardcoded light-mode colors with no
`[data-theme="dark"]` overrides, causing broken rendering in dark mode
(white panels, invisible text, incorrect badge colors).

## Changes

### `StructuredPlanOutput.css` — Primary fix
The structured plan output panel had 650+ lines of hardcoded light-mode
colors and zero dark mode rules. Added a comprehensive dark mode block
covering all elements:

- Shell, toolbar, search input, operation filter select
- Action icons (create / update / replace / delete / read)
- Provider badge, resource address, copy button
- Diff rows with semantic colors (added/removed/changed/unknown/sensitive)
- Diff markers and value tokens
- Action pills and meta pills
- Color inheritance on the root shell element

### Other files
- `App.css` — `.popup-text` dark mode override
- `PatSection.css` — `.breadcrumb` hardcoded `#666` override
- `ThemeSection.css` — `.color-box` border visibility fix

## Root cause

The project uses `[data-theme="dark"]` selector for theming, correctly
implemented in `styles/global.css` and `styles/variables.css`. These
component-level CSS files were added without following that pattern.

## Testing

Verified by visual inspection in dark mode on the Runs → Structured
plan output view.

cc @alfespa17


<img width="1798" height="849" alt="Screenshot at May 11 11-23-25" src="https://github.com/user-attachments/assets/35bfc510-512b-4f5e-980d-e6a3ea4f209e" />
<img width="296" height="654" alt="Screenshot at May 11 11-24-21" src="https://github.com/user-attachments/assets/4427d650-f5b0-4fc0-a3ba-fba23cb9c15a" />
