### PR TITLE
fix(ui): prevent double job submission on Run job modal

### DIFF
--- a/ui/src/domain/Jobs/Create.tsx
+++ b/ui/src/domain/Jobs/Create.tsx
@@ -28,6 +28,7 @@ export const CreateJob = ({ changeJob, planJob = true }: Props) => {
   const [templates, setTemplates] = useState<Template[]>([]);
   const [branchName, setBranchName] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const onCancel = () => {
     setVisible(false);
   };
@@ -60,6 +61,8 @@ export const CreateJob = ({ changeJob, planJob = true }: Props) => {
   };
 
   const onCreate = (values: CreateJobForm) => {
+    setSubmitting(true);
+
     const body = {
       data: {
         type: "job",
@@ -87,6 +90,7 @@ export const CreateJob = ({ changeJob, planJob = true }: Props) => {
       })
       .then((response) => {
         const newJobId = response.data.data.id;
+        setSubmitting(false);
         setVisible(false);
         changeJob(newJobId);
 
@@ -95,6 +99,7 @@ export const CreateJob = ({ changeJob, planJob = true }: Props) => {
         }
       })
       .catch((error) => {
+        setSubmitting(false);
         message.error("Not able to create job: " + error.response.data.errors[0].detail);
         setVisible(false);
       });
@@ -120,6 +125,8 @@ export const CreateJob = ({ changeJob, planJob = true }: Props) => {
         okText="Start"
         cancelText="Cancel"
         onCancel={onCancel}
+        okButtonProps={{ loading: submitting, disabled: submitting }}
+        cancelButtonProps={{ disabled: submitting }}
         onOk={() => {
           form
             .validateFields()

--- a/ui/src/domain/Jobs/Create.tsx
+++ b/ui/src/domain/Jobs/Create.tsx
@@ -29,6 +29,7 @@ export const CreateJob = ({ changeJob, planJob = true }: Props) => {
   const [branchName, setBranchName] = useState([]);
   const [loading, setLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+
   const onCancel = () => {
     setVisible(false);
   };
@@ -61,6 +62,8 @@ export const CreateJob = ({ changeJob, planJob = true }: Props) => {
   };
 
   const onCreate = (values: CreateJobForm) => {
+    // Close modal immediately — don't make user wait
+    setVisible(false);
     setSubmitting(true);
 
     const body = {
@@ -91,7 +94,6 @@ export const CreateJob = ({ changeJob, planJob = true }: Props) => {
       .then((response) => {
         const newJobId = response.data.data.id;
         setSubmitting(false);
-        setVisible(false);
         changeJob(newJobId);
 
         if (organizationId && workspaceId) {
@@ -100,8 +102,7 @@ export const CreateJob = ({ changeJob, planJob = true }: Props) => {
       })
       .catch((error) => {
         setSubmitting(false);
-        message.error("Not able to create job: " + error.response.data.errors[0].detail);
-        setVisible(false);
+        message.error("Failed to start job: " + error.response.data.errors[0].detail);
       });
   };
 
@@ -114,7 +115,8 @@ export const CreateJob = ({ changeJob, planJob = true }: Props) => {
           setVisible(true);
         }}
         icon={<PlayCircleOutlined />}
-        disabled={!planJob}
+        disabled={!planJob || submitting}
+        loading={submitting}
       >
         Run now
       </Button>
@@ -125,8 +127,6 @@ export const CreateJob = ({ changeJob, planJob = true }: Props) => {
         okText="Start"
         cancelText="Cancel"
         onCancel={onCancel}
-        okButtonProps={{ loading: submitting, disabled: submitting }}
-        cancelButtonProps={{ disabled: submitting }}
         onOk={() => {
           form
             .validateFields()


### PR DESCRIPTION
## Summary

Clicking the Start button multiple times in the "Run job" modal was
triggering duplicate job runs, as there was no guard against repeated
submissions while the API call was in flight.

## Changes

- Modal closes immediately when Start is clicked (faster UX, no waiting)
- "Run now" button is disabled and shows a loading spinner while the
  API request is pending, preventing the modal from being reopened
- On success: navigates to the job details page as before
- On failure: displays an error toast (`message.error`) on the workspace
  page — modal is already closed so no blocking UI

## File changed

`ui/src/domain/Jobs/Create.tsx`

cc @alfespa17
