### PR TITLE
fix(executor,api): make dynamic credentials path consistent

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -166,7 +166,8 @@ public class DynamicCredentialsService {
 
         workspaceEnvVariables.put("TERRAKUBE_AWS_CREDENTIALS_FILE", awsWebIdentityToken);
         workspaceEnvVariables.put("AWS_ROLE_ARN", workspaceEnvVariables.get("WORKLOAD_IDENTITY_ROLE_AWS"));
-        workspaceEnvVariables.put("AWS_WEB_IDENTITY_TOKEN_FILE", getDefaultExecutorPath(job) + "/terrakube_config_dynamic_credentials_aws.txt");
+        // AWS_WEB_IDENTITY_TOKEN_FILE is set by the executor once it knows the absolute
+        // path of the file it wrote (the workspace clone dir is only known there).
 
         return workspaceEnvVariables;
     }
@@ -195,7 +196,7 @@ public class DynamicCredentialsService {
                 "    \"token_url\": \"https://sts.googleapis.com/v1/token\",\n" +
                 "    \"service_account_impersonation_url\": \"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken\",\n" +
                 "    \"credential_source\": {\n" +
-                "      \"file\": \"%s/terrakube_dynamic_credentials.json\",\n" +
+                "      \"file\": \"${WORKSPACE_DIRECTORY}/terrakube_dynamic_credentials.json\",\n" +
                 "      \"format\": {\n" +
                 "        \"type\": \"json\",\n" +
                 "        \"subject_token_field_name\": \"access_token\"\n" +
@@ -203,19 +204,20 @@ public class DynamicCredentialsService {
                 "    }\n" +
                 "  }";
 
-        String executorDirectory = getDefaultExecutorPath(job);
-
+        // The ${WORKSPACE_DIRECTORY} placeholder is substituted by the executor when
+        // it writes the config to disk (only the executor knows the workspace clone path).
         String audience = workspaceEnvVariables.get("WORKLOAD_IDENTITY_AUDIENCE_GCP");
         String serviceAccountEmail = workspaceEnvVariables.get("WORKLOAD_IDENTITY_SERVICE_ACCOUNT_EMAIL");
 
-        googleCredentialConfigFile = String.format(googleCredentialConfigFile, audience, serviceAccountEmail, executorDirectory);
+        googleCredentialConfigFile = String.format(googleCredentialConfigFile, audience, serviceAccountEmail);
 
         log.debug("TERRAKUBE_GCP_CREDENTIALS_FILE: {}", googleCredentialsFile);
         log.debug("TERRAKUBE_GCP_CREDENTIALS_CONFIG_FILE: {}", googleCredentialConfigFile);
 
         workspaceEnvVariables.put("TERRAKUBE_GCP_CREDENTIALS_FILE", googleCredentialsFile);
         workspaceEnvVariables.put("TERRAKUBE_GCP_CREDENTIALS_CONFIG_FILE", googleCredentialConfigFile);
-        workspaceEnvVariables.put("GOOGLE_APPLICATION_CREDENTIALS", executorDirectory + "/terrakube_config_dynamic_credentials.json");
+        // GOOGLE_APPLICATION_CREDENTIALS is set by the executor once it knows the absolute
+        // path of the file it wrote (the workspace clone dir is only known there).
 
         return workspaceEnvVariables;
     }
@@ -261,14 +263,5 @@ public class DynamicCredentialsService {
         }
 
         return publicKeyPEM;
-    }
-
-    private static String getDefaultExecutorPath(Job job) {
-        return String.format(
-                "%s/.terraform-spring-boot/executor/%s/%s",
-                FileUtils.getUserDirectoryPath(),
-                job.getOrganization().getId().toString(),
-                job.getWorkspace().getId().toString()
-        );
     }
 }

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -588,16 +588,6 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             log.info("File terrakube_env does not exist");
         }
 
-        if (terraformJob.getEnvironmentVariables().containsKey("AWS_WEB_IDENTITY_TOKEN_FILE")) {
-            log.info("AWS_WEB_IDENTITY_TOKEN_FILE updating location to: {}", workingDirectory.getAbsolutePath() + "/terrakube_config_dynamic_credentials_aws.txt");
-            terraformJob.getEnvironmentVariables().put("AWS_WEB_IDENTITY_TOKEN_FILE", workingDirectory.getAbsolutePath() + "/terrakube_config_dynamic_credentials_aws.txt");
-        }
-
-        if (terraformJob.getEnvironmentVariables().containsKey("GOOGLE_APPLICATION_CREDENTIALS")) {
-            log.info("GOOGLE_APPLICATION_CREDENTIALS updating location to: {}", workingDirectory.getAbsolutePath() + "/terrakube_config_dynamic_credentials_gcp.json");
-            terraformJob.getEnvironmentVariables().put("GOOGLE_APPLICATION_CREDENTIALS", workingDirectory.getAbsolutePath() + "/terrakube_config_dynamic_credentials_gcp.json");
-        }
-
         return terraformJob.getEnvironmentVariables();
     }
 }

--- a/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -89,6 +89,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
             log.info("Executor WorkingDir: {}", workspaceCloneFolder);
             if (terraformJob.getEnvironmentVariables().containsKey("ENABLE_DYNAMIC_CREDENTIALS_GCP")) {
                 setupGcpDynamicCredentials(
+                        terraformJob,
                         workspaceCloneFolder,
                         terraformJob.getEnvironmentVariables().get("TERRAKUBE_GCP_CREDENTIALS_FILE"),
                         terraformJob.getEnvironmentVariables().get("TERRAKUBE_GCP_CREDENTIALS_CONFIG_FILE"));
@@ -96,6 +97,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
 
             if (terraformJob.getEnvironmentVariables().containsKey("ENABLE_DYNAMIC_CREDENTIALS_AWS")) {
                 setupAwsDynamicCredentials(
+                        terraformJob,
                         workspaceCloneFolder,
                         terraformJob.getEnvironmentVariables().get("TERRAKUBE_AWS_CREDENTIALS_FILE"));
             }
@@ -105,31 +107,33 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
         }
     }
 
-    private void setupAwsDynamicCredentials(File workspaceCloneFolder, String awsCredentialsFileContent)
-            throws IOException {
-        log.info("Generating AWS dynamic credentials files inside the workspace execution");
-        log.info("Writing AWS credentials to {}/terrakube_config_dynamic_credentials_aws.txt",
-                workspaceCloneFolder.getAbsolutePath());
-        FileUtils.writeStringToFile(
-                new File(workspaceCloneFolder.getAbsolutePath() + "/terrakube_config_dynamic_credentials_aws.txt"),
-                awsCredentialsFileContent, Charset.defaultCharset());
+    private void setupAwsDynamicCredentials(TerraformJob terraformJob, File workspaceCloneFolder,
+            String awsCredentialsFileContent) throws IOException {
+        File credentialsFile = new File(workspaceCloneFolder, "terrakube_config_dynamic_credentials_aws.txt");
+        log.info("Writing AWS dynamic credentials to {}", credentialsFile.getAbsolutePath());
+        FileUtils.writeStringToFile(credentialsFile, awsCredentialsFileContent, Charset.defaultCharset());
+        terraformJob.getEnvironmentVariables().put("AWS_WEB_IDENTITY_TOKEN_FILE", credentialsFile.getAbsolutePath());
+        log.info("AWS_WEB_IDENTITY_TOKEN_FILE set to {}", credentialsFile.getAbsolutePath());
     }
 
-    private void setupGcpDynamicCredentials(File workspaceCloneFolder, String gcpCredentialsFileContent,
-            String gcpCredentialConfigFileContent) throws IOException {
-        log.info("Generating GCP dynamic credentials files inside the workspace execution");
+    private void setupGcpDynamicCredentials(TerraformJob terraformJob, File workspaceCloneFolder,
+            String gcpCredentialsFileContent, String gcpCredentialConfigFileContent) throws IOException {
+        File credentialsFile = new File(workspaceCloneFolder, "terrakube_dynamic_credentials.json");
+        File configFile = new File(workspaceCloneFolder, "terrakube_config_dynamic_credentials.json");
 
-        log.info("Writing GCP credentials to {}/terrakube_dynamic_credentials.json",
-                workspaceCloneFolder.getAbsolutePath());
-        log.info("Writing GCP credentials Configuration File to {}/terrakube_config_dynamic_credentials.json",
-                workspaceCloneFolder.getAbsolutePath());
+        // The API-generated config JSON references the JWT file via an absolute path that
+        // only the executor knows (the workspace clone directory). The API leaves a
+        // ${WORKSPACE_DIRECTORY} placeholder in the credential_source.file field; we
+        // substitute it here with the actual clone path before writing the file.
+        String resolvedConfig = gcpCredentialConfigFileContent.replace(
+                "${WORKSPACE_DIRECTORY}", workspaceCloneFolder.getAbsolutePath());
 
-        FileUtils.writeStringToFile(
-                new File(workspaceCloneFolder.getAbsolutePath() + "/terrakube_dynamic_credentials.json"),
-                gcpCredentialsFileContent, Charset.defaultCharset());
-        FileUtils.writeStringToFile(
-                new File(workspaceCloneFolder.getAbsolutePath() + "/terrakube_config_dynamic_credentials.json"),
-                gcpCredentialConfigFileContent, Charset.defaultCharset());
+        log.info("Writing GCP dynamic credentials JWT to {}", credentialsFile.getAbsolutePath());
+        log.info("Writing GCP dynamic credentials config to {}", configFile.getAbsolutePath());
+        FileUtils.writeStringToFile(credentialsFile, gcpCredentialsFileContent, Charset.defaultCharset());
+        FileUtils.writeStringToFile(configFile, resolvedConfig, Charset.defaultCharset());
+        terraformJob.getEnvironmentVariables().put("GOOGLE_APPLICATION_CREDENTIALS", configFile.getAbsolutePath());
+        log.info("GOOGLE_APPLICATION_CREDENTIALS set to {}", configFile.getAbsolutePath());
     }
 
     private File setupWorkspaceDirectory(String organizationId, String workspaceId) throws IOException {

--- a/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
@@ -146,6 +146,34 @@ public class SetupWorkspaceTest {
         File workspaceDir = setup.prepareWorkspace(job);
         File credsFile = FileUtils.getFile(workspaceDir, "terrakube_config_dynamic_credentials_aws.txt");
         Assert.assertTrue(credsFile.exists());
-        Assert.assertEquals(FileUtils.readFileToString(credsFile, Charset.defaultCharset()), "ze-secret");
+        Assert.assertEquals("ze-secret", FileUtils.readFileToString(credsFile, Charset.defaultCharset()));
+        Assert.assertEquals(credsFile.getAbsolutePath(),
+                job.getEnvironmentVariables().get("AWS_WEB_IDENTITY_TOKEN_FILE"));
+    }
+
+    @Test
+    public void injectsGcpCredentialsWhenAsked() throws Exception {
+        TerraformJob job = successfulTarGzJob();
+        SetupWorkspace setup = standardSetupWorkspaceImpl(job);
+        job.getEnvironmentVariables().put("ENABLE_DYNAMIC_CREDENTIALS_GCP", "true");
+        job.getEnvironmentVariables().put("TERRAKUBE_GCP_CREDENTIALS_FILE", "{\"access_token\":\"ze-jwt\"}");
+        job.getEnvironmentVariables().put("TERRAKUBE_GCP_CREDENTIALS_CONFIG_FILE",
+                "{\"credential_source\":{\"file\":\"${WORKSPACE_DIRECTORY}/terrakube_dynamic_credentials.json\"}}");
+
+        File workspaceDir = setup.prepareWorkspace(job);
+        File jwtFile = FileUtils.getFile(workspaceDir, "terrakube_dynamic_credentials.json");
+        File configFile = FileUtils.getFile(workspaceDir, "terrakube_config_dynamic_credentials.json");
+
+        Assert.assertTrue(jwtFile.exists());
+        Assert.assertTrue(configFile.exists());
+        Assert.assertEquals("{\"access_token\":\"ze-jwt\"}",
+                FileUtils.readFileToString(jwtFile, Charset.defaultCharset()));
+        // ${WORKSPACE_DIRECTORY} placeholder must be substituted with the actual clone path.
+        Assert.assertEquals(
+                "{\"credential_source\":{\"file\":\"" + workspaceDir.getAbsolutePath()
+                        + "/terrakube_dynamic_credentials.json\"}}",
+                FileUtils.readFileToString(configFile, Charset.defaultCharset()));
+        Assert.assertEquals(configFile.getAbsolutePath(),
+                job.getEnvironmentVariables().get("GOOGLE_APPLICATION_CREDENTIALS"));
     }
 }


### PR DESCRIPTION
The executor writes dynamic-credentials files to a random tmp dir (SetupWorkspaceImpl.setupWorkspaceDirectory creates `tmp*` under ~/.terraform-spring-boot/executor), but the API hardcoded a different deterministic path (`~/.terraform-spring-boot/executor/{orgId}/{wsId}`) both inside the credential_source.file of the GCP config JSON and in the GOOGLE_APPLICATION_CREDENTIALS / AWS_WEB_IDENTITY_TOKEN_FILE env vars. PR #3173/#3176 attempted to repair this by rewriting the env vars to the Terraform working directory + `_gcp.json` suffix in TerraformExecutorServiceImpl.loadTempEnvironmentVariables, but the writer kept using the clone-root path with no suffix, so the env var and the file on disk still never agree.

Fix:

- API (DynamicCredentialsService): emit credential_source.file with a `${WORKSPACE_DIRECTORY}` placeholder and stop pre-setting the GOOGLE_APPLICATION_CREDENTIALS / AWS_WEB_IDENTITY_TOKEN_FILE env vars (only the executor can know the real path).
- Executor (SetupWorkspaceImpl): substitute `${WORKSPACE_DIRECTORY}` with the absolute workspace clone path when writing the GCP config, and set the env vars to the absolute path of the file just written.
- Executor (TerraformExecutorServiceImpl): remove the now-redundant post-hoc env-var rewrite in loadTempEnvironmentVariables.

Also extend SetupWorkspaceTest to assert AWS_WEB_IDENTITY_TOKEN_FILE is set and add a GCP test covering placeholder substitution and GOOGLE_APPLICATION_CREDENTIALS.